### PR TITLE
Fix: entity store, friendly name handling, config migration, 2023.8 name compatibility task, installer paths

### DIFF
--- a/src/HASS.Agent.Installer/InstallerScript.iss
+++ b/src/HASS.Agent.Installer/InstallerScript.iss
@@ -39,7 +39,7 @@ InfoAfterFile=.\AfterInstallNotice.rtf
 ;PrivilegesRequired=lowest
 OutputDir=.\bin
 OutputBaseFilename=HASS.Agent.Installer
-SetupIconFile=..\HASS.Agent.Staging\HASS.Agent.Shared\hassagent.ico
+SetupIconFile=..\HASS.Agent\HASS.Agent.Shared\hassagent.ico
 Compression=lzma
 SolidCompression=yes
 WizardStyle=modern
@@ -57,12 +57,12 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 [Files]
 ; Client files
-;Source: "..\HASS.Agent.Staging\HASS.Agent\bin\Publish-x64\Release\*"; Excludes: "*.pdb"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+;Source: "..\HASS.Agent\HASS.Agent\bin\Publish-x64\Release\*"; Excludes: "*.pdb"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; Service files
-;Source: "..\HASS.Agent.Staging\HASS.Agent.Satellite.Service\bin\Publish-x64\Release\*"; Excludes: "*.pdb"; DestDir: "{commonpf64}\{#MyAppName}\Service"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "..\HASS.Agent.Staging\HASS.Agent\bin\Publish-x64\Release\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+;Source: "..\HASS.Agent\HASS.Agent.Satellite.Service\bin\Publish-x64\Release\*"; Excludes: "*.pdb"; DestDir: "{commonpf64}\{#MyAppName}\Service"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "..\HASS.Agent\HASS.Agent\bin\Publish-x64\Release\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; Service files
-Source: "..\HASS.Agent.Staging\HASS.Agent.Satellite.Service\bin\Publish-x64\Release\*"; DestDir: "{commonpf64}\{#MyAppName}\Service"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "..\HASS.Agent\HASS.Agent.Satellite.Service\bin\Publish-x64\Release\*"; DestDir: "{commonpf64}\{#MyAppName}\Service"; Flags: ignoreversion recursesubdirs createallsubdirs
 
 [Icons]
 Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"

--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/Commands/CommandsManager.cs
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/Commands/CommandsManager.cs
@@ -184,21 +184,30 @@ namespace HASS.Agent.Satellite.Service.Commands
                 {
                     foreach (var abstractCommand in toBeDeletedCommands.Select(StoredCommands.ConvertConfiguredToAbstract))
                     {
-                        if (abstractCommand == null) continue;
+                        if (abstractCommand == null)
+                            continue;
 
-                        // remove and unregister
-                        await abstractCommand.UnPublishAutoDiscoveryConfigAsync();
-                        await Variables.MqttManager.UnsubscribeAsync(abstractCommand);
-                        Variables.Commands.RemoveAt(Variables.Commands.FindIndex(x => x.Id == abstractCommand.Id));
+                        var commandIndex = Variables.Commands.FindIndex(x => x.Id == abstractCommand.Id);
+                        if (commandIndex == -1)
+                        {
+                            await abstractCommand.UnPublishAutoDiscoveryConfigAsync();
+                            await Variables.MqttManager.UnsubscribeAsync(abstractCommand);
+                            Variables.Commands.RemoveAt(commandIndex);
 
-                        Log.Information("[COMMANDS] Removed command: {command}", abstractCommand.Name);
+                            Log.Information("[COMMANDS] Removed command: {command}", abstractCommand.Name);
+                        }
+                        else
+                        {
+                            Log.Information("[COMMANDS] Command not removed, not activated: {command}", abstractCommand.Name);
+                        }
                     }
                 }
 
                 // copy our list to the main one
                 foreach (var abstractCommand in commands.Select(StoredCommands.ConvertConfiguredToAbstract))
                 {
-                    if (abstractCommand == null) continue;
+                    if (abstractCommand == null)
+                        continue;
 
                     if (Variables.Commands.All(x => x.Id != abstractCommand.Id))
                     {

--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/Commands/CommandsManager.cs
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/Commands/CommandsManager.cs
@@ -194,11 +194,11 @@ namespace HASS.Agent.Satellite.Service.Commands
                             await Variables.MqttManager.UnsubscribeAsync(abstractCommand);
                             Variables.Commands.RemoveAt(commandIndex);
 
-                            Log.Information("[COMMANDS] Removed command: {command}", abstractCommand.Name);
+                            Log.Information("[COMMANDS] Removed command: {command}", abstractCommand.EntityName);
                         }
                         else
                         {
-                            Log.Information("[COMMANDS] Command not removed, not activated: {command}", abstractCommand.Name);
+                            Log.Information("[COMMANDS] Command not removed, not activated: {command}", abstractCommand.EntityName);
                         }
                     }
                 }
@@ -217,16 +217,16 @@ namespace HASS.Agent.Satellite.Service.Commands
                         await abstractCommand.PublishAutoDiscoveryConfigAsync();
                         await abstractCommand.PublishStateAsync(false);
 
-                        Log.Information("[COMMANDS] Added command: {command}", abstractCommand.Name);
+                        Log.Information("[COMMANDS] Added command: {command}", abstractCommand.EntityName);
                         continue;
                     }
 
                     // existing, update and re-register
                     var currentCommandIndex = Variables.Commands.FindIndex(x => x.Id == abstractCommand.Id);
-                    if (Variables.Commands[currentCommandIndex].Name != abstractCommand.Name || Variables.Commands[currentCommandIndex].EntityType != abstractCommand.EntityType)
+                    if (Variables.Commands[currentCommandIndex].EntityName != abstractCommand.EntityName || Variables.Commands[currentCommandIndex].EntityType != abstractCommand.EntityType)
                     {
                         // command changed, unregister and resubscribe on new mqtt channel
-                        Log.Information("[COMMANDS] Command changed, re-registering as new entity: {old} to {new}", Variables.Commands[currentCommandIndex].Name, abstractCommand.Name);
+                        Log.Information("[COMMANDS] Command changed, re-registering as new entity: {old} to {new}", Variables.Commands[currentCommandIndex].EntityName, abstractCommand.EntityName);
 
                         await Variables.Commands[currentCommandIndex].UnPublishAutoDiscoveryConfigAsync();
                         await Variables.MqttManager.UnsubscribeAsync(Variables.Commands[currentCommandIndex]);
@@ -237,7 +237,7 @@ namespace HASS.Agent.Satellite.Service.Commands
                     await abstractCommand.PublishAutoDiscoveryConfigAsync();
                     await abstractCommand.PublishStateAsync(false);
 
-                    Log.Information("[COMMANDS] Modified command: {command}", abstractCommand.Name);
+                    Log.Information("[COMMANDS] Modified command: {command}", abstractCommand.EntityName);
                 }
 
                 // annouce ourselves

--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/Extensions/RpcExtensions.cs
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/Extensions/RpcExtensions.cs
@@ -17,7 +17,9 @@ namespace HASS.Agent.Satellite.Service.Extensions
         /// <returns></returns>
         public static List<ConfiguredCommand> ConvertToConfiguredCommands(this RepeatedField<RpcConfiguredServerCommand> rpcConfiguredCommands)
         {
-            return rpcConfiguredCommands.Select(rpcConfiguredCommand => rpcConfiguredCommand.ConvertToConfiguredCommand()).ToList();
+            return rpcConfiguredCommands.Select(
+                rpcConfiguredCommand => rpcConfiguredCommand.ConvertToConfiguredCommand()
+            ).ToList();
         }
 
         /// <summary>
@@ -36,6 +38,7 @@ namespace HASS.Agent.Satellite.Service.Extensions
                 RunAsLowIntegrity = rpcConfiguredCommand.RunAsLowIntegrity,
                 EntityType = (CommandEntityType)rpcConfiguredCommand.CommandEntityType
             };
+
             return configuredCommand;
         }
 
@@ -47,7 +50,9 @@ namespace HASS.Agent.Satellite.Service.Extensions
         public static RepeatedField<RpcConfiguredServerCommand> ConvertToRpcConfiguredCommands(this List<ConfiguredCommand> configuredCommands)
         {
             var rpcConfguredCommands = new RepeatedField<RpcConfiguredServerCommand>();
-            foreach (var configuredCommand in configuredCommands) rpcConfguredCommands.Add(configuredCommand.ConvertToRpcConfiguredCommand());
+            foreach (var configuredCommand in configuredCommands)
+                rpcConfguredCommands.Add(configuredCommand.ConvertToRpcConfiguredCommand());
+
             return rpcConfguredCommands;
         }
 
@@ -77,7 +82,9 @@ namespace HASS.Agent.Satellite.Service.Extensions
         /// <returns></returns>
         public static List<ConfiguredSensor> ConvertToConfiguredSensors(this RepeatedField<RpcConfiguredServerSensor> rpcConfiguredSensors)
         {
-            return rpcConfiguredSensors.Select(rpcConfiguredSensor => rpcConfiguredSensor.ConvertToConfiguredSensor()).ToList();
+            return rpcConfiguredSensors.Select(
+                rpcConfiguredSensor => rpcConfiguredSensor.ConvertToConfiguredSensor()
+            ).ToList();
         }
 
         /// <summary>
@@ -98,8 +105,10 @@ namespace HASS.Agent.Satellite.Service.Extensions
                 Category = rpcConfiguredSensor.Category,
                 Counter = rpcConfiguredSensor.Counter,
                 Instance = rpcConfiguredSensor.Instance,
-                EntityName = rpcConfiguredSensor.Name
+                EntityName = rpcConfiguredSensor.EntityName,
+                Name = rpcConfiguredSensor.Name
             };
+
             return configuredSensor;
         }
 
@@ -111,7 +120,9 @@ namespace HASS.Agent.Satellite.Service.Extensions
         public static RepeatedField<RpcConfiguredServerSensor> ConvertToRpcConfiguredSensors(this List<ConfiguredSensor> configuredSensors)
         {
             var rpcConfguredSensors = new RepeatedField<RpcConfiguredServerSensor>();
-            foreach (var configuredSensor in configuredSensors) rpcConfguredSensors.Add(configuredSensor.ConvertToRpcConfiguredSensor());
+            foreach (var configuredSensor in configuredSensors)
+                rpcConfguredSensors.Add(configuredSensor.ConvertToRpcConfiguredSensor());
+            
             return rpcConfguredSensors;
         }
 
@@ -137,6 +148,7 @@ namespace HASS.Agent.Satellite.Service.Extensions
                 Instance = configuredSensor.Instance ?? string.Empty,
                 Name = configuredSensor.EntityName
             };
+
             return configuredRpcSensor;
         }
 
@@ -161,6 +173,7 @@ namespace HASS.Agent.Satellite.Service.Extensions
                 MqttClientCertificate = rpcServiceMqttSettings.MqttClientCertificate,
                 MqttClientId = rpcServiceMqttSettings.MqttClientId
             };
+
             return serviceMqttSettings;
         }
 
@@ -185,6 +198,7 @@ namespace HASS.Agent.Satellite.Service.Extensions
                 MqttClientCertificate = serviceMqttSettings.MqttClientCertificate,
                 MqttClientId = serviceMqttSettings.MqttClientId
             };
+
             return rpcServiceMqttSettings;
         }
 

--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/Extensions/RpcExtensions.cs
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/Extensions/RpcExtensions.cs
@@ -33,7 +33,8 @@ namespace HASS.Agent.Satellite.Service.Extensions
             {
                 Type = (CommandType)rpcConfiguredCommand.Type,
                 Id = Guid.Parse(rpcConfiguredCommand.Id),
-                EntityName = rpcConfiguredCommand.Name,
+                EntityName = rpcConfiguredCommand.EntityName,
+                Name = rpcConfiguredCommand.Name,
                 Command = rpcConfiguredCommand.Command,
                 RunAsLowIntegrity = rpcConfiguredCommand.RunAsLowIntegrity,
                 EntityType = (CommandEntityType)rpcConfiguredCommand.CommandEntityType
@@ -69,7 +70,8 @@ namespace HASS.Agent.Satellite.Service.Extensions
                 Id = configuredCommand.Id.ToString(),
                 Command = configuredCommand.Command ?? string.Empty,
                 RunAsLowIntegrity = configuredCommand.RunAsLowIntegrity,
-                Name = configuredCommand.EntityName,
+                Name = configuredCommand.Name,
+                EntityName = configuredCommand.EntityName,
                 CommandEntityType = (int)configuredCommand.EntityType
             };
             return configuredRpcCommand;
@@ -146,7 +148,8 @@ namespace HASS.Agent.Satellite.Service.Extensions
                 Category = configuredSensor.Category ?? string.Empty,
                 Counter = configuredSensor.Counter ?? string.Empty,
                 Instance = configuredSensor.Instance ?? string.Empty,
-                Name = configuredSensor.EntityName
+                Name = configuredSensor.Name ?? string.Empty,
+                EntityName = configuredSensor?.EntityName ?? string.Empty
             };
 
             return configuredRpcSensor;

--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/Extensions/RpcExtensions.cs
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/Extensions/RpcExtensions.cs
@@ -31,7 +31,7 @@ namespace HASS.Agent.Satellite.Service.Extensions
             {
                 Type = (CommandType)rpcConfiguredCommand.Type,
                 Id = Guid.Parse(rpcConfiguredCommand.Id),
-                Name = rpcConfiguredCommand.Name,
+                EntityName = rpcConfiguredCommand.Name,
                 Command = rpcConfiguredCommand.Command,
                 RunAsLowIntegrity = rpcConfiguredCommand.RunAsLowIntegrity,
                 EntityType = (CommandEntityType)rpcConfiguredCommand.CommandEntityType
@@ -64,7 +64,7 @@ namespace HASS.Agent.Satellite.Service.Extensions
                 Id = configuredCommand.Id.ToString(),
                 Command = configuredCommand.Command ?? string.Empty,
                 RunAsLowIntegrity = configuredCommand.RunAsLowIntegrity,
-                Name = configuredCommand.Name,
+                Name = configuredCommand.EntityName,
                 CommandEntityType = (int)configuredCommand.EntityType
             };
             return configuredRpcCommand;
@@ -98,7 +98,7 @@ namespace HASS.Agent.Satellite.Service.Extensions
                 Category = rpcConfiguredSensor.Category,
                 Counter = rpcConfiguredSensor.Counter,
                 Instance = rpcConfiguredSensor.Instance,
-                Name = rpcConfiguredSensor.Name
+                EntityName = rpcConfiguredSensor.Name
             };
             return configuredSensor;
         }
@@ -135,7 +135,7 @@ namespace HASS.Agent.Satellite.Service.Extensions
                 Category = configuredSensor.Category ?? string.Empty,
                 Counter = configuredSensor.Counter ?? string.Empty,
                 Instance = configuredSensor.Instance ?? string.Empty,
-                Name = configuredSensor.Name
+                Name = configuredSensor.EntityName
             };
             return configuredRpcSensor;
         }

--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/Models/HomeAssistant/Commands/InternalCommands/PublishAllSensorsCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/Models/HomeAssistant/Commands/InternalCommands/PublishAllSensorsCommand.cs
@@ -8,7 +8,7 @@ namespace HASS.Agent.Satellite.Service.Models.HomeAssistant.Commands.InternalCom
     {
         private const string DefaultName = "publishallsensors";
 
-        internal PublishAllSensorsCommand(string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string? id = default) : base(name ?? DefaultName, friendlyName ?? null, string.Empty, entityType, id)
+        internal PublishAllSensorsCommand(string entityName = DefaultName, string name = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string? id = default) : base(entityName ?? DefaultName, name ?? null, string.Empty, entityType, id)
         {
             State = "OFF";
         }

--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/RPC/Protos/hassagentsatellite.proto
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/RPC/Protos/hassagentsatellite.proto
@@ -143,4 +143,5 @@ message RpcConfiguredServerCommand {
   bool runAsLowIntegrity = 4;
   string name = 5;
   int32 commandEntityType = 6;
+  string entityName = 7;
 }

--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/RPC/Protos/hassagentsatellite.proto
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/RPC/Protos/hassagentsatellite.proto
@@ -133,6 +133,7 @@ message RpcConfiguredServerSensor {
   string counter = 8;
   string instance = 9;
   string name = 10;
+  string entityName = 11;
 }
 
 message RpcConfiguredServerCommand {

--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/Sensors/SensorsManager.cs
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/Sensors/SensorsManager.cs
@@ -247,11 +247,11 @@ namespace HASS.Agent.Satellite.Service.Sensors
                                 await abstractSensor.UnPublishAutoDiscoveryConfigAsync();
                                 Variables.SingleValueSensors.RemoveAt(sensorIndex);
 
-                                Log.Information("[SENSORS] Removed single-value sensor: {sensor}", abstractSensor.Name);
+                                Log.Information("[SENSORS] Removed single-value sensor: {sensor}", abstractSensor.EntityName);
                             }
                             else
                             {
-                                Log.Information("[SENSORS] Single-value sensor not removed, not activated: {sensor}", abstractSensor.Name);
+                                Log.Information("[SENSORS] Single-value sensor not removed, not activated: {sensor}", abstractSensor.EntityName);
                             }
                         }
                         else
@@ -267,11 +267,11 @@ namespace HASS.Agent.Satellite.Service.Sensors
                                 await abstractSensor.UnPublishAutoDiscoveryConfigAsync();
                                 Variables.MultiValueSensors.RemoveAt(sensorIndex);
 
-                                Log.Information("[SENSORS] Removed multi-value sensor: {sensor}", abstractSensor.Name);
+                                Log.Information("[SENSORS] Removed multi-value sensor: {sensor}", abstractSensor.EntityName);
                             }
                             else
                             {
-                                Log.Information("[SENSORS] Multi-value sensor not removed, not activated: {sensor}", abstractSensor.Name);
+                                Log.Information("[SENSORS] Multi-value sensor not removed, not activated: {sensor}", abstractSensor.EntityName);
                             }
                         }
                     }
@@ -292,16 +292,16 @@ namespace HASS.Agent.Satellite.Service.Sensors
                             await abstractSensor.PublishAutoDiscoveryConfigAsync();
                             await abstractSensor.PublishStateAsync(false);
 
-                            Log.Information("[SENSORS] Added single-value sensor: {sensor}", abstractSensor.Name);
+                            Log.Information("[SENSORS] Added single-value sensor: {sensor}", abstractSensor.EntityName);
                             continue;
                         }
 
                         // existing, update and re-register
                         var currentSensorIndex = Variables.SingleValueSensors.FindIndex(x => x.Id == abstractSensor.Id);
-                        if (Variables.SingleValueSensors[currentSensorIndex].Name != abstractSensor.Name)
+                        if (Variables.SingleValueSensors[currentSensorIndex].EntityName != abstractSensor.EntityName)
                         {
                             // name changed, unregister
-                            Log.Information("[SENSORS] Single-value sensor changed name, re-registering as new entity: {old} to {new}", Variables.SingleValueSensors[currentSensorIndex].Name, abstractSensor.Name);
+                            Log.Information("[SENSORS] Single-value sensor changed name, re-registering as new entity: {old} to {new}", Variables.SingleValueSensors[currentSensorIndex].EntityName, abstractSensor.EntityName);
 
                             await Variables.SingleValueSensors[currentSensorIndex].UnPublishAutoDiscoveryConfigAsync();
                         }
@@ -310,7 +310,7 @@ namespace HASS.Agent.Satellite.Service.Sensors
                         await abstractSensor.PublishAutoDiscoveryConfigAsync();
                         await abstractSensor.PublishStateAsync(false);
 
-                        Log.Information("[SENSORS] Modified single-value sensor: {sensor}", abstractSensor.Name);
+                        Log.Information("[SENSORS] Modified single-value sensor: {sensor}", abstractSensor.EntityName);
                     }
                     else
                     {
@@ -324,16 +324,16 @@ namespace HASS.Agent.Satellite.Service.Sensors
                             await abstractSensor.PublishAutoDiscoveryConfigAsync();
                             await abstractSensor.PublishStatesAsync(false);
 
-                            Log.Information("[SENSORS] Added multi-value sensor: {sensor}", abstractSensor.Name);
+                            Log.Information("[SENSORS] Added multi-value sensor: {sensor}", abstractSensor.EntityName);
                             continue;
                         }
 
                         // existing, update and re-register
                         var currentSensorIndex = Variables.MultiValueSensors.FindIndex(x => x.Id == abstractSensor.Id);
-                        if (Variables.MultiValueSensors[currentSensorIndex].Name != abstractSensor.Name)
+                        if (Variables.MultiValueSensors[currentSensorIndex].EntityName != abstractSensor.EntityName)
                         {
                             // name changed, unregister
-                            Log.Information("[SENSORS] Multi-value sensor changed name, re-registering as new entity: {old} to {new}", Variables.MultiValueSensors[currentSensorIndex].Name, abstractSensor.Name);
+                            Log.Information("[SENSORS] Multi-value sensor changed name, re-registering as new entity: {old} to {new}", Variables.MultiValueSensors[currentSensorIndex].EntityName, abstractSensor.EntityName);
 
                             await Variables.MultiValueSensors[currentSensorIndex].UnPublishAutoDiscoveryConfigAsync();
                         }
@@ -342,7 +342,7 @@ namespace HASS.Agent.Satellite.Service.Sensors
                         await abstractSensor.PublishAutoDiscoveryConfigAsync();
                         await abstractSensor.PublishStatesAsync(false);
 
-                        Log.Information("[SENSORS] Modified multi-value sensor: {sensor}", abstractSensor.Name);
+                        Log.Information("[SENSORS] Modified multi-value sensor: {sensor}", abstractSensor.EntityName);
                     }
                 }
 

--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/Sensors/SensorsManager.cs
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/Sensors/SensorsManager.cs
@@ -236,24 +236,43 @@ namespace HASS.Agent.Satellite.Service.Sensors
                         if (sensor.IsSingleValue())
                         {
                             var abstractSensor = StoredSensors.ConvertConfiguredToAbstractSingleValue(sensor);
-                            if (abstractSensor == null) continue;
+                            if (abstractSensor == null)
+                                continue;
 
-                            // remove and unregister
-                            await abstractSensor.UnPublishAutoDiscoveryConfigAsync();
-                            Variables.SingleValueSensors.RemoveAt(Variables.SingleValueSensors.FindIndex(x => x.Id == abstractSensor.Id));
+                            var sensorIndex = Variables.SingleValueSensors.FindIndex(x => x.Id == abstractSensor.Id);
+                            if (sensorIndex != -1)
+                            {
 
-                            Log.Information("[SENSORS] Removed single-value sensor: {sensor}", abstractSensor.Name);
+                                // remove and unregister
+                                await abstractSensor.UnPublishAutoDiscoveryConfigAsync();
+                                Variables.SingleValueSensors.RemoveAt(sensorIndex);
+
+                                Log.Information("[SENSORS] Removed single-value sensor: {sensor}", abstractSensor.Name);
+                            }
+                            else
+                            {
+                                Log.Information("[SENSORS] Single-value sensor not removed, not activated: {sensor}", abstractSensor.Name);
+                            }
                         }
                         else
                         {
                             var abstractSensor = StoredSensors.ConvertConfiguredToAbstractMultiValue(sensor);
-                            if (abstractSensor == null) continue;
+                            if (abstractSensor == null)
+                                continue;
 
-                            // remove and unregister
-                            await abstractSensor.UnPublishAutoDiscoveryConfigAsync();
-                            Variables.MultiValueSensors.RemoveAt(Variables.MultiValueSensors.FindIndex(x => x.Id == abstractSensor.Id));
+                            var sensorIndex = Variables.MultiValueSensors.FindIndex(x => x.Id == abstractSensor.Id);
+                            if (sensorIndex != -1)
+                            {
+                                // remove and unregister
+                                await abstractSensor.UnPublishAutoDiscoveryConfigAsync();
+                                Variables.MultiValueSensors.RemoveAt(sensorIndex);
 
-                            Log.Information("[SENSORS] Removed multi-value sensor: {sensor}", abstractSensor.Name);
+                                Log.Information("[SENSORS] Removed multi-value sensor: {sensor}", abstractSensor.Name);
+                            }
+                            else
+                            {
+                                Log.Information("[SENSORS] Multi-value sensor not removed, not activated: {sensor}", abstractSensor.Name);
+                            }
                         }
                     }
                 }

--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/Settings/StoredCommands.cs
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/Settings/StoredCommands.cs
@@ -82,73 +82,73 @@ namespace HASS.Agent.Satellite.Service.Settings
             switch (command.Type)
             {
                 case CommandType.ShutdownCommand:
-                    abstractCommand = new ShutdownCommand(command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new ShutdownCommand(command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.RestartCommand:
-                    abstractCommand = new RestartCommand(command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new RestartCommand(command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.HibernateCommand:
-                    abstractCommand = new HibernateCommand(command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new HibernateCommand(command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.SleepCommand:
-                    abstractCommand = new SleepCommand(command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new SleepCommand(command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.LogOffCommand:
-                    abstractCommand = new LogOffCommand(command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new LogOffCommand(command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.LockCommand:
-                    abstractCommand = new LockCommand(command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new LockCommand(command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.CustomCommand:
-                    abstractCommand = new CustomCommand(command.Command, command.RunAsLowIntegrity, command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new CustomCommand(command.Command, command.RunAsLowIntegrity, command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.PowershellCommand:
-                    abstractCommand = new PowershellCommand(command.Command, command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new PowershellCommand(command.Command, command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.MediaPlayPauseCommand:
-                    abstractCommand = new MediaPlayPauseCommand(command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new MediaPlayPauseCommand(command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.MediaNextCommand:
-                    abstractCommand = new MediaNextCommand(command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new MediaNextCommand(command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.MediaPreviousCommand:
-                    abstractCommand = new MediaPreviousCommand(command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new MediaPreviousCommand(command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.MediaVolumeUpCommand:
-                    abstractCommand = new MediaVolumeUpCommand(command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new MediaVolumeUpCommand(command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.MediaVolumeDownCommand:
-                    abstractCommand = new MediaVolumeDownCommand(command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new MediaVolumeDownCommand(command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.MediaMuteCommand:
-                    abstractCommand = new MediaMuteCommand(command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new MediaMuteCommand(command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.KeyCommand:
-                    abstractCommand = new KeyCommand(command.KeyCode, command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new KeyCommand(command.KeyCode, command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.PublishAllSensorsCommand:
-                    abstractCommand = new PublishAllSensorsCommand(command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new PublishAllSensorsCommand(command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.CustomExecutorCommand:
-                    abstractCommand = new CustomExecutorCommand(command.Name, command.FriendlyName, command.Command, command.EntityType, command.Id.ToString());
+                    abstractCommand = new CustomExecutorCommand(command.EntityName, command.Name, command.Command, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.MultipleKeysCommand:
-                    abstractCommand = new MultipleKeysCommand(command.Keys, command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new MultipleKeysCommand(command.Keys, command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.SendWindowToFrontCommand:
-                    abstractCommand = new SendWindowToFrontCommand(command.Name, command.FriendlyName, command.Command, command.EntityType, command.Id.ToString());
+                    abstractCommand = new SendWindowToFrontCommand(command.EntityName, command.Name, command.Command, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.MonitorSleepCommand:
-                    abstractCommand = new MonitorSleepCommand(command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new MonitorSleepCommand(command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.MonitorWakeCommand:
-                    abstractCommand = new MonitorWakeCommand(command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new MonitorWakeCommand(command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.SetVolumeCommand:
-                    abstractCommand = new SetVolumeCommand(command.Name, command.FriendlyName, command.Command, command.EntityType, command.Id.ToString());
+                    abstractCommand = new SetVolumeCommand(command.EntityName, command.Name, command.Command, command.EntityType, command.Id.ToString());
                     break;
                 default:
-                    Log.Error("[SETTINGS_COMMANDS] [{name}] Unknown configured command type: {type}", command.Name, command.Type.ToString());
+                    Log.Error("[SETTINGS_COMMANDS] [{name}] Unknown configured command type: {type}", command.EntityName, command.Type.ToString());
                     break;
             }
 
@@ -170,8 +170,8 @@ namespace HASS.Agent.Satellite.Service.Settings
                         return new ConfiguredCommand()
                         {
                             Id = Guid.Parse(customCommand.Id),
-                            Name = customCommand.Name,
-                            FriendlyName = customCommand.FriendlyName,
+                            EntityName = customCommand.EntityName,
+                            Name = customCommand.EntityName,
                             Type = type,
                             EntityType = command.EntityType,
                             Command = customCommand.Command,
@@ -185,8 +185,8 @@ namespace HASS.Agent.Satellite.Service.Settings
                         return new ConfiguredCommand()
                         {
                             Id = Guid.Parse(powershellCommand.Id),
-                            Name = powershellCommand.Name,
-                            FriendlyName = powershellCommand.FriendlyName,
+                            EntityName = powershellCommand.EntityName,
+                            Name = powershellCommand.EntityName,
                             Type = type,
                             EntityType = command.EntityType,
                             Command = powershellCommand.Command
@@ -199,8 +199,8 @@ namespace HASS.Agent.Satellite.Service.Settings
                         return new ConfiguredCommand()
                         {
                             Id = Guid.Parse(customKeyCommand.Id),
-                            Name = customKeyCommand.Name,
-                            FriendlyName = customKeyCommand.FriendlyName,
+                            EntityName = customKeyCommand.EntityName,
+                            Name = customKeyCommand.EntityName,
                             Type = type,
                             EntityType = command.EntityType,
                             KeyCode = customKeyCommand.KeyCode
@@ -213,8 +213,8 @@ namespace HASS.Agent.Satellite.Service.Settings
                         return new ConfiguredCommand()
                         {
                             Id = Guid.Parse(internalCommand.Id),
-                            Name = internalCommand.Name,
-                            FriendlyName = internalCommand.FriendlyName,
+                            EntityName = internalCommand.EntityName,
+                            Name = internalCommand.EntityName,
                             Command = internalCommand.CommandConfig ?? string.Empty,
                             Type = type,
                             EntityType = command.EntityType,
@@ -227,8 +227,8 @@ namespace HASS.Agent.Satellite.Service.Settings
                         return new ConfiguredCommand()
                         {
                             Id = Guid.Parse(multipleKeysCommand.Id),
-                            Name = multipleKeysCommand.Name,
-                            FriendlyName = multipleKeysCommand.FriendlyName,
+                            EntityName = multipleKeysCommand.EntityName,
+                            Name = multipleKeysCommand.EntityName,
                             Keys = multipleKeysCommand.Keys ?? new List<string>(),
                             Type = type,
                             EntityType = command.EntityType,

--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/Settings/StoredSensors.cs
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/Settings/StoredSensors.cs
@@ -228,7 +228,7 @@ namespace HASS.Agent.Satellite.Service.Settings
                         {
                             Id = Guid.Parse(wmiSensor.Id),
                             EntityName = wmiSensor.EntityName,
-                            Name = wmiSensor.EntityName,
+                            Name = wmiSensor.Name,
                             Type = type,
                             UpdateInterval = wmiSensor.UpdateIntervalSeconds,
                             Scope = wmiSensor.Scope,

--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/Settings/StoredSensors.cs
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/Settings/StoredSensors.cs
@@ -90,85 +90,85 @@ namespace HASS.Agent.Satellite.Service.Settings
             switch (sensor.Type)
             {
                 case SensorType.UserNotificationStateSensor:
-                    abstractSensor = new UserNotificationStateSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new UserNotificationStateSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.DummySensor:
-                    abstractSensor = new DummySensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new DummySensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.CurrentClockSpeedSensor:
-                    abstractSensor = new CurrentClockSpeedSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new CurrentClockSpeedSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.CpuLoadSensor:
-                    abstractSensor = new CpuLoadSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new CpuLoadSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.MemoryUsageSensor:
-                    abstractSensor = new MemoryUsageSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new MemoryUsageSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.ActiveWindowSensor:
-                    abstractSensor = new ActiveWindowSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new ActiveWindowSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.NamedWindowSensor:
-                    abstractSensor = new NamedWindowSensor(sensor.WindowName, sensor.Name, sensor.FriendlyName, sensor.UpdateInterval, sensor.Id.ToString());
+                    abstractSensor = new NamedWindowSensor(sensor.WindowName, sensor.EntityName, sensor.Name, sensor.UpdateInterval, sensor.Id.ToString());
                     break;
                 case SensorType.LastActiveSensor:
-                    abstractSensor = new LastActiveSensor(sensor.ApplyRounding, sensor.Round, sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new LastActiveSensor(sensor.ApplyRounding, sensor.Round, sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.LastSystemStateChangeSensor:
-                    abstractSensor = new LastSystemStateChangeSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new LastSystemStateChangeSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.LastBootSensor:
-                    abstractSensor = new LastBootSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new LastBootSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.WebcamActiveSensor:
-                    abstractSensor = new WebcamActiveSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new WebcamActiveSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.MicrophoneActiveSensor:
-                    abstractSensor = new MicrophoneActiveSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new MicrophoneActiveSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.SessionStateSensor:
-                    abstractSensor = new SessionStateSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new SessionStateSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.CurrentVolumeSensor:
-                    abstractSensor = new CurrentVolumeSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new CurrentVolumeSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.GpuLoadSensor:
-                    abstractSensor = new GpuLoadSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new GpuLoadSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.GpuTemperatureSensor:
-                    abstractSensor = new GpuTemperatureSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new GpuTemperatureSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.WmiQuerySensor:
-                    abstractSensor = new WmiQuerySensor(sensor.Query, sensor.Scope, sensor.ApplyRounding, sensor.Round, sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new WmiQuerySensor(sensor.Query, sensor.Scope, sensor.ApplyRounding, sensor.Round, sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.PerformanceCounterSensor:
-                    abstractSensor = new PerformanceCounterSensor(sensor.Category, sensor.Counter, sensor.Instance, sensor.ApplyRounding, sensor.Round, sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new PerformanceCounterSensor(sensor.Category, sensor.Counter, sensor.Instance, sensor.ApplyRounding, sensor.Round, sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.ProcessActiveSensor:
-                    abstractSensor = new ProcessActiveSensor(sensor.Query, sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new ProcessActiveSensor(sensor.Query, sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.ServiceStateSensor:
-                    abstractSensor = new ServiceStateSensor(sensor.Query, sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new ServiceStateSensor(sensor.Query, sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.LoggedUsersSensor:
-                    abstractSensor = new LoggedUsersSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new LoggedUsersSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.LoggedUserSensor:
-                    abstractSensor = new LoggedUserSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new LoggedUserSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.PowershellSensor:
-                    abstractSensor = new PowershellSensor(sensor.Query, sensor.ApplyRounding, sensor.Round, sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new PowershellSensor(sensor.Query, sensor.ApplyRounding, sensor.Round, sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.WindowStateSensor:
-                    abstractSensor = new WindowStateSensor(sensor.Query, sensor.Name, sensor.FriendlyName, sensor.UpdateInterval, sensor.Id.ToString());
+                    abstractSensor = new WindowStateSensor(sensor.Query, sensor.EntityName, sensor.Name, sensor.UpdateInterval, sensor.Id.ToString());
                     break;
                 case SensorType.MicrophoneProcessSensor:
-                    abstractSensor = new MicrophoneProcessSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new MicrophoneProcessSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.WebcamProcessSensor:
-                    abstractSensor = new WebcamProcessSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new WebcamProcessSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 default:
-                    Log.Error("[SETTINGS_SENSORS] [{name}] Unknown configured single-value sensor type: {type}", sensor.Name, sensor.Type.ToString());
+                    Log.Error("[SETTINGS_SENSORS] [{name}] Unknown configured single-value sensor type: {type}", sensor.EntityName, sensor.Type.ToString());
                     break;
             }
 
@@ -187,25 +187,25 @@ namespace HASS.Agent.Satellite.Service.Settings
             switch (sensor.Type)
             {
                 case SensorType.StorageSensors:
-                    abstractSensor = new StorageSensors(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new StorageSensors(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.NetworkSensors:
-                    abstractSensor = new NetworkSensors(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Query, sensor.Id.ToString());
+                    abstractSensor = new NetworkSensors(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Query, sensor.Id.ToString());
                     break;
                 case SensorType.WindowsUpdatesSensors:
-                    abstractSensor = new WindowsUpdatesSensors(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new WindowsUpdatesSensors(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.BatterySensors:
-                    abstractSensor = new BatterySensors(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new BatterySensors(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.DisplaySensors:
-                    abstractSensor = new DisplaySensors(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new DisplaySensors(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.AudioSensors:
-                    abstractSensor = new AudioSensors(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new AudioSensors(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 default:
-                    Log.Error("[SETTINGS_SENSORS] [{name}] Unknown configured multi-value sensor type: {type}", sensor.Name, sensor.Type.ToString());
+                    Log.Error("[SETTINGS_SENSORS] [{name}] Unknown configured multi-value sensor type: {type}", sensor.EntityName, sensor.Type.ToString());
                     break;
             }
 
@@ -227,8 +227,8 @@ namespace HASS.Agent.Satellite.Service.Settings
                         return new ConfiguredSensor
                         {
                             Id = Guid.Parse(wmiSensor.Id),
-                            Name = wmiSensor.Name,
-                            FriendlyName = wmiSensor.FriendlyName,
+                            EntityName = wmiSensor.EntityName,
+                            Name = wmiSensor.EntityName,
                             Type = type,
                             UpdateInterval = wmiSensor.UpdateIntervalSeconds,
                             Scope = wmiSensor.Scope,
@@ -244,8 +244,8 @@ namespace HASS.Agent.Satellite.Service.Settings
                         return new ConfiguredSensor
                         {
                             Id = Guid.Parse(namedWindowSensor.Id),
-                            Name = namedWindowSensor.Name,
-                            FriendlyName = namedWindowSensor.FriendlyName,
+                            EntityName = namedWindowSensor.EntityName,
+                            Name = namedWindowSensor.EntityName,
                             Type = type,
                             UpdateInterval = namedWindowSensor.UpdateIntervalSeconds,
                             WindowName = namedWindowSensor.WindowName
@@ -258,8 +258,8 @@ namespace HASS.Agent.Satellite.Service.Settings
                         return new ConfiguredSensor
                         {
                             Id = Guid.Parse(performanceCounterSensor.Id),
-                            Name = performanceCounterSensor.Name,
-                            FriendlyName = performanceCounterSensor.FriendlyName,
+                            EntityName = performanceCounterSensor.EntityName,
+                            Name = performanceCounterSensor.EntityName,
                             Type = type,
                             UpdateInterval = performanceCounterSensor.UpdateIntervalSeconds,
                             Category = performanceCounterSensor.CategoryName,
@@ -276,8 +276,8 @@ namespace HASS.Agent.Satellite.Service.Settings
                         return new ConfiguredSensor
                         {
                             Id = Guid.Parse(processActiveSensor.Id),
-                            Name = processActiveSensor.Name,
-                            FriendlyName = processActiveSensor.FriendlyName,
+                            EntityName = processActiveSensor.EntityName,
+                            Name = processActiveSensor.EntityName,
                             Type = type,
                             UpdateInterval = processActiveSensor.UpdateIntervalSeconds,
                             Query = processActiveSensor.ProcessName
@@ -290,8 +290,8 @@ namespace HASS.Agent.Satellite.Service.Settings
                         return new ConfiguredSensor
                         {
                             Id = Guid.Parse(serviceStateSensor.Id),
-                            Name = serviceStateSensor.Name,
-                            FriendlyName = serviceStateSensor.FriendlyName,
+                            EntityName = serviceStateSensor.EntityName,
+                            Name = serviceStateSensor.EntityName,
                             Type = type,
                             UpdateInterval = serviceStateSensor.UpdateIntervalSeconds,
                             Query = serviceStateSensor.ServiceName
@@ -304,8 +304,8 @@ namespace HASS.Agent.Satellite.Service.Settings
                         return new ConfiguredSensor
                         {
                             Id = Guid.Parse(powershellSensor.Id),
-                            Name = powershellSensor.Name,
-                            FriendlyName = powershellSensor.FriendlyName,
+                            EntityName = powershellSensor.EntityName,
+                            Name = powershellSensor.EntityName,
                             Type = type,
                             UpdateInterval = powershellSensor.UpdateIntervalSeconds,
                             Query = powershellSensor.Command,
@@ -320,8 +320,8 @@ namespace HASS.Agent.Satellite.Service.Settings
                         return new ConfiguredSensor
                         {
                             Id = Guid.Parse(windowStateSensor.Id),
-                            Name = windowStateSensor.Name,
-                            FriendlyName = windowStateSensor.FriendlyName,
+                            EntityName = windowStateSensor.EntityName,
+                            Name = windowStateSensor.EntityName,
                             Type = type,
                             UpdateInterval = windowStateSensor.UpdateIntervalSeconds,
                             Query = windowStateSensor.ProcessName
@@ -334,8 +334,8 @@ namespace HASS.Agent.Satellite.Service.Settings
                         return new ConfiguredSensor
                         {
                             Id = Guid.Parse(sensor.Id),
-                            Name = sensor.Name,
-                            FriendlyName = sensor.FriendlyName,
+                            EntityName = sensor.EntityName,
+                            Name = sensor.EntityName,
                             Type = type,
                             UpdateInterval = sensor.UpdateIntervalSeconds
                         };
@@ -358,8 +358,8 @@ namespace HASS.Agent.Satellite.Service.Settings
                         return new ConfiguredSensor
                         {
                             Id = Guid.Parse(sensor.Id),
-                            Name = sensor.Name,
-                            FriendlyName = storageSensors.FriendlyName,
+                            EntityName = sensor.EntityName,
+                            Name = storageSensors.EntityName,
                             Type = type,
                             UpdateInterval = sensor.UpdateIntervalSeconds
                         };
@@ -371,8 +371,8 @@ namespace HASS.Agent.Satellite.Service.Settings
                         return new ConfiguredSensor
                         {
                             Id = Guid.Parse(sensor.Id),
-                            Name = sensor.Name,
-                            FriendlyName = networkSensors.FriendlyName,
+                            EntityName = sensor.EntityName,
+                            Name = networkSensors.EntityName,
                             Query = networkSensors.NetworkCard,
                             Type = type,
                             UpdateInterval = sensor.UpdateIntervalSeconds
@@ -385,7 +385,7 @@ namespace HASS.Agent.Satellite.Service.Settings
                         return new ConfiguredSensor
                         {
                             Id = Guid.Parse(sensor.Id),
-                            Name = sensor.Name,
+                            EntityName = sensor.EntityName,
                             Type = type,
                             UpdateInterval = sensor.UpdateIntervalSeconds
                         };
@@ -397,8 +397,8 @@ namespace HASS.Agent.Satellite.Service.Settings
                         return new ConfiguredSensor
                         {
                             Id = Guid.Parse(sensor.Id),
-                            Name = sensor.Name,
-                            FriendlyName = sensor.FriendlyName,
+                            EntityName = sensor.EntityName,
+                            Name = sensor.EntityName,
                             Type = type,
                             UpdateInterval = sensor.UpdateIntervalSeconds
                         };
@@ -410,8 +410,8 @@ namespace HASS.Agent.Satellite.Service.Settings
                         return new ConfiguredSensor
                         {
                             Id = Guid.Parse(sensor.Id),
-                            Name = sensor.Name,
-                            FriendlyName = sensor.FriendlyName,
+                            EntityName = sensor.EntityName,
+                            Name = sensor.EntityName,
                             Type = type,
                             UpdateInterval = sensor.UpdateIntervalSeconds
                         };
@@ -423,8 +423,8 @@ namespace HASS.Agent.Satellite.Service.Settings
                         return new ConfiguredSensor
                         {
                             Id = Guid.Parse(sensor.Id),
-                            Name = sensor.Name,
-                            FriendlyName = sensor.FriendlyName,
+                            EntityName = sensor.EntityName,
+                            Name = sensor.EntityName,
                             Type = type,
                             UpdateInterval = sensor.UpdateIntervalSeconds
                         };

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/CustomCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/CustomCommand.cs
@@ -18,7 +18,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands
         public bool RunAsLowIntegrity { get; protected set; }
         public Process Process { get; set; } = null;
 
-        public CustomCommand(string command, bool runAsLowIntegrity, string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(name ?? DefaultName, friendlyName ?? null, entityType, id)
+        public CustomCommand(string command, bool runAsLowIntegrity, string entityName = DefaultName, string name = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(entityName ?? DefaultName, name ?? null, entityType, id)
         {
             Command = command;
             RunAsLowIntegrity = runAsLowIntegrity;
@@ -31,7 +31,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands
 
             if (string.IsNullOrWhiteSpace(Command))
             {
-                Log.Warning("[CUSTOMCOMMAND] [{name}] Unable to launch command, it's configured as action-only", Name);
+                Log.Warning("[CUSTOMCOMMAND] [{name}] Unable to launch command, it's configured as action-only", EntityName);
                 State = "OFF";
                 return;
             }
@@ -41,7 +41,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands
             {
                 var executed = CommandLineManager.ExecuteHeadless(Command);
 
-                if (!executed) Log.Error("[CUSTOMCOMMAND] [{name}] Launching command failed", Name);
+                if (!executed) Log.Error("[CUSTOMCOMMAND] [{name}] Launching command failed", EntityName);
             }
 
             State = "OFF";
@@ -61,7 +61,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands
                     ? CommandLineManager.Execute(Command, action)
                     : CommandLineManager.ExecuteHeadless(action);
 
-                if (!executed) Log.Error("[CUSTOMCOMMAND] [{name}] Launching command with action '{action}' failed", Name, action);
+                if (!executed) Log.Error("[CUSTOMCOMMAND] [{name}] Launching command with action '{action}' failed", EntityName, action);
             }
 
             State = "OFF";
@@ -76,8 +76,8 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands
 
             return new CommandDiscoveryConfigModel()
             {
-                Name = Name,
-                FriendlyName = FriendlyName,
+                EntityName = EntityName,
+                Name = EntityName,
                 Unique_id = Id,
                 Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/sensor/{deviceConfig.Name}/availability",
                 Command_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/set",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/CustomCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/CustomCommand.cs
@@ -77,7 +77,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands
             return new CommandDiscoveryConfigModel()
             {
                 EntityName = EntityName,
-                Name = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/sensor/{deviceConfig.Name}/availability",
                 Command_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/set",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/CustomCommands/HibernateCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/CustomCommands/HibernateCommand.cs
@@ -9,6 +9,6 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.CustomCommands
     {
         private const string DefaultName = "hibernate";
 
-        public HibernateCommand(string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base("shutdown /h", false, name ?? DefaultName, friendlyName ?? null, entityType, id) => State = "OFF";
+        public HibernateCommand(string entityName = DefaultName, string name = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base("shutdown /h", false, entityName ?? DefaultName, name ?? null, entityType, id) => State = "OFF";
     }
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/CustomCommands/LockCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/CustomCommands/LockCommand.cs
@@ -9,6 +9,6 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.CustomCommands
     {
         private const string DefaultName = "lock";
 
-        public LockCommand(string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base("Rundll32.exe user32.dll,LockWorkStation", false, name ?? DefaultName, friendlyName ?? null, entityType, id) => State = "OFF";
+        public LockCommand(string entityName = DefaultName, string name = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base("Rundll32.exe user32.dll,LockWorkStation", false, entityName ?? DefaultName, name ?? null, entityType, id) => State = "OFF";
     }
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/CustomCommands/LogOffCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/CustomCommands/LogOffCommand.cs
@@ -9,6 +9,6 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.CustomCommands
     {
         private const string DefaultName = "logoff";
 
-        public LogOffCommand(string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base("shutdown /l", false, name ?? DefaultName, friendlyName ?? null, entityType, id) => State = "OFF";
+        public LogOffCommand(string entityName = DefaultName, string name = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base("shutdown /l", false, entityName ?? DefaultName, name ?? null, entityType, id) => State = "OFF";
     }
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/CustomCommands/RestartCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/CustomCommands/RestartCommand.cs
@@ -9,6 +9,6 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.CustomCommands
     {
         private const string DefaultName = "restart";
 
-        public RestartCommand(string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base("shutdown /r", false, name ?? DefaultName, friendlyName ?? null, entityType, id) => State = "OFF";
+        public RestartCommand(string entityName = DefaultName, string name = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base("shutdown /r", false, entityName ?? DefaultName, name ?? null, entityType, id) => State = "OFF";
     }
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/CustomCommands/ShutdownCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/CustomCommands/ShutdownCommand.cs
@@ -9,6 +9,6 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.CustomCommands
     {
         private const string DefaultName = "shutdown";
 
-        public ShutdownCommand(string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base("shutdown /s", false, name ?? DefaultName, friendlyName ?? null, entityType, id) => State = "OFF";
+        public ShutdownCommand(string entityName = DefaultName, string name = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base("shutdown /s", false, entityName ?? DefaultName, name ?? null, entityType, id) => State = "OFF";
     }
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/CustomCommands/SleepCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/CustomCommands/SleepCommand.cs
@@ -10,6 +10,6 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.CustomCommands
     {
         private const string DefaultName = "sleep";
 
-        public SleepCommand(string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base("Rundll32.exe powrprof.dll,SetSuspendState 0,1,0", false, name ?? DefaultName, friendlyName ?? null, entityType, id) => State = "OFF";
+        public SleepCommand(string entityName = DefaultName, string name = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base("Rundll32.exe powrprof.dll,SetSuspendState 0,1,0", false, entityName ?? DefaultName, name ?? null, entityType, id) => State = "OFF";
     }
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/InternalCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/InternalCommand.cs
@@ -13,7 +13,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands
         public string State { get; protected set; }
         public string CommandConfig { get; protected set; }
 
-        public InternalCommand(string name = DefaultName, string friendlyName = DefaultName, string commandConfig = "", CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(name ?? DefaultName, friendlyName ?? null, entityType, id)
+        public InternalCommand(string entityName = DefaultName, string name = DefaultName, string commandConfig = "", CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(entityName ?? DefaultName, name ?? null, entityType, id)
         {
             State = "OFF";
             CommandConfig = commandConfig;
@@ -46,8 +46,8 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands
 
             return new CommandDiscoveryConfigModel()
             {
-                Name = Name,
-                FriendlyName = FriendlyName,
+                EntityName = EntityName,
+                Name = EntityName,
                 Unique_id = Id,
                 Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/sensor/{deviceConfig.Name}/availability",
                 Command_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/set",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/InternalCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/InternalCommand.cs
@@ -47,7 +47,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands
             return new CommandDiscoveryConfigModel()
             {
                 EntityName = EntityName,
-                Name = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/sensor/{deviceConfig.Name}/availability",
                 Command_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/set",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/InternalCommands/CustomExecutorCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/InternalCommands/CustomExecutorCommand.cs
@@ -13,7 +13,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.InternalCommands
     {
         private const string DefaultName = "customexecutor";
 
-        public CustomExecutorCommand(string name = DefaultName, string friendlyName = DefaultName, string command = "", CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(name ?? DefaultName, friendlyName ?? null, command, entityType, id)
+        public CustomExecutorCommand(string entityName = DefaultName, string name = DefaultName, string command = "", CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(entityName ?? DefaultName, name ?? null, command, entityType, id)
         {
             CommandConfig = command;
             State = "OFF";
@@ -25,7 +25,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.InternalCommands
 
             if (string.IsNullOrWhiteSpace(CommandConfig))
             {
-                Log.Warning("[CUSTOMEXECUTOR] [{name}] Unable to launch command, it's configured as action-only", Name, Name);
+                Log.Warning("[CUSTOMEXECUTOR] [{name}] Unable to launch command, it's configured as action-only", EntityName, EntityName);
 
                 State = "OFF";
                 return;
@@ -36,14 +36,14 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.InternalCommands
                 // is there a custom executor provided?
                 if (string.IsNullOrEmpty(Variables.CustomExecutorBinary))
                 {
-                    Log.Warning("[CUSTOMEXECUTOR] [{name}] No custom executor provided, unable to execute", Name);
+                    Log.Warning("[CUSTOMEXECUTOR] [{name}] No custom executor provided, unable to execute", EntityName);
                     return;
                 }
 
                 // does the binary still exist?
                 if (!File.Exists(Variables.CustomExecutorBinary))
                 {
-                    Log.Error("[CUSTOMEXECUTOR] [{name}] Provided custom executor not found: {file}", Name, Variables.CustomExecutorBinary);
+                    Log.Error("[CUSTOMEXECUTOR] [{name}] Provided custom executor not found: {file}", EntityName, Variables.CustomExecutorBinary);
                     return;
                 }
 
@@ -61,13 +61,13 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.InternalCommands
                 var start = process.Start();
 
                 // check if the start went ok
-                if (!start) Log.Error("[CUSTOMEXECUTOR] [{name}] Unable to start executing command: {command}", Name, CommandConfig);
+                if (!start) Log.Error("[CUSTOMEXECUTOR] [{name}] Unable to start executing command: {command}", EntityName, CommandConfig);
 
                 // yep, done
             }
             catch (Exception ex)
             {
-                Log.Error("[CUSTOMEXECUTOR] [{name}] Error while processing: {err}", Name, ex.Message);
+                Log.Error("[CUSTOMEXECUTOR] [{name}] Error while processing: {err}", EntityName, ex.Message);
             }
             finally
             {
@@ -84,14 +84,14 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.InternalCommands
                 // is there a custom executor provided?
                 if (string.IsNullOrEmpty(Variables.CustomExecutorBinary))
                 {
-                    Log.Warning("[CUSTOMEXECUTOR] [{name}] No custom executor provided, unable to execute", Name);
+                    Log.Warning("[CUSTOMEXECUTOR] [{name}] No custom executor provided, unable to execute", EntityName);
                     return;
                 }
 
                 // does the binary still exist?
                 if (!File.Exists(Variables.CustomExecutorBinary))
                 {
-                    Log.Error("[CUSTOMEXECUTOR] [{name}] Provided custom executor not found: {file}", Name, Variables.CustomExecutorBinary);
+                    Log.Error("[CUSTOMEXECUTOR] [{name}] Provided custom executor not found: {file}", EntityName, Variables.CustomExecutorBinary);
                     return;
                 }
 
@@ -118,7 +118,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.InternalCommands
             }
             catch (Exception ex)
             {
-                Log.Error("[CUSTOMEXECUTOR] [{name}] Error while processing custom executor: {err}", Name, ex.Message);
+                Log.Error("[CUSTOMEXECUTOR] [{name}] Error while processing custom executor: {err}", EntityName, ex.Message);
             }
             finally
             {

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/InternalCommands/MonitorSleepCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/InternalCommands/MonitorSleepCommand.cs
@@ -16,7 +16,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.InternalCommands
     {
         private const string DefaultName = "monitorsleep";
 
-        public MonitorSleepCommand(string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Button, string id = default) : base(name ?? DefaultName, friendlyName ?? null, string.Empty, entityType, id)
+        public MonitorSleepCommand(string entityName = DefaultName, string name = DefaultName, CommandEntityType entityType = CommandEntityType.Button, string id = default) : base(entityName ?? DefaultName, name ?? null, string.Empty, entityType, id)
         {
             State = "OFF";
         }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/InternalCommands/SendWindowToFrontCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/InternalCommands/SendWindowToFrontCommand.cs
@@ -14,7 +14,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.InternalCommands
     {
         private const string DefaultName = "sendwindowtofront";
 
-        public SendWindowToFrontCommand(string name = DefaultName, string friendlyName = DefaultName, string process = "", CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(name ?? DefaultName, friendlyName ?? null, process, entityType, id)
+        public SendWindowToFrontCommand(string entityName = DefaultName, string name = DefaultName, string process = "", CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(entityName ?? DefaultName, name ?? null, process, entityType, id)
         {
             CommandConfig = process;
             State = "OFF";
@@ -26,7 +26,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.InternalCommands
 
             if (string.IsNullOrWhiteSpace(CommandConfig))
             {
-                Log.Warning("[SENDWINDOWTOFRONT] [{name}] Unable to launch command, it's configured as action-only", Name);
+                Log.Warning("[SENDWINDOWTOFRONT] [{name}] Unable to launch command, it's configured as action-only", EntityName);
 
                 State = "OFF";
                 return;
@@ -43,7 +43,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.InternalCommands
 
             if (string.IsNullOrWhiteSpace(action))
             {
-                Log.Warning("[SENDWINDOWTOFRONT] [{name}] Unable to launch command, empty action provided", Name);
+                Log.Warning("[SENDWINDOWTOFRONT] [{name}] Unable to launch command, empty action provided", EntityName);
 
                 State = "OFF";
                 return;
@@ -51,7 +51,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.InternalCommands
 
             if (!string.IsNullOrWhiteSpace(CommandConfig))
             {
-                Log.Warning("[SENDWINDOWTOFRONT] [{name}] Command launched by action, command-provided process will be ignored", Name);
+                Log.Warning("[SENDWINDOWTOFRONT] [{name}] Command launched by action, command-provided process will be ignored", EntityName);
             }
 
             ProcessManager.BringMainWindowToFront(action);

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/InternalCommands/SetApplicationVolumeCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/InternalCommands/SetApplicationVolumeCommand.cs
@@ -15,7 +15,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.InternalCommands
         private const string DefaultName = "setappvolume";
         private static readonly Dictionary<int, string> ApplicationNames = new Dictionary<int, string>();
 
-        public SetApplicationVolumeCommand(string name = DefaultName, string friendlyName = DefaultName, string commandConfig = "", CommandEntityType entityType = CommandEntityType.Button, string id = default) : base(name ?? DefaultName, friendlyName ?? null, commandConfig, entityType, id)
+        public SetApplicationVolumeCommand(string entityName = DefaultName, string name = DefaultName, string commandConfig = "", CommandEntityType entityType = CommandEntityType.Button, string id = default) : base(entityName ?? DefaultName, name ?? null, commandConfig, entityType, id)
         {
             State = "OFF";
         }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/InternalCommands/SetAudioOutputCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/InternalCommands/SetAudioOutputCommand.cs
@@ -18,7 +18,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.InternalCommands
 
         private string OutputDevice { get => CommandConfig; }
 
-        public SetAudioOutputCommand(string name = DefaultName, string friendlyName = DefaultName, string audioDevice = "", CommandEntityType entityType = CommandEntityType.Button, string id = default) : base(name ?? DefaultName, friendlyName ?? null, audioDevice, entityType, id)
+        public SetAudioOutputCommand(string entityName = DefaultName, string name = DefaultName, string audioDevice = "", CommandEntityType entityType = CommandEntityType.Button, string id = default) : base(entityName ?? DefaultName, name ?? null, audioDevice, entityType, id)
         {
             State = "OFF";
         }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/InternalCommands/SetVolumeCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/InternalCommands/SetVolumeCommand.cs
@@ -20,14 +20,14 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.InternalCommands
         private const string DefaultName = "setvolume";
         private readonly float _volume = -1f;
 
-        public SetVolumeCommand(string name = DefaultName, string friendlyName = DefaultName, string volume = "", CommandEntityType entityType = CommandEntityType.Button, string id = default) : base(name ?? DefaultName, friendlyName ?? null, volume, entityType, id)
+        public SetVolumeCommand(string entityName = DefaultName, string name = DefaultName, string volume = "", CommandEntityType entityType = CommandEntityType.Button, string id = default) : base(entityName ?? DefaultName, name ?? null, volume, entityType, id)
         {
             if (!string.IsNullOrWhiteSpace(volume))
             {
                 var parsed = int.TryParse(volume, out var volumeInt);
                 if (!parsed)
                 {
-                    Log.Error("[SETVOLUME] [{name}] Unable to parse configured volume level, not an int: {val}", Name, volume);
+                    Log.Error("[SETVOLUME] [{name}] Unable to parse configured volume level, not an int: {val}", EntityName, volume);
                     _volume = -1f;
                 }
 
@@ -45,7 +45,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.InternalCommands
             {
                 if (_volume == -1f)
                 {
-                    Log.Warning("[SETVOLUME] [{name}] Unable to trigger command, it's configured as action-only", Name);
+                    Log.Warning("[SETVOLUME] [{name}] Unable to trigger command, it's configured as action-only", EntityName);
                     
                     return;
                 }
@@ -54,7 +54,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.InternalCommands
                 using var audioDevice = Variables.AudioDeviceEnumerator?.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
                 if (audioDevice?.AudioEndpointVolume == null)
                 {
-                    Log.Warning("[SETVOLUME] [{name}] Unable to trigger command, no default audio endpoint found", Name);
+                    Log.Warning("[SETVOLUME] [{name}] Unable to trigger command, no default audio endpoint found", EntityName);
                     
                     return;
                 }
@@ -63,7 +63,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.InternalCommands
             }
             catch (Exception ex)
             {
-                Log.Error("[SETVOLUME] [{name}] Error while processing: {err}", Name, ex.Message);
+                Log.Error("[SETVOLUME] [{name}] Error while processing: {err}", EntityName, ex.Message);
             }
             finally
             {
@@ -80,7 +80,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.InternalCommands
                 var parsed = int.TryParse(action, out var volumeInt);
                 if (!parsed)
                 {
-                    Log.Error("[SETVOLUME] [{name}] Unable to trigger command, the provided action value can't be parsed: {val}", Name, action);
+                    Log.Error("[SETVOLUME] [{name}] Unable to trigger command, the provided action value can't be parsed: {val}", EntityName, action);
                     
                     return;
                 }
@@ -89,7 +89,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.InternalCommands
                 using var audioDevice = Variables.AudioDeviceEnumerator?.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
                 if (audioDevice?.AudioEndpointVolume == null)
                 {
-                    Log.Warning("[SETVOLUME] [{name}] Unable to trigger action for command, no default audio endpoint found", Name);
+                    Log.Warning("[SETVOLUME] [{name}] Unable to trigger action for command, no default audio endpoint found", EntityName);
                     
                     return;
                 }
@@ -98,7 +98,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.InternalCommands
             }
             catch (Exception ex)
             {
-                Log.Error("[SETVOLUME] [{name}] Error while processing action: {err}", Name, ex.Message);
+                Log.Error("[SETVOLUME] [{name}] Error while processing action: {err}", EntityName, ex.Message);
             }
             finally
             {

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/KeyCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/KeyCommand.cs
@@ -38,7 +38,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands
             return new CommandDiscoveryConfigModel
             {
                 EntityName = EntityName,
-                Name = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/sensor/{deviceConfig.Name}/availability",
                 Command_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/set",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/KeyCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/KeyCommand.cs
@@ -22,7 +22,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands
         
         public VirtualKeyShort KeyCode { get; set; }
 
-        public KeyCommand(VirtualKeyShort keyCode, string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(name ?? DefaultName, friendlyName ?? null, entityType, id)
+        public KeyCommand(VirtualKeyShort keyCode, string entityName = DefaultName, string name = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(entityName ?? DefaultName, name ?? null, entityType, id)
         {
             KeyCode = keyCode;
             State = "OFF";
@@ -37,8 +37,8 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands
 
             return new CommandDiscoveryConfigModel
             {
-                Name = Name,
-                FriendlyName = FriendlyName,
+                EntityName = EntityName,
+                Name = EntityName,
                 Unique_id = Id,
                 Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/sensor/{deviceConfig.Name}/availability",
                 Command_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/set",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/KeyCommands/MediaMuteCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/KeyCommands/MediaMuteCommand.cs
@@ -10,6 +10,6 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.KeyCommands
     {
         private const string DefaultName = "mute";
 
-        public MediaMuteCommand(string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(VirtualKeyShort.VOLUME_MUTE, name ?? DefaultName, friendlyName ?? null, entityType, id) { }
+        public MediaMuteCommand(string entityName = DefaultName, string name = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(VirtualKeyShort.VOLUME_MUTE, entityName ?? DefaultName, name ?? null, entityType, id) { }
     }
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/KeyCommands/MediaNextCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/KeyCommands/MediaNextCommand.cs
@@ -10,6 +10,6 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.KeyCommands
     {
         private const string DefaultName = "next";
 
-        public MediaNextCommand(string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(VirtualKeyShort.MEDIA_NEXT_TRACK, name ?? DefaultName, friendlyName ?? null, entityType, id) { }
+        public MediaNextCommand(string entityName = DefaultName, string name = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(VirtualKeyShort.MEDIA_NEXT_TRACK, entityName ?? DefaultName, name ?? null, entityType, id) { }
     }
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/KeyCommands/MediaPlayPauseCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/KeyCommands/MediaPlayPauseCommand.cs
@@ -10,6 +10,6 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.KeyCommands
     {
         private const string DefaultName = "playpause";
 
-        public MediaPlayPauseCommand(string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(VirtualKeyShort.MEDIA_PLAY_PAUSE, name ?? DefaultName, friendlyName ?? null, entityType, id) { }
+        public MediaPlayPauseCommand(string entityName = DefaultName, string name = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(VirtualKeyShort.MEDIA_PLAY_PAUSE, entityName ?? DefaultName, name ?? null, entityType, id) { }
     }
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/KeyCommands/MediaPreviousCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/KeyCommands/MediaPreviousCommand.cs
@@ -10,6 +10,6 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.KeyCommands
     {
         private const string DefaultName = "previous";
 
-        public MediaPreviousCommand(string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(VirtualKeyShort.MEDIA_PREV_TRACK, name ?? DefaultName, friendlyName ?? null, entityType, id) { }
+        public MediaPreviousCommand(string entityName = DefaultName, string name = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(VirtualKeyShort.MEDIA_PREV_TRACK, entityName ?? DefaultName, name ?? null, entityType, id) { }
     }
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/KeyCommands/MediaVolumeDownCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/KeyCommands/MediaVolumeDownCommand.cs
@@ -10,6 +10,6 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.KeyCommands
     {
         private const string DefaultName = "volumedown";
 
-        public MediaVolumeDownCommand(string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(VirtualKeyShort.VOLUME_DOWN, name ?? DefaultName, friendlyName ?? null, entityType, id) { }
+        public MediaVolumeDownCommand(string entityName = DefaultName, string name = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(VirtualKeyShort.VOLUME_DOWN, entityName ?? DefaultName, name ?? null, entityType, id) { }
     }
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/KeyCommands/MediaVolumeUpCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/KeyCommands/MediaVolumeUpCommand.cs
@@ -10,6 +10,6 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.KeyCommands
     {
         private const string DefaultName = "volumeup";
 
-        public MediaVolumeUpCommand(string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(VirtualKeyShort.VOLUME_UP, name ?? DefaultName, friendlyName ?? null, entityType, id) { }
+        public MediaVolumeUpCommand(string entityName = DefaultName, string name = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(VirtualKeyShort.VOLUME_UP, entityName ?? DefaultName, name ?? null, entityType, id) { }
     }
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/KeyCommands/MonitorWakeCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/KeyCommands/MonitorWakeCommand.cs
@@ -11,6 +11,6 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.KeyCommands
     {
         private const string DefaultName = "monitorwake";
 
-        public MonitorWakeCommand(string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Button, string id = default) : base(VirtualKeyShort.UP, name ?? DefaultName, friendlyName ?? null, entityType, id) { }
+        public MonitorWakeCommand(string entityName = DefaultName, string name = DefaultName, CommandEntityType entityType = CommandEntityType.Button, string id = default) : base(VirtualKeyShort.UP, entityName ?? DefaultName, name ?? null, entityType, id) { }
     }
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/MultipleKeysCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/MultipleKeysCommand.cs
@@ -17,7 +17,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands
         public string State { get; protected set; }
         public List<string> Keys { get; set; }
 
-        public MultipleKeysCommand(List<string> keys, string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(name ?? DefaultName, friendlyName ?? null, entityType, id)
+        public MultipleKeysCommand(List<string> keys, string entityName = DefaultName, string name = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(entityName ?? DefaultName, name ?? null, entityType, id)
         {
             Keys = keys;
             State = "OFF";
@@ -32,8 +32,8 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands
 
             return new CommandDiscoveryConfigModel
             {
-                Name = Name,
-                FriendlyName = FriendlyName,
+                EntityName = EntityName,
+                Name = EntityName,
                 Unique_id = Id,
                 Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/sensor/{deviceConfig.Name}/availability",
                 Command_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/set",
@@ -65,7 +65,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands
             }
             catch (Exception ex)
             {
-                Log.Error("[MULTIPLEKEYS] [{name}] Executing command failed: {ex}", Name, ex.Message);
+                Log.Error("[MULTIPLEKEYS] [{name}] Executing command failed: {ex}", EntityName, ex.Message);
             }
             finally
             {

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/MultipleKeysCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/MultipleKeysCommand.cs
@@ -33,7 +33,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands
             return new CommandDiscoveryConfigModel
             {
                 EntityName = EntityName,
-                Name = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/sensor/{deviceConfig.Name}/availability",
                 Command_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/set",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/PowershellCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/PowershellCommand.cs
@@ -76,7 +76,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands
             return new CommandDiscoveryConfigModel()
             {
                 EntityName = EntityName,
-                Name = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/sensor/{deviceConfig.Name}/availability",
                 Command_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/set",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/PowershellCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/PowershellCommand.cs
@@ -20,7 +20,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands
         private readonly bool _isScript = false;
         private readonly string _descriptor = "command";
 
-        public PowershellCommand(string command, string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(name ?? DefaultName, friendlyName ?? null, entityType, id)
+        public PowershellCommand(string command, string entityName = DefaultName, string name = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(entityName ?? DefaultName, name ?? null, entityType, id)
         {
             Command = command;
             if (Command.ToLower().EndsWith(".ps1"))
@@ -38,7 +38,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands
 
             if (string.IsNullOrWhiteSpace(Command))
             {
-                Log.Warning("[POWERSHELL] [{name}] Unable to execute, it's configured as action-only", Name);
+                Log.Warning("[POWERSHELL] [{name}] Unable to execute, it's configured as action-only", EntityName);
 
                 State = "OFF";
                 return;
@@ -48,7 +48,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands
                 ? PowershellManager.ExecuteScriptHeadless(Command, string.Empty)
                 : PowershellManager.ExecuteCommandHeadless(Command);
 
-            if (!executed) Log.Error("[POWERSHELL] [{name}] Executing {descriptor} failed", Name, _descriptor, Name);
+            if (!executed) Log.Error("[POWERSHELL] [{name}] Executing {descriptor} failed", EntityName, _descriptor, EntityName);
             
             State = "OFF";
         }
@@ -61,7 +61,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands
                 ? PowershellManager.ExecuteScriptHeadless(Command, action)
                 : PowershellManager.ExecuteCommandHeadless(Command);
 
-            if (!executed) Log.Error("[POWERSHELL] [{name}] Launching PS {descriptor} with action '{action}' failed", Name, _descriptor, action);
+            if (!executed) Log.Error("[POWERSHELL] [{name}] Launching PS {descriptor} with action '{action}' failed", EntityName, _descriptor, action);
             
             State = "OFF";
         }
@@ -75,8 +75,8 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands
 
             return new CommandDiscoveryConfigModel()
             {
-                Name = Name,
-                FriendlyName = FriendlyName,
+                EntityName = EntityName,
+                Name = EntityName,
                 Unique_id = Id,
                 Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/sensor/{deviceConfig.Name}/availability",
                 Command_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/set",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/AudioSensors.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/AudioSensors.cs
@@ -27,7 +27,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
 
         public sealed override Dictionary<string, AbstractSingleValueSensor> Sensors { get; protected set; } = new Dictionary<string, AbstractSingleValueSensor>();
 
-        public AudioSensors(int? updateInterval = null, string name = DefaultName, string friendlyName = DefaultName, string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 20, id)
+        public AudioSensors(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 20, id)
         {
             _updateInterval = updateInterval ?? 20;
 
@@ -62,24 +62,24 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
             using var audioDevice = Variables.AudioDeviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
 
             var defaultDeviceId = $"{parentSensorSafeName}_default_device";
-            var defaultDeviceSensor = new DataTypeStringSensor(_updateInterval, $"Default Device", defaultDeviceId, string.Empty, "mdi:speaker", string.Empty, Name);
+            var defaultDeviceSensor = new DataTypeStringSensor(_updateInterval, $"Default Device", defaultDeviceId, string.Empty, "mdi:speaker", string.Empty, EntityName);
             defaultDeviceSensor.SetState(audioDevice.DeviceFriendlyName);
             AddUpdateSensor(defaultDeviceId, defaultDeviceSensor);
 
             var defaultDeviceStateId = $"{parentSensorSafeName}_default_device_state";
-            var defaultDeviceStateSensor = new DataTypeStringSensor(_updateInterval, $"Default Device State", defaultDeviceStateId, string.Empty, "mdi:speaker", string.Empty, Name);
+            var defaultDeviceStateSensor = new DataTypeStringSensor(_updateInterval, $"Default Device State", defaultDeviceStateId, string.Empty, "mdi:speaker", string.Empty, EntityName);
             defaultDeviceStateSensor.SetState(GetReadableState(audioDevice.State));
             AddUpdateSensor(defaultDeviceStateId, defaultDeviceStateSensor);
 
             var masterVolume = Convert.ToInt32(Math.Round(audioDevice.AudioEndpointVolume?.MasterVolumeLevelScalar * 100 ?? 0, 0));
             var defaultDeviceVolumeId = $"{parentSensorSafeName}_default_device_volume";
-            var defaultDeviceVolumeSensor = new DataTypeIntSensor(_updateInterval, $"Default Device Volume", defaultDeviceVolumeId, string.Empty, "mdi:speaker", string.Empty, Name);
+            var defaultDeviceVolumeSensor = new DataTypeIntSensor(_updateInterval, $"Default Device Volume", defaultDeviceVolumeId, string.Empty, "mdi:speaker", string.Empty, EntityName);
             defaultDeviceVolumeSensor.SetState(masterVolume);
             AddUpdateSensor(defaultDeviceVolumeId, defaultDeviceVolumeSensor);
 
             var defaultDeviceIsMuted = audioDevice.AudioEndpointVolume?.Mute ?? false;
             var defaultDeviceIsMutedId = $"{parentSensorSafeName}_default_device_muted";
-            var defaultDeviceIsMutedSensor = new DataTypeBoolSensor(_updateInterval, $"Default Device Muted", defaultDeviceIsMutedId, string.Empty, "mdi:speaker", Name);
+            var defaultDeviceIsMutedSensor = new DataTypeBoolSensor(_updateInterval, $"Default Device Muted", defaultDeviceIsMutedId, string.Empty, "mdi:speaker", EntityName);
             defaultDeviceIsMutedSensor.SetState(defaultDeviceIsMuted);
             AddUpdateSensor(defaultDeviceIsMutedId, defaultDeviceIsMutedSensor);
 
@@ -87,12 +87,12 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
             var sessionInfos = GetSessions(out var peakVolume);
 
             var peakVolumeId = $"{parentSensorSafeName}_peak_volume";
-            var peakVolumeSensor = new DataTypeStringSensor(_updateInterval, $"Peak Volume", peakVolumeId, string.Empty, "mdi:volume-high", string.Empty, Name);
+            var peakVolumeSensor = new DataTypeStringSensor(_updateInterval, $"Peak Volume", peakVolumeId, string.Empty, "mdi:volume-high", string.Empty, EntityName);
             peakVolumeSensor.SetState(peakVolume.ToString(CultureInfo.CurrentCulture));
             AddUpdateSensor(peakVolumeId, peakVolumeSensor);
 
             var sessionsId = $"{parentSensorSafeName}_sessions";
-            var sessionsSensor = new DataTypeIntSensor(_updateInterval, $"Audio Sessions", sessionsId, string.Empty, "mdi:music-box-multiple-outline", string.Empty, Name, true);
+            var sessionsSensor = new DataTypeIntSensor(_updateInterval, $"Audio Sessions", sessionsId, string.Empty, "mdi:music-box-multiple-outline", string.Empty, EntityName, true);
             sessionsSensor.SetState(sessionInfos.Count);
             sessionsSensor.SetAttributes(
                 JsonConvert.SerializeObject(new
@@ -104,7 +104,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
 
             var audioOutputDevices = GetAudioOutputDevices();
             var audioOutputDevicesId = $"{parentSensorSafeName}_output_devices";
-            var audioOutputDevicesSensor = new DataTypeIntSensor(_updateInterval, $"Audio Output Devices", audioOutputDevicesId, string.Empty, "mdi:music-box-multiple-outline", string.Empty, Name, true);
+            var audioOutputDevicesSensor = new DataTypeIntSensor(_updateInterval, $"Audio Output Devices", audioOutputDevicesId, string.Empty, "mdi:music-box-multiple-outline", string.Empty, EntityName, true);
             audioOutputDevicesSensor.SetState(audioOutputDevices.Count);
             audioOutputDevicesSensor.SetAttributes(
                 JsonConvert.SerializeObject(new
@@ -120,30 +120,30 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
             using var inputDevice = Variables.AudioDeviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Capture, Role.Communications);
 
             var defaultInputDeviceId = $"{parentSensorSafeName}_default_input_device";
-            var defaultInputDeviceSensor = new DataTypeStringSensor(_updateInterval, $"Default Input Device", defaultInputDeviceId, string.Empty, "mdi:microphone", string.Empty, Name);
+            var defaultInputDeviceSensor = new DataTypeStringSensor(_updateInterval, $"Default Input Device", defaultInputDeviceId, string.Empty, "mdi:microphone", string.Empty, EntityName);
             defaultInputDeviceSensor.SetState(inputDevice.DeviceFriendlyName);
             AddUpdateSensor(defaultInputDeviceId, defaultInputDeviceSensor);
 
             var defaultInputDeviceStateId = $"{parentSensorSafeName}_default_input_device_state";
-            var defaultInputDeviceStateSensor = new DataTypeStringSensor(_updateInterval, $"Default Input Device State", defaultInputDeviceStateId, string.Empty, "mdi:microphone", string.Empty, Name);
+            var defaultInputDeviceStateSensor = new DataTypeStringSensor(_updateInterval, $"Default Input Device State", defaultInputDeviceStateId, string.Empty, "mdi:microphone", string.Empty, EntityName);
             defaultInputDeviceStateSensor.SetState(GetReadableState(inputDevice.State));
             AddUpdateSensor(defaultInputDeviceStateId, defaultInputDeviceStateSensor);
 
             var defaultInputDeviceIsMuted = inputDevice.AudioEndpointVolume?.Mute ?? false;
             var defaultInputDeviceIsMutedId = $"{parentSensorSafeName}_default_input_device_muted";
-            var defaultInputDeviceIsMutedSensor = new DataTypeBoolSensor(_updateInterval, $"Default Input Device Muted", defaultInputDeviceIsMutedId, string.Empty, "mdi:microphone", Name);
+            var defaultInputDeviceIsMutedSensor = new DataTypeBoolSensor(_updateInterval, $"Default Input Device Muted", defaultInputDeviceIsMutedId, string.Empty, "mdi:microphone", EntityName);
             defaultInputDeviceIsMutedSensor.SetState(defaultInputDeviceIsMuted);
             AddUpdateSensor(defaultInputDeviceIsMutedId, defaultInputDeviceIsMutedSensor);
 
             var inputVolume = (int)GetDefaultInputDevicePeakVolume(inputDevice);
             var defaultInputDeviceVolumeId = $"{parentSensorSafeName}_default_input_device_volume";
-            var defaultInputDeviceVolumeSensor = new DataTypeIntSensor(_updateInterval, $"Default Input Device Volume", defaultInputDeviceVolumeId, string.Empty, "mdi:microphone", string.Empty, Name);
+            var defaultInputDeviceVolumeSensor = new DataTypeIntSensor(_updateInterval, $"Default Input Device Volume", defaultInputDeviceVolumeId, string.Empty, "mdi:microphone", string.Empty, EntityName);
             defaultInputDeviceVolumeSensor.SetState(inputVolume);
             AddUpdateSensor(defaultInputDeviceVolumeId, defaultInputDeviceVolumeSensor);
 
             var audioInputDevices = GetAudioInputDevices();
             var audioInputDevicesId = $"{parentSensorSafeName}_input_devices";
-            var audioInputDevicesSensor = new DataTypeIntSensor(_updateInterval, $"Audio Input Devices", audioInputDevicesId, string.Empty, "mdi:microphone", string.Empty, Name, true);
+            var audioInputDevicesSensor = new DataTypeIntSensor(_updateInterval, $"Audio Input Devices", audioInputDevicesId, string.Empty, "mdi:microphone", string.Empty, EntityName, true);
             audioInputDevicesSensor.SetState(audioInputDevices.Count);
             audioInputDevicesSensor.SetAttributes(
                 JsonConvert.SerializeObject(new
@@ -158,7 +158,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
         {
             try
             {
-                var parentSensorSafeName = SharedHelperFunctions.GetSafeValue(Name);
+                var parentSensorSafeName = SharedHelperFunctions.GetSafeValue(EntityName);
 
                 HandleAudioOutputSensors(parentSensorSafeName);
                 HandleAudioInputSensors(parentSensorSafeName);
@@ -173,7 +173,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
 
                 _errorPrinted = true;
 
-                Log.Fatal(ex, "[AUDIO] [{name}] Error while fetching audio info: {err}", Name, ex.Message);
+                Log.Fatal(ex, "[AUDIO] [{name}] Error while fetching audio info: {err}", EntityName, ex.Message);
             }
         }
 
@@ -241,7 +241,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
                             catch (Exception ex)
                             {
                                 if (!_errorPrinted)
-                                    Log.Fatal(ex, "[AUDIO] [{name}] [{app}] Exception while retrieving info: {err}", Name, session.DisplayName, ex.Message);
+                                    Log.Fatal(ex, "[AUDIO] [{name}] [{app}] Exception while retrieving info: {err}", EntityName, session.DisplayName, ex.Message);
 
                                 errors = true;
                             }
@@ -273,7 +273,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
 
                 _errorPrinted = true;
 
-                Log.Fatal(ex, "[AUDIO] [{name}] Fatal exception while getting sessions: {err}", Name, ex.Message);
+                Log.Fatal(ex, "[AUDIO] [{name}] Fatal exception while getting sessions: {err}", EntityName, ex.Message);
             }
 
             return sessionInfos;
@@ -309,7 +309,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
                     catch (Exception ex)
                     {
                         if (!_errorPrinted)
-                            Log.Fatal(ex, "[AUDIO] [{name}] [{app}] Exception while retrieving input info: {err}", Name, session.DisplayName, ex.Message);
+                            Log.Fatal(ex, "[AUDIO] [{name}] [{app}] Exception while retrieving input info: {err}", EntityName, session.DisplayName, ex.Message);
 
                         errors = true;
                     }
@@ -339,7 +339,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
 
                 _errorPrinted = true;
 
-                Log.Fatal(ex, "[AUDIO] [{name}] Fatal exception while getting input info: {err}", Name, ex.Message);
+                Log.Fatal(ex, "[AUDIO] [{name}] Fatal exception while getting input info: {err}", EntityName, ex.Message);
             }
 
             return peakVolume;

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/AudioSensors.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/AudioSensors.cs
@@ -12,357 +12,369 @@ using HidSharp;
 using Newtonsoft.Json;
 using Serilog;
 
-namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
+namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue;
+
+/// <summary>
+/// Multivalue sensor containing audio-related info
+/// </summary>
+public class AudioSensors : AbstractMultiValueSensor
 {
-    /// <summary>
-    /// Multivalue sensor containing audio-related info
-    /// </summary>
-    public class AudioSensors : AbstractMultiValueSensor
+    private const string DefaultName = "audio";
+    private static readonly Dictionary<int, string> ApplicationNames = new();
+    private bool _errorPrinted = false;
+
+    private readonly int _updateInterval;
+
+    public override sealed Dictionary<string, AbstractSingleValueSensor> Sensors { get; protected set; } = new Dictionary<string, AbstractSingleValueSensor>();
+
+    public AudioSensors(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 20, id)
     {
-        private const string DefaultName = "audio";
-        private static readonly Dictionary<int, string> ApplicationNames = new Dictionary<int, string>();
-        private bool _errorPrinted = false;
+        _updateInterval = updateInterval ?? 20;
 
-        private readonly int _updateInterval;
+        UpdateSensorValues();
+    }
 
-        public sealed override Dictionary<string, AbstractSingleValueSensor> Sensors { get; protected set; } = new Dictionary<string, AbstractSingleValueSensor>();
+    private void AddUpdateSensor(string sensorId, AbstractSingleValueSensor sensor)
+    {
+        if (!Sensors.ContainsKey(sensorId))
+            Sensors.Add(sensorId, sensor);
+        else
+            Sensors[sensorId] = sensor;
+    }
 
-        public AudioSensors(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 20, id)
+    private List<string> GetAudioDevices(DataFlow type)
+    {
+        var audioDevices = new List<string>();
+        foreach (var device in Variables.AudioDeviceEnumerator.EnumerateAudioEndPoints(type, DeviceState.Active))
         {
-            _updateInterval = updateInterval ?? 20;
-
-            UpdateSensorValues();
+            audioDevices.Add(device.DeviceFriendlyName);
+            device.Dispose();
         }
 
-        private void AddUpdateSensor(string sensorId, AbstractSingleValueSensor sensor)
-        {
-            if (!Sensors.ContainsKey(sensorId))
-                Sensors.Add(sensorId, sensor);
-            else
-                Sensors[sensorId] = sensor;
-        }
+        return audioDevices;
+    }
 
-        private List<String> GetAudioDevices(DataFlow type)
-        {
-            var audioDevices = new List<string>();
-            foreach (var device in Variables.AudioDeviceEnumerator.EnumerateAudioEndPoints(type, DeviceState.Active))
+    private List<string> GetAudioOutputDevices() => GetAudioDevices(DataFlow.Render);
+    private List<string> GetAudioInputDevices() => GetAudioDevices(DataFlow.Capture);
+
+    private void HandleAudioOutputSensors(string parentSensorSafeName, string deviceName)
+    {
+        using var audioDevice = Variables.AudioDeviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
+
+        var defaultDeviceEntityName = $"{parentSensorSafeName}_default_device";
+        var defaultDeviceId = $"{Id}_default_device";
+        var defaultDeviceSensor = new DataTypeStringSensor(_updateInterval, defaultDeviceEntityName, $"Default Device", defaultDeviceId, string.Empty, "mdi:speaker", string.Empty, EntityName);
+        defaultDeviceSensor.SetState(audioDevice.DeviceFriendlyName);
+        AddUpdateSensor(defaultDeviceId, defaultDeviceSensor);
+
+        var defaultDeviceStateEntityName = $"{parentSensorSafeName}_default_device_state";
+        var defaultDeviceStateId = $"{Id}_default_device_state";
+        var defaultDeviceStateSensor = new DataTypeStringSensor(_updateInterval, defaultDeviceStateEntityName, $"Default Device State", defaultDeviceStateId, string.Empty, "mdi:speaker", string.Empty, EntityName);
+        defaultDeviceStateSensor.SetState(GetReadableState(audioDevice.State));
+        AddUpdateSensor(defaultDeviceStateId, defaultDeviceStateSensor);
+
+        var masterVolume = Convert.ToInt32(Math.Round(audioDevice.AudioEndpointVolume?.MasterVolumeLevelScalar * 100 ?? 0, 0));
+        var defaultDeviceVolumeEntityName = $"{parentSensorSafeName}_default_device_volume";
+        var defaultDeviceVolumeId = $"{Id}_default_device_volume";
+        var defaultDeviceVolumeSensor = new DataTypeIntSensor(_updateInterval, defaultDeviceVolumeEntityName, $"Default Device Volume", defaultDeviceVolumeId, string.Empty, "mdi:speaker", string.Empty, EntityName);
+        defaultDeviceVolumeSensor.SetState(masterVolume);
+        AddUpdateSensor(defaultDeviceVolumeId, defaultDeviceVolumeSensor);
+
+        var defaultDeviceIsMuted = audioDevice.AudioEndpointVolume?.Mute ?? false;
+        var defaultDeviceIsMutedEntityName = $"{parentSensorSafeName}_default_device_muted";
+        var defaultDeviceIsMutedId = $"{Id}_default_device_muted";
+        var defaultDeviceIsMutedSensor = new DataTypeBoolSensor(_updateInterval, defaultDeviceIsMutedEntityName, $"Default Device Muted", defaultDeviceIsMutedId, string.Empty, "mdi:speaker", EntityName);
+        defaultDeviceIsMutedSensor.SetState(defaultDeviceIsMuted);
+        AddUpdateSensor(defaultDeviceIsMutedId, defaultDeviceIsMutedSensor);
+
+        // get session and volume info
+        var sessionInfos = GetSessions(out var peakVolume);
+
+        var peakVolumeEntityName = $"{parentSensorSafeName}_peak_volume";
+        var peakVolumeId = $"{Id}_peak_volume";
+        var peakVolumeSensor = new DataTypeStringSensor(_updateInterval, peakVolumeEntityName, $"Peak Volume", peakVolumeId, string.Empty, "mdi:volume-high", string.Empty, EntityName);
+        peakVolumeSensor.SetState(peakVolume.ToString(CultureInfo.CurrentCulture));
+        AddUpdateSensor(peakVolumeId, peakVolumeSensor);
+
+        var sessionsEntityName = $"{parentSensorSafeName}_sessions";
+        var sessionsId = $"{Id}_sessions";
+        var sessionsSensor = new DataTypeIntSensor(_updateInterval, sessionsEntityName, $"Audio Sessions", sessionsId, string.Empty, "mdi:music-box-multiple-outline", string.Empty, EntityName, true);
+        sessionsSensor.SetState(sessionInfos.Count);
+        sessionsSensor.SetAttributes(
+            JsonConvert.SerializeObject(new
             {
-                audioDevices.Add(device.DeviceFriendlyName);
-                device.Dispose();
-            }
+                AudioSessions = sessionInfos
+            }, Formatting.Indented)
+        );
+        AddUpdateSensor(sessionsId, sessionsSensor);
 
-            return audioDevices;
-        }
-
-        private List<string> GetAudioOutputDevices() => GetAudioDevices(DataFlow.Render);
-        private List<string> GetAudioInputDevices() => GetAudioDevices(DataFlow.Capture);
-
-        private void HandleAudioOutputSensors(string parentSensorSafeName)
-        {
-            using var audioDevice = Variables.AudioDeviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
-
-            var defaultDeviceId = $"{parentSensorSafeName}_default_device";
-            var defaultDeviceSensor = new DataTypeStringSensor(_updateInterval, defaultDeviceId, $"Default Device", defaultDeviceId, string.Empty, "mdi:speaker", string.Empty, EntityName);
-            defaultDeviceSensor.SetState(audioDevice.DeviceFriendlyName);
-            AddUpdateSensor(defaultDeviceId, defaultDeviceSensor);
-
-            var defaultDeviceStateId = $"{parentSensorSafeName}_default_device_state";
-            var defaultDeviceStateSensor = new DataTypeStringSensor(_updateInterval, defaultDeviceStateId, $"Default Device State", defaultDeviceStateId, string.Empty, "mdi:speaker", string.Empty, EntityName);
-            defaultDeviceStateSensor.SetState(GetReadableState(audioDevice.State));
-            AddUpdateSensor(defaultDeviceStateId, defaultDeviceStateSensor);
-
-            var masterVolume = Convert.ToInt32(Math.Round(audioDevice.AudioEndpointVolume?.MasterVolumeLevelScalar * 100 ?? 0, 0));
-            var defaultDeviceVolumeId = $"{parentSensorSafeName}_default_device_volume";
-            var defaultDeviceVolumeSensor = new DataTypeIntSensor(_updateInterval, defaultDeviceVolumeId, $"Default Device Volume", defaultDeviceVolumeId, string.Empty, "mdi:speaker", string.Empty, EntityName);
-            defaultDeviceVolumeSensor.SetState(masterVolume);
-            AddUpdateSensor(defaultDeviceVolumeId, defaultDeviceVolumeSensor);
-
-            var defaultDeviceIsMuted = audioDevice.AudioEndpointVolume?.Mute ?? false;
-            var defaultDeviceIsMutedId = $"{parentSensorSafeName}_default_device_muted";
-            var defaultDeviceIsMutedSensor = new DataTypeBoolSensor(_updateInterval, defaultDeviceIsMutedId, $"Default Device Muted", defaultDeviceIsMutedId, string.Empty, "mdi:speaker", EntityName);
-            defaultDeviceIsMutedSensor.SetState(defaultDeviceIsMuted);
-            AddUpdateSensor(defaultDeviceIsMutedId, defaultDeviceIsMutedSensor);
-
-            // get session and volume info
-            var sessionInfos = GetSessions(out var peakVolume);
-
-            var peakVolumeId = $"{parentSensorSafeName}_peak_volume";
-            var peakVolumeSensor = new DataTypeStringSensor(_updateInterval, peakVolumeId, $"Peak Volume", peakVolumeId, string.Empty, "mdi:volume-high", string.Empty, EntityName);
-            peakVolumeSensor.SetState(peakVolume.ToString(CultureInfo.CurrentCulture));
-            AddUpdateSensor(peakVolumeId, peakVolumeSensor);
-
-            var sessionsId = $"{parentSensorSafeName}_sessions";
-            var sessionsSensor = new DataTypeIntSensor(_updateInterval, sessionsId, $"Audio Sessions", sessionsId, string.Empty, "mdi:music-box-multiple-outline", string.Empty, EntityName, true);
-            sessionsSensor.SetState(sessionInfos.Count);
-            sessionsSensor.SetAttributes(
-                JsonConvert.SerializeObject(new
-                {
-                    AudioSessions = sessionInfos
-                }, Formatting.Indented)
-            );
-            AddUpdateSensor(sessionsId, sessionsSensor);
-
-            var audioOutputDevices = GetAudioOutputDevices();
-            var audioOutputDevicesId = $"{parentSensorSafeName}_output_devices";
-            var audioOutputDevicesSensor = new DataTypeIntSensor(_updateInterval, audioOutputDevicesId, $"Audio Output Devices", audioOutputDevicesId, string.Empty, "mdi:music-box-multiple-outline", string.Empty, EntityName, true);
-            audioOutputDevicesSensor.SetState(audioOutputDevices.Count);
-            audioOutputDevicesSensor.SetAttributes(
-                JsonConvert.SerializeObject(new
-                {
-                    OutputDevices = audioOutputDevices
-                }, Formatting.Indented)
-            );
-            AddUpdateSensor(audioOutputDevicesId, audioOutputDevicesSensor);
-        }
-
-        private void HandleAudioInputSensors(string parentSensorSafeName)
-        {
-            using var inputDevice = Variables.AudioDeviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Capture, Role.Communications);
-
-            var defaultInputDeviceId = $"{parentSensorSafeName}_default_input_device";
-            var defaultInputDeviceSensor = new DataTypeStringSensor(_updateInterval, defaultInputDeviceId, $"Default Input Device", defaultInputDeviceId, string.Empty, "mdi:microphone", string.Empty, EntityName);
-            defaultInputDeviceSensor.SetState(inputDevice.DeviceFriendlyName);
-            AddUpdateSensor(defaultInputDeviceId, defaultInputDeviceSensor);
-
-            var defaultInputDeviceStateId = $"{parentSensorSafeName}_default_input_device_state";
-            var defaultInputDeviceStateSensor = new DataTypeStringSensor(_updateInterval, defaultInputDeviceStateId, $"Default Input Device State", defaultInputDeviceStateId, string.Empty, "mdi:microphone", string.Empty, EntityName);
-            defaultInputDeviceStateSensor.SetState(GetReadableState(inputDevice.State));
-            AddUpdateSensor(defaultInputDeviceStateId, defaultInputDeviceStateSensor);
-
-            var defaultInputDeviceIsMuted = inputDevice.AudioEndpointVolume?.Mute ?? false;
-            var defaultInputDeviceIsMutedId = $"{parentSensorSafeName}_default_input_device_muted";
-            var defaultInputDeviceIsMutedSensor = new DataTypeBoolSensor(_updateInterval, defaultInputDeviceIsMutedId, $"Default Input Device Muted", defaultInputDeviceIsMutedId, string.Empty, "mdi:microphone", EntityName);
-            defaultInputDeviceIsMutedSensor.SetState(defaultInputDeviceIsMuted);
-            AddUpdateSensor(defaultInputDeviceIsMutedId, defaultInputDeviceIsMutedSensor);
-
-            var inputVolume = (int)GetDefaultInputDevicePeakVolume(inputDevice);
-            var defaultInputDeviceVolumeId = $"{parentSensorSafeName}_default_input_device_volume";
-            var defaultInputDeviceVolumeSensor = new DataTypeIntSensor(_updateInterval, defaultInputDeviceVolumeId, $"Default Input Device Volume", defaultInputDeviceVolumeId, string.Empty, "mdi:microphone", string.Empty, EntityName);
-            defaultInputDeviceVolumeSensor.SetState(inputVolume);
-            AddUpdateSensor(defaultInputDeviceVolumeId, defaultInputDeviceVolumeSensor);
-
-            var audioInputDevices = GetAudioInputDevices();
-            var audioInputDevicesId = $"{parentSensorSafeName}_input_devices";
-            var audioInputDevicesSensor = new DataTypeIntSensor(_updateInterval, audioInputDevicesId, $"Audio Input Devices", audioInputDevicesId, string.Empty, "mdi:microphone", string.Empty, EntityName, true);
-            audioInputDevicesSensor.SetState(audioInputDevices.Count);
-            audioInputDevicesSensor.SetAttributes(
-                JsonConvert.SerializeObject(new
-                {
-                    InputDevices = audioInputDevices
-                }, Formatting.Indented)
-            );
-            AddUpdateSensor(audioInputDevicesId, audioInputDevicesSensor);
-        }
-
-        public sealed override void UpdateSensorValues()
-        {
-            try
+        var audioOutputDevices = GetAudioOutputDevices();
+        var audioOutputDevicesEntityName = $"{parentSensorSafeName}_output_devices";
+        var audioOutputDevicesId = $"{Id}_output_devices";
+        var audioOutputDevicesSensor = new DataTypeIntSensor(_updateInterval, audioOutputDevicesEntityName, $"Audio Output Devices", audioOutputDevicesId, string.Empty, "mdi:music-box-multiple-outline", string.Empty, EntityName, true);
+        audioOutputDevicesSensor.SetState(audioOutputDevices.Count);
+        audioOutputDevicesSensor.SetAttributes(
+            JsonConvert.SerializeObject(new
             {
-                var parentSensorSafeName = SharedHelperFunctions.GetSafeValue(EntityName);
+                OutputDevices = audioOutputDevices
+            }, Formatting.Indented)
+        );
+        AddUpdateSensor(audioOutputDevicesId, audioOutputDevicesSensor);
+    }
 
-                HandleAudioOutputSensors(parentSensorSafeName);
-                HandleAudioInputSensors(parentSensorSafeName);
+    private void HandleAudioInputSensors(string parentSensorSafeName, string deviceName)
+    {
+        using var inputDevice = Variables.AudioDeviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Capture, Role.Communications);
 
-                if (_errorPrinted)
-                    _errorPrinted = false;
-            }
-            catch (Exception ex)
+        var defaultInputDeviceEntityName = $"{parentSensorSafeName}_default_input_device";
+        var defaultInputDeviceId = $"{Id}_default_input_device";
+        var defaultInputDeviceSensor = new DataTypeStringSensor(_updateInterval, defaultInputDeviceEntityName, $"Default Input Device", defaultInputDeviceId, string.Empty, "mdi:microphone", string.Empty, EntityName);
+        defaultInputDeviceSensor.SetState(inputDevice.DeviceFriendlyName);
+        AddUpdateSensor(defaultInputDeviceId, defaultInputDeviceSensor);
+
+        var defaultInputDeviceStateEntityName = $"{parentSensorSafeName}_default_input_device_state";
+        var defaultInputDeviceStateId = $"{Id}_default_input_device_state";
+        var defaultInputDeviceStateSensor = new DataTypeStringSensor(_updateInterval, defaultInputDeviceStateEntityName, $"Default Input Device State", defaultInputDeviceStateId, string.Empty, "mdi:microphone", string.Empty, EntityName);
+        defaultInputDeviceStateSensor.SetState(GetReadableState(inputDevice.State));
+        AddUpdateSensor(defaultInputDeviceStateId, defaultInputDeviceStateSensor);
+
+        var defaultInputDeviceIsMuted = inputDevice.AudioEndpointVolume?.Mute ?? false;
+        var defaultInputDeviceIsMutedEntityName = $"{parentSensorSafeName}_default_input_device_muted";
+        var defaultInputDeviceIsMutedId = $"{Id}_default_input_device_muted";
+        var defaultInputDeviceIsMutedSensor = new DataTypeBoolSensor(_updateInterval, defaultInputDeviceIsMutedEntityName, $"Default Input Device Muted", defaultInputDeviceIsMutedId, string.Empty, "mdi:microphone", EntityName);
+        defaultInputDeviceIsMutedSensor.SetState(defaultInputDeviceIsMuted);
+        AddUpdateSensor(defaultInputDeviceIsMutedId, defaultInputDeviceIsMutedSensor);
+
+        var inputVolume = (int)GetDefaultInputDevicePeakVolume(inputDevice);
+        var defaultInputDeviceVolumeEntityName = $"{parentSensorSafeName}_default_input_device_volume";
+        var defaultInputDeviceVolumeId = $"{Id}_default_input_device_volume";
+        var defaultInputDeviceVolumeSensor = new DataTypeIntSensor(_updateInterval, defaultInputDeviceVolumeEntityName, $"Default Input Device Volume", defaultInputDeviceVolumeId, string.Empty, "mdi:microphone", string.Empty, EntityName);
+        defaultInputDeviceVolumeSensor.SetState(inputVolume);
+        AddUpdateSensor(defaultInputDeviceVolumeId, defaultInputDeviceVolumeSensor);
+
+        var audioInputDevices = GetAudioInputDevices();
+        var audioInputDevicesEntityName = $"{parentSensorSafeName}_input_devices";
+        var audioInputDevicesId = $"{Id}_input_devices";
+        var audioInputDevicesSensor = new DataTypeIntSensor(_updateInterval, audioInputDevicesEntityName, $"Audio Input Devices", audioInputDevicesId, string.Empty, "mdi:microphone", string.Empty, EntityName, true);
+        audioInputDevicesSensor.SetState(audioInputDevices.Count);
+        audioInputDevicesSensor.SetAttributes(
+            JsonConvert.SerializeObject(new
             {
-                if (_errorPrinted)
-                    return;
+                InputDevices = audioInputDevices
+            }, Formatting.Indented)
+        );
+        AddUpdateSensor(audioInputDevicesId, audioInputDevicesSensor);
+    }
 
-                _errorPrinted = true;
-
-                Log.Fatal(ex, "[AUDIO] [{name}] Error while fetching audio info: {err}", EntityName, ex.Message);
-            }
-        }
-
-        private string GetSessionDisplayName(AudioSessionControl2 session)
+    public override sealed void UpdateSensorValues()
+    {
+        try
         {
-            var procId = (int)session.ProcessID;
+            var parentSensorSafeName = SharedHelperFunctions.GetSafeValue(EntityName);
+            var deviceSafeName = SharedHelperFunctions.GetSafeDeviceName();
 
-            if (procId <= 0)
-                return session.DisplayName;
+            HandleAudioOutputSensors(parentSensorSafeName, deviceSafeName);
+            HandleAudioInputSensors(parentSensorSafeName, deviceSafeName);
 
-            if (ApplicationNames.ContainsKey(procId))
-                return ApplicationNames[procId];
-
-            // we don't know this app yet, get process info
-            using var p = Process.GetProcessById(procId);
-            ApplicationNames.Add(procId, p.ProcessName);
-
-            return p.ProcessName;
+            if (_errorPrinted)
+                _errorPrinted = false;
         }
-
-        private List<AudioSessionInfo> GetSessions(out float peakVolume)
+        catch (Exception ex)
         {
-            var sessionInfos = new List<AudioSessionInfo>();
-            peakVolume = 0f;
+            if (_errorPrinted)
+                return;
 
-            try
+            _errorPrinted = true;
+
+            Log.Fatal(ex, "[AUDIO] [{name}] Error while fetching audio info: {err}", EntityName, ex.Message);
+        }
+    }
+
+    private string GetSessionDisplayName(AudioSessionControl2 session)
+    {
+        var procId = (int)session.ProcessID;
+
+        if (procId <= 0)
+            return session.DisplayName;
+
+        if (ApplicationNames.ContainsKey(procId))
+            return ApplicationNames[procId];
+
+        // we don't know this app yet, get process info
+        using var p = Process.GetProcessById(procId);
+        ApplicationNames.Add(procId, p.ProcessName);
+
+        return p.ProcessName;
+    }
+
+    private List<AudioSessionInfo> GetSessions(out float peakVolume)
+    {
+        var sessionInfos = new List<AudioSessionInfo>();
+        peakVolume = 0f;
+
+        try
+        {
+            var errors = false;
+
+            foreach (var device in Variables.AudioDeviceEnumerator.EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active))
             {
-                var errors = false;
-
-                foreach (var device in Variables.AudioDeviceEnumerator.EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active))
+                using (device)
                 {
-                    using (device)
+                    foreach (var session in device.AudioSessionManager2?.Sessions.Where(x => x != null))
                     {
-                        foreach (var session in device.AudioSessionManager2?.Sessions.Where(x => x != null))
+                        if (session.ProcessID == 0)
+                            continue;
+
+                        try
                         {
-                            if (session.ProcessID == 0)
+                            var displayName = GetSessionDisplayName(session);
+
+                            if (displayName == "audiodg")
                                 continue;
 
-                            try
+                            if (displayName.Length > 30)
+                                displayName = $"{displayName[..30]}..";
+
+                            var sessionInfo = new AudioSessionInfo
                             {
-                                var displayName = GetSessionDisplayName(session);
+                                Application = displayName,
+                                PlaybackDevice = device.DeviceFriendlyName,
+                                Muted = session.SimpleAudioVolume?.Mute ?? false,
+                                Active = session.State == AudioSessionState.AudioSessionStateActive,
+                                MasterVolume = session.SimpleAudioVolume?.MasterVolume * 100 ?? 0f,
+                                PeakVolume = session.AudioMeterInformation?.MasterPeakValue * 100 ?? 0f
+                            };
 
-                                if (displayName == "audiodg")
-                                    continue;
+                            // new max?
+                            if (sessionInfo.PeakVolume > peakVolume)
+                                peakVolume = sessionInfo.PeakVolume;
 
-                                if (displayName.Length > 30)
-                                    displayName = $"{displayName[..30]}..";
+                            sessionInfos.Add(sessionInfo);
+                        }
+                        catch (Exception ex)
+                        {
+                            if (!_errorPrinted)
+                                Log.Fatal(ex, "[AUDIO] [{name}] [{app}] Exception while retrieving info: {err}", EntityName, session.DisplayName, ex.Message);
 
-                                var sessionInfo = new AudioSessionInfo
-                                {
-                                    Application = displayName,
-                                    PlaybackDevice = device.DeviceFriendlyName,
-                                    Muted = session.SimpleAudioVolume?.Mute ?? false,
-                                    Active = session.State == AudioSessionState.AudioSessionStateActive,
-                                    MasterVolume = session.SimpleAudioVolume?.MasterVolume * 100 ?? 0f,
-                                    PeakVolume = session.AudioMeterInformation?.MasterPeakValue * 100 ?? 0f
-                                };
-
-                                // new max?
-                                if (sessionInfo.PeakVolume > peakVolume)
-                                    peakVolume = sessionInfo.PeakVolume;
-
-                                sessionInfos.Add(sessionInfo);
-                            }
-                            catch (Exception ex)
-                            {
-                                if (!_errorPrinted)
-                                    Log.Fatal(ex, "[AUDIO] [{name}] [{app}] Exception while retrieving info: {err}", EntityName, session.DisplayName, ex.Message);
-
-                                errors = true;
-                            }
-                            finally
-                            {
-                                session?.Dispose();
-                            }
+                            errors = true;
+                        }
+                        finally
+                        {
+                            session?.Dispose();
                         }
                     }
                 }
-
-                // only print errors once
-                if (errors && !_errorPrinted)
-                {
-                    _errorPrinted = true;
-
-                    return sessionInfos;
-                }
-
-                // optionally reset error flag
-                if (_errorPrinted)
-                    _errorPrinted = false;
             }
-            catch (Exception ex)
-            {
-                // something went wrong, only print once
-                if (_errorPrinted)
-                    return sessionInfos;
 
+            // only print errors once
+            if (errors && !_errorPrinted)
+            {
                 _errorPrinted = true;
 
-                Log.Fatal(ex, "[AUDIO] [{name}] Fatal exception while getting sessions: {err}", EntityName, ex.Message);
+                return sessionInfos;
             }
 
-            return sessionInfos;
+            // optionally reset error flag
+            if (_errorPrinted)
+                _errorPrinted = false;
         }
-
-        private float GetDefaultInputDevicePeakVolume(MMDevice inputDevice)
+        catch (Exception ex)
         {
-            if (inputDevice == null)
-                return 0f;
+            // something went wrong, only print once
+            if (_errorPrinted)
+                return sessionInfos;
 
-            var peakVolume = 0f;
+            _errorPrinted = true;
 
-            try
-            {
-                var errors = false;
-
-                // process sessions (and get peak volume)
-                foreach (var session in inputDevice.AudioSessionManager2?.Sessions?.Where(x => x != null)!)
-                {
-                    try
-                    {
-                        // filter inactive sessions
-                        if (session.State != AudioSessionState.AudioSessionStateActive)
-                            continue;
-
-                        // set peak volume
-                        var sessionPeakVolume = session.AudioMeterInformation?.MasterPeakValue * 100 ?? 0f;
-
-                        // new max?
-                        if (sessionPeakVolume > peakVolume)
-                            peakVolume = sessionPeakVolume;
-                    }
-                    catch (Exception ex)
-                    {
-                        if (!_errorPrinted)
-                            Log.Fatal(ex, "[AUDIO] [{name}] [{app}] Exception while retrieving input info: {err}", EntityName, session.DisplayName, ex.Message);
-
-                        errors = true;
-                    }
-                    finally
-                    {
-                        session?.Dispose();
-                    }
-                }
-
-                // only print errors once
-                if (errors && !_errorPrinted)
-                {
-                    _errorPrinted = true;
-
-                    return peakVolume;
-                }
-
-                // optionally reset error flag
-                if (_errorPrinted)
-                    _errorPrinted = false;
-            }
-            catch (Exception ex)
-            {
-                // something went wrong, only print once
-                if (_errorPrinted)
-                    return peakVolume;
-
-                _errorPrinted = true;
-
-                Log.Fatal(ex, "[AUDIO] [{name}] Fatal exception while getting input info: {err}", EntityName, ex.Message);
-            }
-
-            return peakVolume;
+            Log.Fatal(ex, "[AUDIO] [{name}] Fatal exception while getting sessions: {err}", EntityName, ex.Message);
         }
 
-        /// <summary>
-        /// Converts the audio device's state to a better readable form
-        /// </summary>
-        /// <param name="state"></param>
-        /// <returns></returns>
-        private static string GetReadableState(DeviceState state)
-        {
-            return state switch
-            {
-                DeviceState.Active => "ACTIVE",
-                DeviceState.Disabled => "DISABLED",
-                DeviceState.NotPresent => "NOT PRESENT",
-                DeviceState.Unplugged => "UNPLUGGED",
-                DeviceState.MaskAll => "STATEMASK_ALL",
-                _ => "UNKNOWN"
-            };
-        }
-
-        public override DiscoveryConfigModel GetAutoDiscoveryConfig() => null;
+        return sessionInfos;
     }
+
+    private float GetDefaultInputDevicePeakVolume(MMDevice inputDevice)
+    {
+        if (inputDevice == null)
+            return 0f;
+
+        var peakVolume = 0f;
+
+        try
+        {
+            var errors = false;
+
+            // process sessions (and get peak volume)
+            foreach (var session in inputDevice.AudioSessionManager2?.Sessions?.Where(x => x != null)!)
+            {
+                try
+                {
+                    // filter inactive sessions
+                    if (session.State != AudioSessionState.AudioSessionStateActive)
+                        continue;
+
+                    // set peak volume
+                    var sessionPeakVolume = session.AudioMeterInformation?.MasterPeakValue * 100 ?? 0f;
+
+                    // new max?
+                    if (sessionPeakVolume > peakVolume)
+                        peakVolume = sessionPeakVolume;
+                }
+                catch (Exception ex)
+                {
+                    if (!_errorPrinted)
+                        Log.Fatal(ex, "[AUDIO] [{name}] [{app}] Exception while retrieving input info: {err}", EntityName, session.DisplayName, ex.Message);
+
+                    errors = true;
+                }
+                finally
+                {
+                    session?.Dispose();
+                }
+            }
+
+            // only print errors once
+            if (errors && !_errorPrinted)
+            {
+                _errorPrinted = true;
+
+                return peakVolume;
+            }
+
+            // optionally reset error flag
+            if (_errorPrinted)
+                _errorPrinted = false;
+        }
+        catch (Exception ex)
+        {
+            // something went wrong, only print once
+            if (_errorPrinted)
+                return peakVolume;
+
+            _errorPrinted = true;
+
+            Log.Fatal(ex, "[AUDIO] [{name}] Fatal exception while getting input info: {err}", EntityName, ex.Message);
+        }
+
+        return peakVolume;
+    }
+
+    /// <summary>
+    /// Converts the audio device's state to a better readable form
+    /// </summary>
+    /// <param name="state"></param>
+    /// <returns></returns>
+    private static string GetReadableState(DeviceState state)
+    {
+        return state switch
+        {
+            DeviceState.Active => "ACTIVE",
+            DeviceState.Disabled => "DISABLED",
+            DeviceState.NotPresent => "NOT PRESENT",
+            DeviceState.Unplugged => "UNPLUGGED",
+            DeviceState.MaskAll => "STATEMASK_ALL",
+            _ => "UNKNOWN"
+        };
+    }
+
+    public override DiscoveryConfigModel GetAutoDiscoveryConfig() => null;
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/AudioSensors.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/AudioSensors.cs
@@ -62,24 +62,24 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
             using var audioDevice = Variables.AudioDeviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
 
             var defaultDeviceId = $"{parentSensorSafeName}_default_device";
-            var defaultDeviceSensor = new DataTypeStringSensor(_updateInterval, $"Default Device", defaultDeviceId, string.Empty, "mdi:speaker", string.Empty, EntityName);
+            var defaultDeviceSensor = new DataTypeStringSensor(_updateInterval, defaultDeviceId, $"Default Device", defaultDeviceId, string.Empty, "mdi:speaker", string.Empty, EntityName);
             defaultDeviceSensor.SetState(audioDevice.DeviceFriendlyName);
             AddUpdateSensor(defaultDeviceId, defaultDeviceSensor);
 
             var defaultDeviceStateId = $"{parentSensorSafeName}_default_device_state";
-            var defaultDeviceStateSensor = new DataTypeStringSensor(_updateInterval, $"Default Device State", defaultDeviceStateId, string.Empty, "mdi:speaker", string.Empty, EntityName);
+            var defaultDeviceStateSensor = new DataTypeStringSensor(_updateInterval, defaultDeviceStateId, $"Default Device State", defaultDeviceStateId, string.Empty, "mdi:speaker", string.Empty, EntityName);
             defaultDeviceStateSensor.SetState(GetReadableState(audioDevice.State));
             AddUpdateSensor(defaultDeviceStateId, defaultDeviceStateSensor);
 
             var masterVolume = Convert.ToInt32(Math.Round(audioDevice.AudioEndpointVolume?.MasterVolumeLevelScalar * 100 ?? 0, 0));
             var defaultDeviceVolumeId = $"{parentSensorSafeName}_default_device_volume";
-            var defaultDeviceVolumeSensor = new DataTypeIntSensor(_updateInterval, $"Default Device Volume", defaultDeviceVolumeId, string.Empty, "mdi:speaker", string.Empty, EntityName);
+            var defaultDeviceVolumeSensor = new DataTypeIntSensor(_updateInterval, defaultDeviceVolumeId, $"Default Device Volume", defaultDeviceVolumeId, string.Empty, "mdi:speaker", string.Empty, EntityName);
             defaultDeviceVolumeSensor.SetState(masterVolume);
             AddUpdateSensor(defaultDeviceVolumeId, defaultDeviceVolumeSensor);
 
             var defaultDeviceIsMuted = audioDevice.AudioEndpointVolume?.Mute ?? false;
             var defaultDeviceIsMutedId = $"{parentSensorSafeName}_default_device_muted";
-            var defaultDeviceIsMutedSensor = new DataTypeBoolSensor(_updateInterval, $"Default Device Muted", defaultDeviceIsMutedId, string.Empty, "mdi:speaker", EntityName);
+            var defaultDeviceIsMutedSensor = new DataTypeBoolSensor(_updateInterval, defaultDeviceIsMutedId, $"Default Device Muted", defaultDeviceIsMutedId, string.Empty, "mdi:speaker", EntityName);
             defaultDeviceIsMutedSensor.SetState(defaultDeviceIsMuted);
             AddUpdateSensor(defaultDeviceIsMutedId, defaultDeviceIsMutedSensor);
 
@@ -87,12 +87,12 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
             var sessionInfos = GetSessions(out var peakVolume);
 
             var peakVolumeId = $"{parentSensorSafeName}_peak_volume";
-            var peakVolumeSensor = new DataTypeStringSensor(_updateInterval, $"Peak Volume", peakVolumeId, string.Empty, "mdi:volume-high", string.Empty, EntityName);
+            var peakVolumeSensor = new DataTypeStringSensor(_updateInterval, peakVolumeId, $"Peak Volume", peakVolumeId, string.Empty, "mdi:volume-high", string.Empty, EntityName);
             peakVolumeSensor.SetState(peakVolume.ToString(CultureInfo.CurrentCulture));
             AddUpdateSensor(peakVolumeId, peakVolumeSensor);
 
             var sessionsId = $"{parentSensorSafeName}_sessions";
-            var sessionsSensor = new DataTypeIntSensor(_updateInterval, $"Audio Sessions", sessionsId, string.Empty, "mdi:music-box-multiple-outline", string.Empty, EntityName, true);
+            var sessionsSensor = new DataTypeIntSensor(_updateInterval, sessionsId, $"Audio Sessions", sessionsId, string.Empty, "mdi:music-box-multiple-outline", string.Empty, EntityName, true);
             sessionsSensor.SetState(sessionInfos.Count);
             sessionsSensor.SetAttributes(
                 JsonConvert.SerializeObject(new
@@ -104,7 +104,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
 
             var audioOutputDevices = GetAudioOutputDevices();
             var audioOutputDevicesId = $"{parentSensorSafeName}_output_devices";
-            var audioOutputDevicesSensor = new DataTypeIntSensor(_updateInterval, $"Audio Output Devices", audioOutputDevicesId, string.Empty, "mdi:music-box-multiple-outline", string.Empty, EntityName, true);
+            var audioOutputDevicesSensor = new DataTypeIntSensor(_updateInterval, audioOutputDevicesId, $"Audio Output Devices", audioOutputDevicesId, string.Empty, "mdi:music-box-multiple-outline", string.Empty, EntityName, true);
             audioOutputDevicesSensor.SetState(audioOutputDevices.Count);
             audioOutputDevicesSensor.SetAttributes(
                 JsonConvert.SerializeObject(new
@@ -120,30 +120,30 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
             using var inputDevice = Variables.AudioDeviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Capture, Role.Communications);
 
             var defaultInputDeviceId = $"{parentSensorSafeName}_default_input_device";
-            var defaultInputDeviceSensor = new DataTypeStringSensor(_updateInterval, $"Default Input Device", defaultInputDeviceId, string.Empty, "mdi:microphone", string.Empty, EntityName);
+            var defaultInputDeviceSensor = new DataTypeStringSensor(_updateInterval, defaultInputDeviceId, $"Default Input Device", defaultInputDeviceId, string.Empty, "mdi:microphone", string.Empty, EntityName);
             defaultInputDeviceSensor.SetState(inputDevice.DeviceFriendlyName);
             AddUpdateSensor(defaultInputDeviceId, defaultInputDeviceSensor);
 
             var defaultInputDeviceStateId = $"{parentSensorSafeName}_default_input_device_state";
-            var defaultInputDeviceStateSensor = new DataTypeStringSensor(_updateInterval, $"Default Input Device State", defaultInputDeviceStateId, string.Empty, "mdi:microphone", string.Empty, EntityName);
+            var defaultInputDeviceStateSensor = new DataTypeStringSensor(_updateInterval, defaultInputDeviceStateId, $"Default Input Device State", defaultInputDeviceStateId, string.Empty, "mdi:microphone", string.Empty, EntityName);
             defaultInputDeviceStateSensor.SetState(GetReadableState(inputDevice.State));
             AddUpdateSensor(defaultInputDeviceStateId, defaultInputDeviceStateSensor);
 
             var defaultInputDeviceIsMuted = inputDevice.AudioEndpointVolume?.Mute ?? false;
             var defaultInputDeviceIsMutedId = $"{parentSensorSafeName}_default_input_device_muted";
-            var defaultInputDeviceIsMutedSensor = new DataTypeBoolSensor(_updateInterval, $"Default Input Device Muted", defaultInputDeviceIsMutedId, string.Empty, "mdi:microphone", EntityName);
+            var defaultInputDeviceIsMutedSensor = new DataTypeBoolSensor(_updateInterval, defaultInputDeviceIsMutedId, $"Default Input Device Muted", defaultInputDeviceIsMutedId, string.Empty, "mdi:microphone", EntityName);
             defaultInputDeviceIsMutedSensor.SetState(defaultInputDeviceIsMuted);
             AddUpdateSensor(defaultInputDeviceIsMutedId, defaultInputDeviceIsMutedSensor);
 
             var inputVolume = (int)GetDefaultInputDevicePeakVolume(inputDevice);
             var defaultInputDeviceVolumeId = $"{parentSensorSafeName}_default_input_device_volume";
-            var defaultInputDeviceVolumeSensor = new DataTypeIntSensor(_updateInterval, $"Default Input Device Volume", defaultInputDeviceVolumeId, string.Empty, "mdi:microphone", string.Empty, EntityName);
+            var defaultInputDeviceVolumeSensor = new DataTypeIntSensor(_updateInterval, defaultInputDeviceVolumeId, $"Default Input Device Volume", defaultInputDeviceVolumeId, string.Empty, "mdi:microphone", string.Empty, EntityName);
             defaultInputDeviceVolumeSensor.SetState(inputVolume);
             AddUpdateSensor(defaultInputDeviceVolumeId, defaultInputDeviceVolumeSensor);
 
             var audioInputDevices = GetAudioInputDevices();
             var audioInputDevicesId = $"{parentSensorSafeName}_input_devices";
-            var audioInputDevicesSensor = new DataTypeIntSensor(_updateInterval, $"Audio Input Devices", audioInputDevicesId, string.Empty, "mdi:microphone", string.Empty, EntityName, true);
+            var audioInputDevicesSensor = new DataTypeIntSensor(_updateInterval, audioInputDevicesId, $"Audio Input Devices", audioInputDevicesId, string.Empty, "mdi:microphone", string.Empty, EntityName, true);
             audioInputDevicesSensor.SetState(audioInputDevices.Count);
             audioInputDevicesSensor.SetAttributes(
                 JsonConvert.SerializeObject(new
@@ -216,7 +216,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
                             {
                                 var displayName = GetSessionDisplayName(session);
 
-                                if(displayName == "audiodg")
+                                if (displayName == "audiodg")
                                     continue;
 
                                 if (displayName.Length > 30)

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/BatterySensors.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/BatterySensors.cs
@@ -40,7 +40,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
             var chargeStatus = powerStatus.BatteryChargeStatus.ToString();
 
             var chargeStatusId = $"{parentSensorSafeName}_charge_status";
-            var chargeStatusSensor = new DataTypeStringSensor(_updateInterval, "Charge Status", chargeStatusId, string.Empty, "mdi:battery-charging", string.Empty, EntityName);
+            var chargeStatusSensor = new DataTypeStringSensor(_updateInterval, chargeStatusId, "Charge Status", chargeStatusId, string.Empty, "mdi:battery-charging", string.Empty, EntityName);
             chargeStatusSensor.SetState(chargeStatus);
             AddUpdateSensor(chargeStatusId, chargeStatusSensor);
 
@@ -49,13 +49,13 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
                 fullChargeLifetimeMinutes = Convert.ToInt32(Math.Round(TimeSpan.FromSeconds(fullChargeLifetimeMinutes).TotalMinutes));
 
             var fullChargeLifetimeId = $"{parentSensorSafeName}_full_charge_lifetime";
-            var fullChargeLifetimeSensor = new DataTypeIntSensor(_updateInterval, "Full Charge Lifetime", fullChargeLifetimeId, string.Empty, "mdi:battery-high", string.Empty, EntityName);
+            var fullChargeLifetimeSensor = new DataTypeIntSensor(_updateInterval, fullChargeLifetimeId, "Full Charge Lifetime", fullChargeLifetimeId, string.Empty, "mdi:battery-high", string.Empty, EntityName);
             fullChargeLifetimeSensor.SetState(fullChargeLifetimeMinutes);
             AddUpdateSensor(fullChargeLifetimeId, fullChargeLifetimeSensor);
 
             var chargeRemainingPercentage = Convert.ToInt32(powerStatus.BatteryLifePercent * 100);
             var chargeRemainingPercentageId = $"{parentSensorSafeName}_charge_remaining_percentage";
-            var chargeRemainingPercentageSensor = new DataTypeIntSensor(_updateInterval, "Charge Remaining Percentage", chargeRemainingPercentageId, string.Empty, "mdi:battery-high", "%", EntityName);
+            var chargeRemainingPercentageSensor = new DataTypeIntSensor(_updateInterval, chargeRemainingPercentageId, "Charge Remaining Percentage", chargeRemainingPercentageId, string.Empty, "mdi:battery-high", "%", EntityName);
             chargeRemainingPercentageSensor.SetState(chargeRemainingPercentage);
             AddUpdateSensor(chargeRemainingPercentageId, chargeRemainingPercentageSensor);
 
@@ -64,13 +64,13 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
                 chargeRemainingMinutes = Convert.ToInt32(Math.Round(TimeSpan.FromSeconds(chargeRemainingMinutes).TotalMinutes));
 
             var chargeRemainingMinutesId = $"{parentSensorSafeName}_charge_remaining";
-            var chargeRemainingMinutesSensor = new DataTypeIntSensor(_updateInterval, "Charge Remaining", chargeRemainingMinutesId, string.Empty, "mdi:battery-high", string.Empty, EntityName);
+            var chargeRemainingMinutesSensor = new DataTypeIntSensor(_updateInterval, chargeRemainingMinutesId, "Charge Remaining", chargeRemainingMinutesId, string.Empty, "mdi:battery-high", string.Empty, EntityName);
             chargeRemainingMinutesSensor.SetState(chargeRemainingMinutes);
             AddUpdateSensor(chargeRemainingMinutesId, chargeRemainingMinutesSensor);
 
             var powerlineStatus = powerStatus.PowerLineStatus.ToString();
             var powerlineStatusId = $"{parentSensorSafeName}_powerline_status";
-            var powerlineStatusSensor = new DataTypeStringSensor(_updateInterval, "Powerline Status", powerlineStatusId, string.Empty, "mdi:power-plug", string.Empty, EntityName);
+            var powerlineStatusSensor = new DataTypeStringSensor(_updateInterval, powerlineStatusId, "Powerline Status", powerlineStatusId, string.Empty, "mdi:power-plug", string.Empty, EntityName);
             powerlineStatusSensor.SetState(powerlineStatus);
             AddUpdateSensor(powerlineStatusId, powerlineStatusSensor);
         }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/BatterySensors.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/BatterySensors.cs
@@ -5,76 +5,81 @@ using HASS.Agent.Shared.Functions;
 using HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.DataTypes;
 using HASS.Agent.Shared.Models.HomeAssistant;
 
-namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
+namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue;
+
+/// <summary>
+/// Multivalue sensor containing power and battery info
+/// </summary>
+public class BatterySensors : AbstractMultiValueSensor
 {
-    /// <summary>
-    /// Multivalue sensor containing power and battery info
-    /// </summary>
-    public class BatterySensors : AbstractMultiValueSensor
+    private const string DefaultName = "battery";
+    private readonly int _updateInterval;
+
+    public sealed override Dictionary<string, AbstractSingleValueSensor> Sensors { get; protected set; } = new Dictionary<string, AbstractSingleValueSensor>();
+
+    public BatterySensors(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 30, id)
     {
-        private const string DefaultName = "battery";
-        private readonly int _updateInterval;
+        _updateInterval = updateInterval ?? 30;
 
-        public sealed override Dictionary<string, AbstractSingleValueSensor> Sensors { get; protected set; } = new Dictionary<string, AbstractSingleValueSensor>();
-
-        public BatterySensors(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 30, id)
-        {
-            _updateInterval = updateInterval ?? 30;
-
-            UpdateSensorValues();
-        }
-
-        private void AddUpdateSensor(string sensorId, AbstractSingleValueSensor sensor)
-        {
-            if (!Sensors.ContainsKey(sensorId))
-                Sensors.Add(sensorId, sensor);
-            else
-                Sensors[sensorId] = sensor;
-        }
-
-        public sealed override void UpdateSensorValues()
-        {
-            var parentSensorSafeName = SharedHelperFunctions.GetSafeValue(EntityName);
-
-            var powerStatus = SystemInformation.PowerStatus;
-            var chargeStatus = powerStatus.BatteryChargeStatus.ToString();
-
-            var chargeStatusId = $"{parentSensorSafeName}_charge_status";
-            var chargeStatusSensor = new DataTypeStringSensor(_updateInterval, chargeStatusId, "Charge Status", chargeStatusId, string.Empty, "mdi:battery-charging", string.Empty, EntityName);
-            chargeStatusSensor.SetState(chargeStatus);
-            AddUpdateSensor(chargeStatusId, chargeStatusSensor);
-
-            var fullChargeLifetimeMinutes = powerStatus.BatteryFullLifetime;
-            if (fullChargeLifetimeMinutes != -1)
-                fullChargeLifetimeMinutes = Convert.ToInt32(Math.Round(TimeSpan.FromSeconds(fullChargeLifetimeMinutes).TotalMinutes));
-
-            var fullChargeLifetimeId = $"{parentSensorSafeName}_full_charge_lifetime";
-            var fullChargeLifetimeSensor = new DataTypeIntSensor(_updateInterval, fullChargeLifetimeId, "Full Charge Lifetime", fullChargeLifetimeId, string.Empty, "mdi:battery-high", string.Empty, EntityName);
-            fullChargeLifetimeSensor.SetState(fullChargeLifetimeMinutes);
-            AddUpdateSensor(fullChargeLifetimeId, fullChargeLifetimeSensor);
-
-            var chargeRemainingPercentage = Convert.ToInt32(powerStatus.BatteryLifePercent * 100);
-            var chargeRemainingPercentageId = $"{parentSensorSafeName}_charge_remaining_percentage";
-            var chargeRemainingPercentageSensor = new DataTypeIntSensor(_updateInterval, chargeRemainingPercentageId, "Charge Remaining Percentage", chargeRemainingPercentageId, string.Empty, "mdi:battery-high", "%", EntityName);
-            chargeRemainingPercentageSensor.SetState(chargeRemainingPercentage);
-            AddUpdateSensor(chargeRemainingPercentageId, chargeRemainingPercentageSensor);
-
-            var chargeRemainingMinutes = powerStatus.BatteryLifeRemaining;
-            if (chargeRemainingMinutes != -1)
-                chargeRemainingMinutes = Convert.ToInt32(Math.Round(TimeSpan.FromSeconds(chargeRemainingMinutes).TotalMinutes));
-
-            var chargeRemainingMinutesId = $"{parentSensorSafeName}_charge_remaining";
-            var chargeRemainingMinutesSensor = new DataTypeIntSensor(_updateInterval, chargeRemainingMinutesId, "Charge Remaining", chargeRemainingMinutesId, string.Empty, "mdi:battery-high", string.Empty, EntityName);
-            chargeRemainingMinutesSensor.SetState(chargeRemainingMinutes);
-            AddUpdateSensor(chargeRemainingMinutesId, chargeRemainingMinutesSensor);
-
-            var powerlineStatus = powerStatus.PowerLineStatus.ToString();
-            var powerlineStatusId = $"{parentSensorSafeName}_powerline_status";
-            var powerlineStatusSensor = new DataTypeStringSensor(_updateInterval, powerlineStatusId, "Powerline Status", powerlineStatusId, string.Empty, "mdi:power-plug", string.Empty, EntityName);
-            powerlineStatusSensor.SetState(powerlineStatus);
-            AddUpdateSensor(powerlineStatusId, powerlineStatusSensor);
-        }
-
-        public override DiscoveryConfigModel GetAutoDiscoveryConfig() => null;
+        UpdateSensorValues();
     }
+
+    private void AddUpdateSensor(string sensorId, AbstractSingleValueSensor sensor)
+    {
+        if (!Sensors.ContainsKey(sensorId))
+            Sensors.Add(sensorId, sensor);
+        else
+            Sensors[sensorId] = sensor;
+    }
+
+    public sealed override void UpdateSensorValues()
+    {
+        var parentSensorSafeName = SharedHelperFunctions.GetSafeValue(EntityName);
+        var deviceName = SharedHelperFunctions.GetSafeDeviceName();
+
+        var powerStatus = SystemInformation.PowerStatus;
+        var chargeStatus = powerStatus.BatteryChargeStatus.ToString();
+
+        var chargeStatusEntityName = $"{parentSensorSafeName}_charge_status";
+        var chargeStatusId = $"{Id}_charge_status";
+        var chargeStatusSensor = new DataTypeStringSensor(_updateInterval, chargeStatusEntityName, "Charge Status", chargeStatusId, string.Empty, "mdi:battery-charging", string.Empty, EntityName);
+        chargeStatusSensor.SetState(chargeStatus);
+        AddUpdateSensor(chargeStatusId, chargeStatusSensor);
+
+        var fullChargeLifetimeMinutes = powerStatus.BatteryFullLifetime;
+        if (fullChargeLifetimeMinutes != -1)
+            fullChargeLifetimeMinutes = Convert.ToInt32(Math.Round(TimeSpan.FromSeconds(fullChargeLifetimeMinutes).TotalMinutes));
+
+        var fullChargeLifetimeEntityName = $"{parentSensorSafeName}_full_charge_lifetime";
+        var fullChargeLifetimeId = $"{Id}_full_charge_lifetime";
+        var fullChargeLifetimeSensor = new DataTypeIntSensor(_updateInterval, fullChargeLifetimeEntityName, "Full Charge Lifetime", fullChargeLifetimeId, string.Empty, "mdi:battery-high", string.Empty, EntityName);
+        fullChargeLifetimeSensor.SetState(fullChargeLifetimeMinutes);
+        AddUpdateSensor(fullChargeLifetimeId, fullChargeLifetimeSensor);
+
+        var chargeRemainingPercentage = Convert.ToInt32(powerStatus.BatteryLifePercent * 100);
+        var chargeRemainingPercentageEntityName = $"{parentSensorSafeName}_charge_remaining_percentage";
+        var chargeRemainingPercentageId = $"{Id}_charge_remaining_percentage";
+        var chargeRemainingPercentageSensor = new DataTypeIntSensor(_updateInterval, chargeRemainingPercentageEntityName, "Charge Remaining Percentage", chargeRemainingPercentageId, string.Empty, "mdi:battery-high", "%", EntityName);
+        chargeRemainingPercentageSensor.SetState(chargeRemainingPercentage);
+        AddUpdateSensor(chargeRemainingPercentageId, chargeRemainingPercentageSensor);
+
+        var chargeRemainingMinutes = powerStatus.BatteryLifeRemaining;
+        if (chargeRemainingMinutes != -1)
+            chargeRemainingMinutes = Convert.ToInt32(Math.Round(TimeSpan.FromSeconds(chargeRemainingMinutes).TotalMinutes));
+
+        var chargeRemainingMinutesEntityName = $"{parentSensorSafeName}_charge_remaining";
+        var chargeRemainingMinutesId = $"{Id}_charge_remaining";
+        var chargeRemainingMinutesSensor = new DataTypeIntSensor(_updateInterval, chargeRemainingMinutesEntityName, "Charge Remaining", chargeRemainingMinutesId, string.Empty, "mdi:battery-high", string.Empty, EntityName);
+        chargeRemainingMinutesSensor.SetState(chargeRemainingMinutes);
+        AddUpdateSensor(chargeRemainingMinutesId, chargeRemainingMinutesSensor);
+
+        var powerlineStatus = powerStatus.PowerLineStatus.ToString();
+        var powerlineStatusEntityName = $"{parentSensorSafeName}_powerline_status";
+        var powerlineStatusId = $"{Id}_powerline_status";
+        var powerlineStatusSensor = new DataTypeStringSensor(_updateInterval, powerlineStatusEntityName, "Powerline Status", powerlineStatusId, string.Empty, "mdi:power-plug", string.Empty, EntityName);
+        powerlineStatusSensor.SetState(powerlineStatus);
+        AddUpdateSensor(powerlineStatusId, powerlineStatusSensor);
+    }
+
+    public override DiscoveryConfigModel GetAutoDiscoveryConfig() => null;
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/BatterySensors.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/BatterySensors.cs
@@ -17,7 +17,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
 
         public sealed override Dictionary<string, AbstractSingleValueSensor> Sensors { get; protected set; } = new Dictionary<string, AbstractSingleValueSensor>();
 
-        public BatterySensors(int? updateInterval = null, string name = DefaultName, string friendlyName = DefaultName, string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 30, id)
+        public BatterySensors(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 30, id)
         {
             _updateInterval = updateInterval ?? 30;
 
@@ -34,13 +34,13 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
 
         public sealed override void UpdateSensorValues()
         {
-            var parentSensorSafeName = SharedHelperFunctions.GetSafeValue(Name);
+            var parentSensorSafeName = SharedHelperFunctions.GetSafeValue(EntityName);
 
             var powerStatus = SystemInformation.PowerStatus;
             var chargeStatus = powerStatus.BatteryChargeStatus.ToString();
 
             var chargeStatusId = $"{parentSensorSafeName}_charge_status";
-            var chargeStatusSensor = new DataTypeStringSensor(_updateInterval, "Charge Status", chargeStatusId, string.Empty, "mdi:battery-charging", string.Empty, Name);
+            var chargeStatusSensor = new DataTypeStringSensor(_updateInterval, "Charge Status", chargeStatusId, string.Empty, "mdi:battery-charging", string.Empty, EntityName);
             chargeStatusSensor.SetState(chargeStatus);
             AddUpdateSensor(chargeStatusId, chargeStatusSensor);
 
@@ -49,13 +49,13 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
                 fullChargeLifetimeMinutes = Convert.ToInt32(Math.Round(TimeSpan.FromSeconds(fullChargeLifetimeMinutes).TotalMinutes));
 
             var fullChargeLifetimeId = $"{parentSensorSafeName}_full_charge_lifetime";
-            var fullChargeLifetimeSensor = new DataTypeIntSensor(_updateInterval, "Full Charge Lifetime", fullChargeLifetimeId, string.Empty, "mdi:battery-high", string.Empty, Name);
+            var fullChargeLifetimeSensor = new DataTypeIntSensor(_updateInterval, "Full Charge Lifetime", fullChargeLifetimeId, string.Empty, "mdi:battery-high", string.Empty, EntityName);
             fullChargeLifetimeSensor.SetState(fullChargeLifetimeMinutes);
             AddUpdateSensor(fullChargeLifetimeId, fullChargeLifetimeSensor);
 
             var chargeRemainingPercentage = Convert.ToInt32(powerStatus.BatteryLifePercent * 100);
             var chargeRemainingPercentageId = $"{parentSensorSafeName}_charge_remaining_percentage";
-            var chargeRemainingPercentageSensor = new DataTypeIntSensor(_updateInterval, "Charge Remaining Percentage", chargeRemainingPercentageId, string.Empty, "mdi:battery-high", "%", Name);
+            var chargeRemainingPercentageSensor = new DataTypeIntSensor(_updateInterval, "Charge Remaining Percentage", chargeRemainingPercentageId, string.Empty, "mdi:battery-high", "%", EntityName);
             chargeRemainingPercentageSensor.SetState(chargeRemainingPercentage);
             AddUpdateSensor(chargeRemainingPercentageId, chargeRemainingPercentageSensor);
 
@@ -64,13 +64,13 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
                 chargeRemainingMinutes = Convert.ToInt32(Math.Round(TimeSpan.FromSeconds(chargeRemainingMinutes).TotalMinutes));
 
             var chargeRemainingMinutesId = $"{parentSensorSafeName}_charge_remaining";
-            var chargeRemainingMinutesSensor = new DataTypeIntSensor(_updateInterval, "Charge Remaining", chargeRemainingMinutesId, string.Empty, "mdi:battery-high", string.Empty, Name);
+            var chargeRemainingMinutesSensor = new DataTypeIntSensor(_updateInterval, "Charge Remaining", chargeRemainingMinutesId, string.Empty, "mdi:battery-high", string.Empty, EntityName);
             chargeRemainingMinutesSensor.SetState(chargeRemainingMinutes);
             AddUpdateSensor(chargeRemainingMinutesId, chargeRemainingMinutesSensor);
 
             var powerlineStatus = powerStatus.PowerLineStatus.ToString();
             var powerlineStatusId = $"{parentSensorSafeName}_powerline_status";
-            var powerlineStatusSensor = new DataTypeStringSensor(_updateInterval, "Powerline Status", powerlineStatusId, string.Empty, "mdi:power-plug", string.Empty, Name);
+            var powerlineStatusSensor = new DataTypeStringSensor(_updateInterval, "Powerline Status", powerlineStatusId, string.Empty, "mdi:power-plug", string.Empty, EntityName);
             powerlineStatusSensor.SetState(powerlineStatus);
             AddUpdateSensor(powerlineStatusId, powerlineStatusSensor);
         }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/DataTypes/DataTypeBoolSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/DataTypes/DataTypeBoolSensor.cs
@@ -14,14 +14,14 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.Data
         private bool _value = false;
         private string _attributes = string.Empty;
 
-        public DataTypeBoolSensor(int? updateInterval, string name, string friendlyName, string id, string deviceClass, string icon, string multiValueSensorName, bool useAttributes = false) : base(name, friendlyName, updateInterval ?? 30, id, useAttributes)
+        public DataTypeBoolSensor(int? updateInterval, string entityName, string name, string id, string deviceClass, string icon, string multiValueSensorName, bool useAttributes = false) : base(entityName, name, updateInterval ?? 30, id, useAttributes)
         {
             TopicName = multiValueSensorName;
 
             _deviceClass = deviceClass;
             _icon = icon;
 
-            ObjectId = id;
+            //ObjectId = id;
         }
 
         public DataTypeBoolSensor(int? updateInterval, string name, string id, string deviceClass, string icon, string multiValueSensorName, bool useAttributes = false) : base(name, name, updateInterval ?? 30, id, useAttributes)
@@ -31,7 +31,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.Data
             _deviceClass = deviceClass;
             _icon = icon;
 
-            ObjectId = id;
+            //ObjectId = id;
         }
 
         public override DiscoveryConfigModel GetAutoDiscoveryConfig()
@@ -45,7 +45,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.Data
 
             var model = new SensorDiscoveryConfigModel()
             {
-                Name = Name,
+                EntityName = EntityName,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{TopicName}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/DataTypes/DataTypeBoolSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/DataTypes/DataTypeBoolSensor.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Globalization;
 using HASS.Agent.Shared.Models.HomeAssistant;
 
 namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.DataTypes
@@ -21,9 +22,10 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.Data
             _deviceClass = deviceClass;
             _icon = icon;
 
-            //ObjectId = id;
+            ObjectId = id;
         }
 
+        [Obsolete("Deprecated due to HA 2023.8 MQTT changes in favor of method specifying entityName")]
         public DataTypeBoolSensor(int? updateInterval, string name, string id, string deviceClass, string icon, string multiValueSensorName, bool useAttributes = false) : base(name, name, updateInterval ?? 30, id, useAttributes)
         {
             TopicName = multiValueSensorName;
@@ -31,7 +33,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.Data
             _deviceClass = deviceClass;
             _icon = icon;
 
-            //ObjectId = id;
+            ObjectId = id;
         }
 
         public override DiscoveryConfigModel GetAutoDiscoveryConfig()
@@ -46,6 +48,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.Data
             var model = new SensorDiscoveryConfigModel()
             {
                 EntityName = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{TopicName}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/DataTypes/DataTypeDoubleSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/DataTypes/DataTypeDoubleSensor.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Globalization;
 using HASS.Agent.Shared.Models.HomeAssistant;
 
 namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.DataTypes
@@ -23,9 +24,10 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.Data
             _unitOfMeasurement = unitOfMeasurement;
             _icon = icon;
 
-            //ObjectId = id;
+            ObjectId = id;
         }
 
+        [Obsolete("Deprecated due to HA 2023.8 MQTT changes in favor of method specifying entityName")]
         public DataTypeDoubleSensor(int? updateInterval, string name, string id, string deviceClass, string icon, string unitOfMeasurement, string multiValueSensorName, bool useAttributes = false) : base(name, name, updateInterval ?? 30, id, useAttributes)
         {
             TopicName = multiValueSensorName;
@@ -34,7 +36,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.Data
             _unitOfMeasurement = unitOfMeasurement;
             _icon = icon;
 
-            //ObjectId = id;
+            ObjectId = id;
         }
 
         public override DiscoveryConfigModel GetAutoDiscoveryConfig()
@@ -49,6 +51,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.Data
             var model = new SensorDiscoveryConfigModel()
             {
                 EntityName = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{TopicName}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/DataTypes/DataTypeDoubleSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/DataTypes/DataTypeDoubleSensor.cs
@@ -15,7 +15,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.Data
         private double _value = 0d;
         private string _attributes = string.Empty;
 
-        public DataTypeDoubleSensor(int? updateInterval, string name, string friendlyName, string id, string deviceClass, string icon, string unitOfMeasurement, string multiValueSensorName, bool useAttributes = false) : base(name, friendlyName, updateInterval ?? 30, id, useAttributes)
+        public DataTypeDoubleSensor(int? updateInterval, string entityName, string name, string id, string deviceClass, string icon, string unitOfMeasurement, string multiValueSensorName, bool useAttributes = false) : base(entityName, name, updateInterval ?? 30, id, useAttributes)
         {
             TopicName = multiValueSensorName;
 
@@ -23,7 +23,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.Data
             _unitOfMeasurement = unitOfMeasurement;
             _icon = icon;
 
-            ObjectId = id;
+            //ObjectId = id;
         }
 
         public DataTypeDoubleSensor(int? updateInterval, string name, string id, string deviceClass, string icon, string unitOfMeasurement, string multiValueSensorName, bool useAttributes = false) : base(name, name, updateInterval ?? 30, id, useAttributes)
@@ -34,7 +34,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.Data
             _unitOfMeasurement = unitOfMeasurement;
             _icon = icon;
 
-            ObjectId = id;
+            //ObjectId = id;
         }
 
         public override DiscoveryConfigModel GetAutoDiscoveryConfig()
@@ -48,7 +48,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.Data
 
             var model = new SensorDiscoveryConfigModel()
             {
-                Name = Name,
+                EntityName = EntityName,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{TopicName}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/DataTypes/DataTypeIntSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/DataTypes/DataTypeIntSensor.cs
@@ -14,7 +14,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.Data
         private int _value = 0;
         private string _attributes = string.Empty;
 
-        public DataTypeIntSensor(int? updateInterval, string name, string friendlyName, string id, string deviceClass, string icon, string unitOfMeasurement, string multiValueSensorName, bool useAttributes = false) : base(name, friendlyName, updateInterval ?? 30, id, useAttributes)
+        public DataTypeIntSensor(int? updateInterval, string entityName, string name, string id, string deviceClass, string icon, string unitOfMeasurement, string multiValueSensorName, bool useAttributes = false) : base(entityName, name, updateInterval ?? 30, id, useAttributes)
         {
             TopicName = multiValueSensorName;
 
@@ -22,7 +22,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.Data
             _unitOfMeasurement = unitOfMeasurement;
             _icon = icon;
 
-            ObjectId = id;
+            //ObjectId = id;
         }
 
         public DataTypeIntSensor(int? updateInterval, string name, string id, string deviceClass, string icon, string unitOfMeasurement, string multiValueSensorName, bool useAttributes = false) : base(name, name, updateInterval ?? 30, id, useAttributes)
@@ -33,7 +33,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.Data
             _unitOfMeasurement = unitOfMeasurement;
             _icon = icon;
 
-            ObjectId = id;
+            //ObjectId = id;
         }
 
         public override DiscoveryConfigModel GetAutoDiscoveryConfig()
@@ -47,7 +47,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.Data
 
             var model = new SensorDiscoveryConfigModel()
             {
-                Name = Name,
+                EntityName = EntityName,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{TopicName}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/DataTypes/DataTypeIntSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/DataTypes/DataTypeIntSensor.cs
@@ -1,4 +1,5 @@
-﻿using HASS.Agent.Shared.Models.HomeAssistant;
+﻿using System;
+using HASS.Agent.Shared.Models.HomeAssistant;
 
 namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.DataTypes
 {
@@ -22,9 +23,10 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.Data
             _unitOfMeasurement = unitOfMeasurement;
             _icon = icon;
 
-            //ObjectId = id;
+            ObjectId = id;
         }
 
+        [Obsolete("Deprecated due to HA 2023.8 MQTT changes in favor of method specifying entityName")]
         public DataTypeIntSensor(int? updateInterval, string name, string id, string deviceClass, string icon, string unitOfMeasurement, string multiValueSensorName, bool useAttributes = false) : base(name, name, updateInterval ?? 30, id, useAttributes)
         {
             TopicName = multiValueSensorName;
@@ -33,7 +35,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.Data
             _unitOfMeasurement = unitOfMeasurement;
             _icon = icon;
 
-            //ObjectId = id;
+            ObjectId = id;
         }
 
         public override DiscoveryConfigModel GetAutoDiscoveryConfig()
@@ -48,6 +50,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.Data
             var model = new SensorDiscoveryConfigModel()
             {
                 EntityName = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{TopicName}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/DataTypes/DataTypeStringSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/DataTypes/DataTypeStringSensor.cs
@@ -15,7 +15,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.Data
         private string _value = string.Empty;
         private string _attributes = string.Empty;
 
-        public DataTypeStringSensor(int? updateInterval, string name, string friendlyName, string id, string deviceClass, string icon, string unitOfMeasurement, string multiValueSensorName, bool useAttributes = false) : base(name, friendlyName, updateInterval ?? 30, id, useAttributes)
+        public DataTypeStringSensor(int? updateInterval, string entityName, string name, string id, string deviceClass, string icon, string unitOfMeasurement, string multiValueSensorName, bool useAttributes = false) : base(entityName, name, updateInterval ?? 30, id, useAttributes)
         {
             TopicName = multiValueSensorName;
 
@@ -23,7 +23,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.Data
             _unitOfMeasurement = unitOfMeasurement;
             _icon = icon;
 
-            ObjectId = id;
+            //ObjectId = id;
         }
 
         public DataTypeStringSensor(int? updateInterval, string name, string id, string deviceClass, string icon, string unitOfMeasurement, string multiValueSensorName, bool useAttributes = false) : base(name, name, updateInterval ?? 30, id, useAttributes)
@@ -34,7 +34,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.Data
             _unitOfMeasurement = unitOfMeasurement;
             _icon = icon;
 
-            ObjectId = id;
+            //ObjectId = id;
         }
 
         public override DiscoveryConfigModel GetAutoDiscoveryConfig()
@@ -48,7 +48,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.Data
 
             var model = new SensorDiscoveryConfigModel()
             {
-                Name = Name,
+                EntityName = EntityName,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{TopicName}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/DataTypes/DataTypeStringSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/DataTypes/DataTypeStringSensor.cs
@@ -1,5 +1,7 @@
-﻿using HASS.Agent.Shared.Models.HomeAssistant;
+﻿using System;
+using HASS.Agent.Shared.Models.HomeAssistant;
 using Serilog;
+using Windows.Foundation.Metadata;
 
 namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.DataTypes
 {
@@ -23,9 +25,10 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.Data
             _unitOfMeasurement = unitOfMeasurement;
             _icon = icon;
 
-            //ObjectId = id;
+            ObjectId = id;
         }
 
+        [Obsolete("Deprecated due to HA 2023.8 MQTT changes in favor of method specifying entityName")]
         public DataTypeStringSensor(int? updateInterval, string name, string id, string deviceClass, string icon, string unitOfMeasurement, string multiValueSensorName, bool useAttributes = false) : base(name, name, updateInterval ?? 30, id, useAttributes)
         {
             TopicName = multiValueSensorName;
@@ -34,7 +37,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.Data
             _unitOfMeasurement = unitOfMeasurement;
             _icon = icon;
 
-            //ObjectId = id;
+            ObjectId = id;
         }
 
         public override DiscoveryConfigModel GetAutoDiscoveryConfig()
@@ -49,6 +52,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.Data
             var model = new SensorDiscoveryConfigModel()
             {
                 EntityName = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{TopicName}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/DisplaySensors.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/DisplaySensors.cs
@@ -7,111 +7,113 @@ using HASS.Agent.Shared.Models.HomeAssistant;
 using HASS.Agent.Shared.Models.Internal;
 using Newtonsoft.Json;
 
-namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
+namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue;
+
+/// <summary>
+/// Multivalue sensor containing display-related info
+/// </summary>
+public class DisplaySensors : AbstractMultiValueSensor
 {
-    /// <summary>
-    /// Multivalue sensor containing display-related info
-    /// </summary>
-    public class DisplaySensors : AbstractMultiValueSensor
+    private const string DefaultName = "display";
+    private readonly int _updateInterval;
+
+    public sealed override Dictionary<string, AbstractSingleValueSensor> Sensors { get; protected set; } = new Dictionary<string, AbstractSingleValueSensor>();
+
+    public DisplaySensors(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 30, id)
     {
-        private const string DefaultName = "display";
-        private readonly int _updateInterval;
+        _updateInterval = updateInterval ?? 30;
 
-        public sealed override Dictionary<string, AbstractSingleValueSensor> Sensors { get; protected set; } = new Dictionary<string, AbstractSingleValueSensor>();
-
-        public DisplaySensors(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 30, id)
-        {
-            _updateInterval = updateInterval ?? 30;
-
-            UpdateSensorValues();
-        }
-
-        private void AddUpdateSensor(string sensorId, AbstractSingleValueSensor sensor)
-        {
-            if (!Sensors.ContainsKey(sensorId))
-                Sensors.Add(sensorId, sensor);
-            else
-                Sensors[sensorId] = sensor;
-        }
-
-        public sealed override void UpdateSensorValues()
-        {
-            var parentSensorSafeName = SharedHelperFunctions.GetSafeValue(EntityName);
-
-            var displays = Screen.AllScreens;
-
-            var primaryDisplayStr = string.Empty;
-            var primaryDisplay = displays.FirstOrDefault(x => x.Primary);
-            if (primaryDisplay != null)
-                primaryDisplayStr = primaryDisplay.DeviceName.Split('\\').Last();
-
-            var displayCount = displays.Length;
-            var displayCountId = $"{parentSensorSafeName}_display_count";
-            var displayCountSensor = new DataTypeIntSensor(_updateInterval, displayCountId, "Display Count", displayCountId, string.Empty, "mdi:monitor", string.Empty, EntityName);
-            displayCountSensor.SetState(displayCount);
-            AddUpdateSensor(displayCountId, displayCountSensor);
-
-            if (displayCount == 0)
-                return;
-
-            var primaryDisplayId = $"{parentSensorSafeName}_primary_display";
-            var primaryDisplaySensor = new DataTypeStringSensor(_updateInterval, primaryDisplayId, "Primary Display", primaryDisplayId, string.Empty, "mdi:monitor", string.Empty, EntityName);
-            primaryDisplaySensor.SetState(primaryDisplayStr);
-            AddUpdateSensor(primaryDisplayId, primaryDisplaySensor);
-
-            var monitors = Monitors.All?.ToList() ?? new List<Monitors>();
-
-            foreach (var display in displays)
-            {
-                var id = SharedHelperFunctions.GetSafeValue(display.DeviceName);
-                if (string.IsNullOrWhiteSpace(id))
-                    continue;
-
-                var name = display.DeviceName.Split('\\').Last();
-
-                var resolution = $"{display.Bounds.Width}x{display.Bounds.Height}";
-                var virtualResolution = $"{display.Bounds.Width}x{display.Bounds.Height}";
-                var width = display.Bounds.Width;
-                var virtualWidth = display.Bounds.Width;
-                var height = display.Bounds.Height;
-                var virtualHeight = display.Bounds.Height;
-                var rotated = 0;
-
-                if (monitors.Any(x => x.Name == name))
-                {
-                    var monitor = monitors.Find(x => x.Name == name);
-                    resolution = $"{monitor.PhysicalBounds.Width}x{monitor.PhysicalBounds.Height}";
-                    width = monitor.PhysicalBounds.Width;
-                    height = monitor.PhysicalBounds.Height;
-                    rotated = monitor.RotatedDegrees;
-                }
-
-                var displayInfo = new DisplayInfo
-                {
-                    Name = name,
-                    Resolution = resolution,
-                    VirtualResolution = virtualResolution,
-                    Width = width,
-                    VirtualWidth = virtualWidth,
-                    Height = height,
-                    VirtualHeight = virtualHeight,
-                    BitsPerPixel = display.BitsPerPixel,
-                    PrimaryDisplay = display.Primary,
-                    WorkingArea = $"{display.WorkingArea.Width}x{display.WorkingArea.Height}",
-                    WorkingAreaWidth = display.WorkingArea.Width,
-                    WorkingAreaHeight = display.WorkingArea.Height,
-                    RotatedDegrees = rotated
-                };
-
-                var info = JsonConvert.SerializeObject(displayInfo, Formatting.Indented);
-                var displayInfoId = $"{parentSensorSafeName}_{id}";
-                var displayInfoSensor = new DataTypeStringSensor(_updateInterval, displayInfoId, name, displayInfoId, string.Empty, "mdi:monitor", string.Empty, EntityName, true);
-                displayInfoSensor.SetState(name);
-                displayInfoSensor.SetAttributes(info);
-                AddUpdateSensor(displayInfoId, displayInfoSensor);
-            }
-        }
-
-        public override DiscoveryConfigModel GetAutoDiscoveryConfig() => null;
+        UpdateSensorValues();
     }
+
+    private void AddUpdateSensor(string sensorId, AbstractSingleValueSensor sensor)
+    {
+        if (!Sensors.ContainsKey(sensorId))
+            Sensors.Add(sensorId, sensor);
+        else
+            Sensors[sensorId] = sensor;
+    }
+
+    public sealed override void UpdateSensorValues()
+    {
+        var parentSensorSafeName = SharedHelperFunctions.GetSafeValue(EntityName);
+
+        var displays = Screen.AllScreens;
+
+        var primaryDisplayStr = string.Empty;
+        var primaryDisplay = displays.FirstOrDefault(x => x.Primary);
+        if (primaryDisplay != null)
+            primaryDisplayStr = primaryDisplay.DeviceName.Split('\\').Last();
+
+        var displayCount = displays.Length;
+        var displayCountEntityName = $"{parentSensorSafeName}_display_count";
+        var displayCountId = $"{Id}_display_count";
+        var displayCountSensor = new DataTypeIntSensor(_updateInterval, displayCountEntityName, "Display Count", displayCountId, string.Empty, "mdi:monitor", string.Empty, EntityName);
+        displayCountSensor.SetState(displayCount);
+        AddUpdateSensor(displayCountId, displayCountSensor);
+
+        if (displayCount == 0)
+            return;
+
+        var primaryDisplayEntityName = $"{parentSensorSafeName}_primary_display";
+        var primaryDisplayId = $"{Id}_primary_display";
+        var primaryDisplaySensor = new DataTypeStringSensor(_updateInterval, primaryDisplayEntityName, "Primary Display", primaryDisplayId, string.Empty, "mdi:monitor", string.Empty, EntityName);
+        primaryDisplaySensor.SetState(primaryDisplayStr);
+        AddUpdateSensor(primaryDisplayId, primaryDisplaySensor);
+
+        var monitors = Monitors.All?.ToList() ?? new List<Monitors>();
+
+        foreach (var display in displays)
+        {
+            var id = SharedHelperFunctions.GetSafeValue(display.DeviceName);
+            if (string.IsNullOrWhiteSpace(id))
+                continue;
+
+            var name = display.DeviceName.Split('\\').Last();
+
+            var resolution = $"{display.Bounds.Width}x{display.Bounds.Height}";
+            var virtualResolution = $"{display.Bounds.Width}x{display.Bounds.Height}";
+            var width = display.Bounds.Width;
+            var virtualWidth = display.Bounds.Width;
+            var height = display.Bounds.Height;
+            var virtualHeight = display.Bounds.Height;
+            var rotated = 0;
+
+            if (monitors.Any(x => x.Name == name))
+            {
+                var monitor = monitors.Find(x => x.Name == name);
+                resolution = $"{monitor.PhysicalBounds.Width}x{monitor.PhysicalBounds.Height}";
+                width = monitor.PhysicalBounds.Width;
+                height = monitor.PhysicalBounds.Height;
+                rotated = monitor.RotatedDegrees;
+            }
+
+            var displayInfo = new DisplayInfo
+            {
+                Name = name,
+                Resolution = resolution,
+                VirtualResolution = virtualResolution,
+                Width = width,
+                VirtualWidth = virtualWidth,
+                Height = height,
+                VirtualHeight = virtualHeight,
+                BitsPerPixel = display.BitsPerPixel,
+                PrimaryDisplay = display.Primary,
+                WorkingArea = $"{display.WorkingArea.Width}x{display.WorkingArea.Height}",
+                WorkingAreaWidth = display.WorkingArea.Width,
+                WorkingAreaHeight = display.WorkingArea.Height,
+                RotatedDegrees = rotated
+            };
+
+            var info = JsonConvert.SerializeObject(displayInfo, Formatting.Indented);
+            var displayInfoEntityName = $"{parentSensorSafeName}_{id}";
+            var displayInfoId = $"{Id}_{id}";
+            var displayInfoSensor = new DataTypeStringSensor(_updateInterval, displayInfoId, name, displayInfoId, string.Empty, "mdi:monitor", string.Empty, EntityName, true);
+            displayInfoSensor.SetState(name);
+            displayInfoSensor.SetAttributes(info);
+            AddUpdateSensor(displayInfoId, displayInfoSensor);
+        }
+    }
+
+    public override DiscoveryConfigModel GetAutoDiscoveryConfig() => null;
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/DisplaySensors.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/DisplaySensors.cs
@@ -19,7 +19,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
 
         public sealed override Dictionary<string, AbstractSingleValueSensor> Sensors { get; protected set; } = new Dictionary<string, AbstractSingleValueSensor>();
 
-        public DisplaySensors(int? updateInterval = null, string name = DefaultName, string friendlyName = DefaultName, string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 30, id)
+        public DisplaySensors(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 30, id)
         {
             _updateInterval = updateInterval ?? 30;
 
@@ -36,7 +36,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
 
         public sealed override void UpdateSensorValues()
         {
-            var parentSensorSafeName = SharedHelperFunctions.GetSafeValue(Name);
+            var parentSensorSafeName = SharedHelperFunctions.GetSafeValue(EntityName);
 
             var displays = Screen.AllScreens;
 
@@ -47,7 +47,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
 
             var displayCount = displays.Length;
             var displayCountId = $"{parentSensorSafeName}_display_count";
-            var displayCountSensor = new DataTypeIntSensor(_updateInterval, "Display Count", displayCountId, string.Empty, "mdi:monitor", string.Empty, Name);
+            var displayCountSensor = new DataTypeIntSensor(_updateInterval, "Display Count", displayCountId, string.Empty, "mdi:monitor", string.Empty, EntityName);
             displayCountSensor.SetState(displayCount);
             AddUpdateSensor(displayCountId, displayCountSensor);
 
@@ -55,7 +55,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
                 return;
 
             var primaryDisplayId = $"{parentSensorSafeName}_primary_display";
-            var primaryDisplaySensor = new DataTypeStringSensor(_updateInterval, "Primary Display", primaryDisplayId, string.Empty, "mdi:monitor", string.Empty, Name);
+            var primaryDisplaySensor = new DataTypeStringSensor(_updateInterval, "Primary Display", primaryDisplayId, string.Empty, "mdi:monitor", string.Empty, EntityName);
             primaryDisplaySensor.SetState(primaryDisplayStr);
             AddUpdateSensor(primaryDisplayId, primaryDisplaySensor);
 
@@ -105,7 +105,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
 
                 var info = JsonConvert.SerializeObject(displayInfo, Formatting.Indented);
                 var displayInfoId = $"{parentSensorSafeName}_{id}";
-                var displayInfoSensor = new DataTypeStringSensor(_updateInterval, name, displayInfoId, string.Empty, "mdi:monitor", string.Empty, Name, true);
+                var displayInfoSensor = new DataTypeStringSensor(_updateInterval, name, displayInfoId, string.Empty, "mdi:monitor", string.Empty, EntityName, true);
                 displayInfoSensor.SetState(name);
                 displayInfoSensor.SetAttributes(info);
                 AddUpdateSensor(displayInfoId, displayInfoSensor);

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/DisplaySensors.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/DisplaySensors.cs
@@ -47,7 +47,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
 
             var displayCount = displays.Length;
             var displayCountId = $"{parentSensorSafeName}_display_count";
-            var displayCountSensor = new DataTypeIntSensor(_updateInterval, "Display Count", displayCountId, string.Empty, "mdi:monitor", string.Empty, EntityName);
+            var displayCountSensor = new DataTypeIntSensor(_updateInterval, displayCountId, "Display Count", displayCountId, string.Empty, "mdi:monitor", string.Empty, EntityName);
             displayCountSensor.SetState(displayCount);
             AddUpdateSensor(displayCountId, displayCountSensor);
 
@@ -55,7 +55,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
                 return;
 
             var primaryDisplayId = $"{parentSensorSafeName}_primary_display";
-            var primaryDisplaySensor = new DataTypeStringSensor(_updateInterval, "Primary Display", primaryDisplayId, string.Empty, "mdi:monitor", string.Empty, EntityName);
+            var primaryDisplaySensor = new DataTypeStringSensor(_updateInterval, primaryDisplayId, "Primary Display", primaryDisplayId, string.Empty, "mdi:monitor", string.Empty, EntityName);
             primaryDisplaySensor.SetState(primaryDisplayStr);
             AddUpdateSensor(primaryDisplayId, primaryDisplaySensor);
 
@@ -105,7 +105,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
 
                 var info = JsonConvert.SerializeObject(displayInfo, Formatting.Indented);
                 var displayInfoId = $"{parentSensorSafeName}_{id}";
-                var displayInfoSensor = new DataTypeStringSensor(_updateInterval, name, displayInfoId, string.Empty, "mdi:monitor", string.Empty, EntityName, true);
+                var displayInfoSensor = new DataTypeStringSensor(_updateInterval, displayInfoId, name, displayInfoId, string.Empty, "mdi:monitor", string.Empty, EntityName, true);
                 displayInfoSensor.SetState(name);
                 displayInfoSensor.SetAttributes(info);
                 AddUpdateSensor(displayInfoId, displayInfoSensor);

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/NetworkSensors.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/NetworkSensors.cs
@@ -24,7 +24,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
 
         public sealed override Dictionary<string, AbstractSingleValueSensor> Sensors { get; protected set; } = new Dictionary<string, AbstractSingleValueSensor>();
 
-        public NetworkSensors(int? updateInterval = null, string name = DefaultName, string friendlyName = DefaultName, string networkCard = "*", string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 30, id)
+        public NetworkSensors(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string networkCard = "*", string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 30, id)
         {
             _updateInterval = updateInterval ?? 30;
 
@@ -44,7 +44,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
 
         public sealed override void UpdateSensorValues()
         {
-            var parentSensorSafeName = SharedHelperFunctions.GetSafeValue(Name);
+            var parentSensorSafeName = SharedHelperFunctions.GetSafeValue(EntityName);
 
             var nicCount = 0;
             var networkInterfaces = NetworkInterface.GetAllNetworkInterfaces();
@@ -122,7 +122,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
 
                     var info = JsonConvert.SerializeObject(networkInfo, Formatting.Indented);
                     var networkInfoId = $"{parentSensorSafeName}_{id}";
-                    var networkInfoSensor = new DataTypeStringSensor(_updateInterval, nic.Name, networkInfoId, string.Empty, "mdi:lan", string.Empty, Name, true);
+                    var networkInfoSensor = new DataTypeStringSensor(_updateInterval, nic.Name, networkInfoId, string.Empty, "mdi:lan", string.Empty, EntityName, true);
 
                     networkInfoSensor.SetState(nic.OperationalStatus.ToString());
                     networkInfoSensor.SetAttributes(info);
@@ -132,12 +132,12 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
                 }
                 catch (Exception ex)
                 {
-                    Log.Fatal(ex, "[NETWORK] [{name}] Error querying NIC: {msg}", Name, ex.Message);
+                    Log.Fatal(ex, "[NETWORK] [{name}] Error querying NIC: {msg}", EntityName, ex.Message);
                 }
             }
 
             var nicCountId = $"{parentSensorSafeName}_total_network_card_count";
-            var nicCountSensor = new DataTypeIntSensor(_updateInterval, "Network Card Count", nicCountId, string.Empty, "mdi:lan", string.Empty, Name);
+            var nicCountSensor = new DataTypeIntSensor(_updateInterval, "Network Card Count", nicCountId, string.Empty, "mdi:lan", string.Empty, EntityName);
             nicCountSensor.SetState(nicCount);
             AddUpdateSensor(nicCountId, nicCountSensor);
         }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/NetworkSensors.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/NetworkSensors.cs
@@ -122,7 +122,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
 
                     var info = JsonConvert.SerializeObject(networkInfo, Formatting.Indented);
                     var networkInfoId = $"{parentSensorSafeName}_{id}";
-                    var networkInfoSensor = new DataTypeStringSensor(_updateInterval, nic.Name, networkInfoId, string.Empty, "mdi:lan", string.Empty, EntityName, true);
+                    var networkInfoSensor = new DataTypeStringSensor(_updateInterval, networkInfoId, nic.Name, networkInfoId, string.Empty, "mdi:lan", string.Empty, EntityName, true);
 
                     networkInfoSensor.SetState(nic.OperationalStatus.ToString());
                     networkInfoSensor.SetAttributes(info);
@@ -137,7 +137,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
             }
 
             var nicCountId = $"{parentSensorSafeName}_total_network_card_count";
-            var nicCountSensor = new DataTypeIntSensor(_updateInterval, "Network Card Count", nicCountId, string.Empty, "mdi:lan", string.Empty, EntityName);
+            var nicCountSensor = new DataTypeIntSensor(_updateInterval, nicCountId, "Network Card Count", nicCountId, string.Empty, "mdi:lan", string.Empty, EntityName);
             nicCountSensor.SetState(nicCount);
             AddUpdateSensor(nicCountId, nicCountSensor);
         }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/NetworkSensors.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/NetworkSensors.cs
@@ -9,139 +9,140 @@ using HASS.Agent.Shared.Models.Internal;
 using Newtonsoft.Json;
 using Serilog;
 
-namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
+namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue;
+
+/// <summary>
+/// Multivalue sensor containing network and NIC info
+/// </summary>
+public class NetworkSensors : AbstractMultiValueSensor
 {
-    /// <summary>
-    /// Multivalue sensor containing network and NIC info
-    /// </summary>
-    public class NetworkSensors : AbstractMultiValueSensor
+    private const string DefaultName = "network";
+    private readonly int _updateInterval;
+
+    public string NetworkCard { get; protected set; }
+    private readonly bool _useSpecificCard = false;
+
+    public override sealed Dictionary<string, AbstractSingleValueSensor> Sensors { get; protected set; } = new Dictionary<string, AbstractSingleValueSensor>();
+
+    public NetworkSensors(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string networkCard = "*", string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 30, id)
     {
-        private const string DefaultName = "network";
-        private readonly int _updateInterval;
+        _updateInterval = updateInterval ?? 30;
 
-        public string NetworkCard { get; protected set; }
-        private readonly bool _useSpecificCard = false;
+        NetworkCard = networkCard;
+        _useSpecificCard = networkCard != "*" && !string.IsNullOrEmpty(networkCard);
 
-        public sealed override Dictionary<string, AbstractSingleValueSensor> Sensors { get; protected set; } = new Dictionary<string, AbstractSingleValueSensor>();
-
-        public NetworkSensors(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string networkCard = "*", string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 30, id)
-        {
-            _updateInterval = updateInterval ?? 30;
-
-            NetworkCard = networkCard;
-            _useSpecificCard = networkCard != "*" && !string.IsNullOrEmpty(networkCard);
-
-            UpdateSensorValues();
-        }
-
-        private void AddUpdateSensor(string sensorId, AbstractSingleValueSensor sensor)
-        {
-            if (!Sensors.ContainsKey(sensorId))
-                Sensors.Add(sensorId, sensor);
-            else
-                Sensors[sensorId] = sensor;
-        }
-
-        public sealed override void UpdateSensorValues()
-        {
-            var parentSensorSafeName = SharedHelperFunctions.GetSafeValue(EntityName);
-
-            var nicCount = 0;
-            var networkInterfaces = NetworkInterface.GetAllNetworkInterfaces();
-
-            foreach (var nic in networkInterfaces)
-            {
-                try
-                {
-                    if (nic == null)
-                        continue;
-
-                    if (_useSpecificCard && nic.Id != NetworkCard)
-                        continue;
-
-                    var id = nic.Id.Replace("{", "").Replace("}", "").Replace("-", "").ToLower();
-                    if (string.IsNullOrWhiteSpace(id))
-                        continue;
-
-                    var networkInfo = new NetworkInfo
-                    {
-                        Name = nic.Name,
-                        NetworkInterfaceType = nic.NetworkInterfaceType.ToString(),
-                        SpeedBitsPerSecond = nic.Speed,
-                        OperationalStatus = nic.OperationalStatus.ToString()
-                    };
-
-                    var interfaceStats = nic.GetIPv4Statistics();
-
-                    networkInfo.DataReceivedMB = Math.Round(ByteSize.FromBytes(interfaceStats.BytesReceived).MegaBytes);
-                    networkInfo.DataSentMB = Math.Round(ByteSize.FromBytes(interfaceStats.BytesSent).MegaBytes);
-                    networkInfo.IncomingPacketsDiscarded = interfaceStats.IncomingPacketsDiscarded;
-                    networkInfo.IncomingPacketsWithErrors = interfaceStats.IncomingPacketsWithErrors;
-                    networkInfo.IncomingPacketsWithUnknownProtocol = interfaceStats.IncomingUnknownProtocolPackets;
-                    networkInfo.OutgoingPacketsDiscarded = interfaceStats.OutgoingPacketsDiscarded;
-                    networkInfo.OutgoingPacketsWithErrors = interfaceStats.OutgoingPacketsWithErrors;
-
-                    var nicProperties = nic.GetIPProperties();
-
-                    foreach (var unicast in nicProperties.UnicastAddresses)
-                    {
-                        var ip = unicast.Address.ToString();
-                        if (!string.IsNullOrEmpty(ip) && !networkInfo.IpAddresses.Contains(ip))
-                            networkInfo.IpAddresses.Add(ip);
-
-                        var mac = nic.GetPhysicalAddress().ToString();
-                        if (!string.IsNullOrEmpty(mac) && !networkInfo.MacAddresses.Contains(mac))
-                            networkInfo.MacAddresses.Add(mac);
-                    }
-
-                    foreach (var gateway in nicProperties.GatewayAddresses)
-                    {
-                        var gatewayAddress = gateway.Address.ToString();
-                        if (!string.IsNullOrEmpty(gatewayAddress) && !networkInfo.Gateways.Contains(gatewayAddress))
-                            networkInfo.Gateways.Add(gatewayAddress);
-                    }
-
-                    networkInfo.DhcpEnabled = nicProperties.GetIPv4Properties().IsDhcpEnabled;
-
-                    foreach (var dhcp in nicProperties.DhcpServerAddresses)
-                    {
-                        var dhcpAddress = dhcp.ToString();
-                        if (!string.IsNullOrEmpty(dhcpAddress) && !networkInfo.DhcpAddresses.Contains(dhcpAddress))
-                            networkInfo.DhcpAddresses.Add(dhcpAddress);
-                    }
-
-                    networkInfo.DnsEnabled = nicProperties.IsDnsEnabled;
-                    networkInfo.DnsSuffix = nicProperties.DnsSuffix;
-
-                    foreach (var dns in nicProperties.DnsAddresses)
-                    {
-                        var dnsAddress = dns.ToString();
-                        if (!string.IsNullOrEmpty(dnsAddress) && !networkInfo.DnsAddresses.Contains(dnsAddress))
-                            networkInfo.DnsAddresses.Add(dnsAddress);
-                    }
-
-                    var info = JsonConvert.SerializeObject(networkInfo, Formatting.Indented);
-                    var networkInfoId = $"{parentSensorSafeName}_{id}";
-                    var networkInfoSensor = new DataTypeStringSensor(_updateInterval, networkInfoId, nic.Name, networkInfoId, string.Empty, "mdi:lan", string.Empty, EntityName, true);
-
-                    networkInfoSensor.SetState(nic.OperationalStatus.ToString());
-                    networkInfoSensor.SetAttributes(info);
-                    AddUpdateSensor(networkInfoId, networkInfoSensor);
-
-                    nicCount++;
-                }
-                catch (Exception ex)
-                {
-                    Log.Fatal(ex, "[NETWORK] [{name}] Error querying NIC: {msg}", EntityName, ex.Message);
-                }
-            }
-
-            var nicCountId = $"{parentSensorSafeName}_total_network_card_count";
-            var nicCountSensor = new DataTypeIntSensor(_updateInterval, nicCountId, "Network Card Count", nicCountId, string.Empty, "mdi:lan", string.Empty, EntityName);
-            nicCountSensor.SetState(nicCount);
-            AddUpdateSensor(nicCountId, nicCountSensor);
-        }
-
-        public override DiscoveryConfigModel GetAutoDiscoveryConfig() => null;
+        UpdateSensorValues();
     }
+
+    private void AddUpdateSensor(string sensorId, AbstractSingleValueSensor sensor)
+    {
+        if (!Sensors.ContainsKey(sensorId))
+            Sensors.Add(sensorId, sensor);
+        else
+            Sensors[sensorId] = sensor;
+    }
+
+    public override sealed void UpdateSensorValues()
+    {
+        var parentSensorSafeName = SharedHelperFunctions.GetSafeValue(EntityName);
+
+        var nicCount = 0;
+        var networkInterfaces = NetworkInterface.GetAllNetworkInterfaces();
+
+        foreach (var nic in networkInterfaces)
+        {
+            try
+            {
+                if (nic == null)
+                    continue;
+
+                if (_useSpecificCard && nic.Id != NetworkCard)
+                    continue;
+
+                var id = nic.Id.Replace("{", "").Replace("}", "").Replace("-", "").ToLower();
+                if (string.IsNullOrWhiteSpace(id))
+                    continue;
+
+                var networkInfo = new NetworkInfo
+                {
+                    Name = nic.Name,
+                    NetworkInterfaceType = nic.NetworkInterfaceType.ToString(),
+                    SpeedBitsPerSecond = nic.Speed,
+                    OperationalStatus = nic.OperationalStatus.ToString()
+                };
+
+                var interfaceStats = nic.GetIPv4Statistics();
+
+                networkInfo.DataReceivedMB = Math.Round(ByteSize.FromBytes(interfaceStats.BytesReceived).MegaBytes);
+                networkInfo.DataSentMB = Math.Round(ByteSize.FromBytes(interfaceStats.BytesSent).MegaBytes);
+                networkInfo.IncomingPacketsDiscarded = interfaceStats.IncomingPacketsDiscarded;
+                networkInfo.IncomingPacketsWithErrors = interfaceStats.IncomingPacketsWithErrors;
+                networkInfo.IncomingPacketsWithUnknownProtocol = interfaceStats.IncomingUnknownProtocolPackets;
+                networkInfo.OutgoingPacketsDiscarded = interfaceStats.OutgoingPacketsDiscarded;
+                networkInfo.OutgoingPacketsWithErrors = interfaceStats.OutgoingPacketsWithErrors;
+
+                var nicProperties = nic.GetIPProperties();
+
+                foreach (var unicast in nicProperties.UnicastAddresses)
+                {
+                    var ip = unicast.Address.ToString();
+                    if (!string.IsNullOrEmpty(ip) && !networkInfo.IpAddresses.Contains(ip))
+                        networkInfo.IpAddresses.Add(ip);
+
+                    var mac = nic.GetPhysicalAddress().ToString();
+                    if (!string.IsNullOrEmpty(mac) && !networkInfo.MacAddresses.Contains(mac))
+                        networkInfo.MacAddresses.Add(mac);
+                }
+
+                foreach (var gateway in nicProperties.GatewayAddresses)
+                {
+                    var gatewayAddress = gateway.Address.ToString();
+                    if (!string.IsNullOrEmpty(gatewayAddress) && !networkInfo.Gateways.Contains(gatewayAddress))
+                        networkInfo.Gateways.Add(gatewayAddress);
+                }
+
+                networkInfo.DhcpEnabled = nicProperties.GetIPv4Properties().IsDhcpEnabled;
+
+                foreach (var dhcp in nicProperties.DhcpServerAddresses)
+                {
+                    var dhcpAddress = dhcp.ToString();
+                    if (!string.IsNullOrEmpty(dhcpAddress) && !networkInfo.DhcpAddresses.Contains(dhcpAddress))
+                        networkInfo.DhcpAddresses.Add(dhcpAddress);
+                }
+
+                networkInfo.DnsEnabled = nicProperties.IsDnsEnabled;
+                networkInfo.DnsSuffix = nicProperties.DnsSuffix;
+
+                foreach (var dns in nicProperties.DnsAddresses)
+                {
+                    var dnsAddress = dns.ToString();
+                    if (!string.IsNullOrEmpty(dnsAddress) && !networkInfo.DnsAddresses.Contains(dnsAddress))
+                        networkInfo.DnsAddresses.Add(dnsAddress);
+                }
+
+                var info = JsonConvert.SerializeObject(networkInfo, Formatting.Indented);
+                var networkInfoEntityName = $"{parentSensorSafeName}_{id}";
+                var networkInfoId = $"{Id}_{id}";
+                var networkInfoSensor = new DataTypeStringSensor(_updateInterval, networkInfoEntityName, nic.Name, networkInfoId, string.Empty, "mdi:lan", string.Empty, EntityName, true);
+
+                networkInfoSensor.SetState(nic.OperationalStatus.ToString());
+                networkInfoSensor.SetAttributes(info);
+                AddUpdateSensor(networkInfoId, networkInfoSensor);
+
+                nicCount++;
+            }
+            catch (Exception ex)
+            {
+                Log.Fatal(ex, "[NETWORK] [{name}] Error querying NIC: {msg}", EntityName, ex.Message);
+            }
+        }
+
+        var nicCountEntityName = $"{parentSensorSafeName}_total_network_card_count";
+        var nicCountId = $"{Id}_total_network_card_count";
+        var nicCountSensor = new DataTypeIntSensor(_updateInterval, nicCountEntityName, "Network Card Count", nicCountId, string.Empty, "mdi:lan", string.Empty, EntityName);
+        nicCountSensor.SetState(nicCount);
+        AddUpdateSensor(nicCountId, nicCountSensor);
+    }
+
+    public override DiscoveryConfigModel GetAutoDiscoveryConfig() => null;
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/StorageSensors.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/StorageSensors.cs
@@ -11,116 +11,117 @@ using Newtonsoft.Json;
 using Serilog;
 #pragma warning disable CS1591
 
-namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
+namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue;
+
+/// <summary>
+/// Multivalue sensor containing local storage info
+/// </summary>
+public class StorageSensors : AbstractMultiValueSensor
 {
-    /// <summary>
-    /// Multivalue sensor containing local storage info
-    /// </summary>
-    public class StorageSensors : AbstractMultiValueSensor
+    private const string DefaultName = "storage";
+    private readonly int _updateInterval;
+
+    public override sealed Dictionary<string, AbstractSingleValueSensor> Sensors { get; protected set; } = new Dictionary<string, AbstractSingleValueSensor>();
+
+    public StorageSensors(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 30, id)
     {
-        private const string DefaultName = "storage";
-        private readonly int _updateInterval;
+        _updateInterval = updateInterval ?? 30;
 
-        public sealed override Dictionary<string, AbstractSingleValueSensor> Sensors { get; protected set; } = new Dictionary<string, AbstractSingleValueSensor>();
-
-        public StorageSensors(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 30, id)
-        {
-            _updateInterval = updateInterval ?? 30;
-
-            UpdateSensorValues();
-        }
-
-        private void AddUpdateSensor(string sensorId, AbstractSingleValueSensor sensor)
-        {
-            if (!Sensors.ContainsKey(sensorId))
-                Sensors.Add(sensorId, sensor);
-            else
-                Sensors[sensorId] = sensor;
-        }
-
-        public sealed override void UpdateSensorValues()
-        {
-            var driveCount = 0;
-
-            var parentSensorSafeName = SharedHelperFunctions.GetSafeValue(EntityName);
-
-            foreach (var drive in DriveInfo.GetDrives())
-            {
-                try
-                {
-                    if (!(drive is { IsReady: true, DriveType: DriveType.Fixed }))
-                        continue;
-
-                    if (string.IsNullOrWhiteSpace(drive.Name))
-                        continue;
-
-                    var driveName = $"{drive.Name[..1].ToUpper()}";
-                    var driveNameLower = driveName.ToLower();
-
-                    var driveLabel = string.IsNullOrEmpty(drive.VolumeLabel) ? "-" : drive.VolumeLabel;
-
-                    var sensorValue = string.IsNullOrEmpty(drive.VolumeLabel) ? driveName : drive.VolumeLabel;
-
-                    var storageInfo = new StorageInfo
-                    {
-                        Name = driveName,
-                        Label = driveLabel,
-                        FileSystem = drive.DriveFormat
-                    };
-
-                    var totalSizeMb = Math.Round(ByteSize.FromBytes(drive.TotalSize).MegaBytes);
-                    storageInfo.TotalSizeMB = totalSizeMb;
-
-                    var availableSpaceMb = Math.Round(ByteSize.FromBytes(drive.AvailableFreeSpace).MegaBytes);
-                    storageInfo.AvailableSpaceMB = availableSpaceMb;
-
-                    var usedSpaceMb = totalSizeMb - availableSpaceMb;
-                    storageInfo.UsedSpaceMB = usedSpaceMb;
-
-                    var availableSpacePercentage = (int)Math.Round((availableSpaceMb / totalSizeMb) * 100);
-                    storageInfo.AvailableSpacePercentage = availableSpacePercentage;
-
-                    var usedSpacePercentage = (int)Math.Round((usedSpaceMb / totalSizeMb) * 100);
-                    storageInfo.UsedSpacePercentage = usedSpacePercentage;
-
-                    var info = JsonConvert.SerializeObject(storageInfo, Formatting.Indented);
-                    var driveInfoId = $"{parentSensorSafeName}_{driveNameLower}";
-                    var driveInfoSensor = new DataTypeStringSensor(_updateInterval, driveInfoId, driveName, driveInfoId, string.Empty, "mdi:harddisk", string.Empty, EntityName, true);
-
-                    driveInfoSensor.SetState(sensorValue);
-                    driveInfoSensor.SetAttributes(info);
-
-                    AddUpdateSensor(driveInfoId, driveInfoSensor);
-
-                    driveCount++;
-                }
-                catch (Exception ex)
-                {
-                    switch (ex)
-                    {
-                        case UnauthorizedAccessException _:
-                        case SecurityException _:
-                            Log.Fatal(ex, "[STORAGE] [{name}] Disk access denied: {msg}", EntityName, ex.Message);
-                            continue;
-                        case DriveNotFoundException _:
-                            Log.Fatal(ex, "[STORAGE] [{name}] Disk not found: {msg}", EntityName, ex.Message);
-                            continue;
-                        case IOException _:
-                            Log.Fatal(ex, "[STORAGE] [{name}] Disk IO error: {msg}", EntityName, ex.Message);
-                            continue;
-                    }
-
-                    Log.Fatal(ex, "[STORAGE] [{name}] Error querying disk: {msg}", EntityName, ex.Message);
-                }
-            }
-
-            var driveCountId = $"{parentSensorSafeName}_total_disk_count";
-            var driveCountSensor = new DataTypeIntSensor(_updateInterval, driveCountId, "Total Disk Count", driveCountId, string.Empty, "mdi:harddisk", string.Empty, EntityName);
-            driveCountSensor.SetState(driveCount);
-
-            AddUpdateSensor(driveCountId, driveCountSensor);
-        }
-
-        public override DiscoveryConfigModel GetAutoDiscoveryConfig() => null;
+        UpdateSensorValues();
     }
+
+    private void AddUpdateSensor(string sensorId, AbstractSingleValueSensor sensor)
+    {
+        if (!Sensors.ContainsKey(sensorId))
+            Sensors.Add(sensorId, sensor);
+        else
+            Sensors[sensorId] = sensor;
+    }
+
+    public override sealed void UpdateSensorValues()
+    {
+        var driveCount = 0;
+
+        var parentSensorSafeName = SharedHelperFunctions.GetSafeValue(EntityName);
+
+        foreach (var drive in DriveInfo.GetDrives())
+        {
+            try
+            {
+                if (!(drive is { IsReady: true, DriveType: DriveType.Fixed }))
+                    continue;
+
+                if (string.IsNullOrWhiteSpace(drive.Name))
+                    continue;
+
+                var driveName = $"{drive.Name[..1].ToUpper()}";
+                var driveNameLower = driveName.ToLower();
+
+                var driveLabel = string.IsNullOrEmpty(drive.VolumeLabel) ? "-" : drive.VolumeLabel;
+
+                var sensorValue = string.IsNullOrEmpty(drive.VolumeLabel) ? driveName : drive.VolumeLabel;
+
+                var storageInfo = new StorageInfo
+                {
+                    Name = driveName,
+                    Label = driveLabel,
+                    FileSystem = drive.DriveFormat
+                };
+
+                var totalSizeMb = Math.Round(ByteSize.FromBytes(drive.TotalSize).MegaBytes);
+                storageInfo.TotalSizeMB = totalSizeMb;
+
+                var availableSpaceMb = Math.Round(ByteSize.FromBytes(drive.AvailableFreeSpace).MegaBytes);
+                storageInfo.AvailableSpaceMB = availableSpaceMb;
+
+                var usedSpaceMb = totalSizeMb - availableSpaceMb;
+                storageInfo.UsedSpaceMB = usedSpaceMb;
+
+                var availableSpacePercentage = (int)Math.Round((availableSpaceMb / totalSizeMb) * 100);
+                storageInfo.AvailableSpacePercentage = availableSpacePercentage;
+
+                var usedSpacePercentage = (int)Math.Round((usedSpaceMb / totalSizeMb) * 100);
+                storageInfo.UsedSpacePercentage = usedSpacePercentage;
+
+                var info = JsonConvert.SerializeObject(storageInfo, Formatting.Indented);
+                var driveInfoEntityName = $"{parentSensorSafeName}_{driveNameLower}";
+                var driveInfoId = $"{Id}_{driveNameLower}";
+                var driveInfoSensor = new DataTypeStringSensor(_updateInterval, driveInfoEntityName, driveName, driveInfoId, string.Empty, "mdi:harddisk", string.Empty, EntityName, true);
+
+                driveInfoSensor.SetState(sensorValue);
+                driveInfoSensor.SetAttributes(info);
+
+                AddUpdateSensor(driveInfoId, driveInfoSensor);
+
+                driveCount++;
+            }
+            catch (Exception ex)
+            {
+                switch (ex)
+                {
+                    case UnauthorizedAccessException _:
+                    case SecurityException _:
+                        Log.Fatal(ex, "[STORAGE] [{name}] Disk access denied: {msg}", EntityName, ex.Message);
+                        continue;
+                    case DriveNotFoundException _:
+                        Log.Fatal(ex, "[STORAGE] [{name}] Disk not found: {msg}", EntityName, ex.Message);
+                        continue;
+                    case IOException _:
+                        Log.Fatal(ex, "[STORAGE] [{name}] Disk IO error: {msg}", EntityName, ex.Message);
+                        continue;
+                }
+
+                Log.Fatal(ex, "[STORAGE] [{name}] Error querying disk: {msg}", EntityName, ex.Message);
+            }
+        }
+         
+        var driveCountEntityName = $"{parentSensorSafeName}_total_disk_count";
+        var driveCountId = $"{Id}_total_disk_count";
+        var driveCountSensor = new DataTypeIntSensor(_updateInterval, driveCountEntityName, "Total Disk Count", driveCountId, string.Empty, "mdi:harddisk", string.Empty, EntityName);
+        driveCountSensor.SetState(driveCount);
+
+        AddUpdateSensor(driveCountId, driveCountSensor);
+    }
+
+    public override DiscoveryConfigModel GetAutoDiscoveryConfig() => null;
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/StorageSensors.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/StorageSensors.cs
@@ -23,7 +23,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
 
         public sealed override Dictionary<string, AbstractSingleValueSensor> Sensors { get; protected set; } = new Dictionary<string, AbstractSingleValueSensor>();
 
-        public StorageSensors(int? updateInterval = null, string name = DefaultName, string friendlyName = DefaultName, string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 30, id)
+        public StorageSensors(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 30, id)
         {
             _updateInterval = updateInterval ?? 30;
 
@@ -42,7 +42,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
         {
             var driveCount = 0;
 
-            var parentSensorSafeName = SharedHelperFunctions.GetSafeValue(Name);
+            var parentSensorSafeName = SharedHelperFunctions.GetSafeValue(EntityName);
 
             foreach (var drive in DriveInfo.GetDrives())
             {
@@ -85,7 +85,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
 
                     var info = JsonConvert.SerializeObject(storageInfo, Formatting.Indented);
                     var driveInfoId = $"{parentSensorSafeName}_{driveNameLower}";
-                    var driveInfoSensor = new DataTypeStringSensor(_updateInterval, driveName, driveInfoId, string.Empty, "mdi:harddisk", string.Empty, Name, true);
+                    var driveInfoSensor = new DataTypeStringSensor(_updateInterval, driveName, driveInfoId, string.Empty, "mdi:harddisk", string.Empty, EntityName, true);
 
                     driveInfoSensor.SetState(sensorValue);
                     driveInfoSensor.SetAttributes(info);
@@ -100,22 +100,22 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
                     {
                         case UnauthorizedAccessException _:
                         case SecurityException _:
-                            Log.Fatal(ex, "[STORAGE] [{name}] Disk access denied: {msg}", Name, ex.Message);
+                            Log.Fatal(ex, "[STORAGE] [{name}] Disk access denied: {msg}", EntityName, ex.Message);
                             continue;
                         case DriveNotFoundException _:
-                            Log.Fatal(ex, "[STORAGE] [{name}] Disk not found: {msg}", Name, ex.Message);
+                            Log.Fatal(ex, "[STORAGE] [{name}] Disk not found: {msg}", EntityName, ex.Message);
                             continue;
                         case IOException _:
-                            Log.Fatal(ex, "[STORAGE] [{name}] Disk IO error: {msg}", Name, ex.Message);
+                            Log.Fatal(ex, "[STORAGE] [{name}] Disk IO error: {msg}", EntityName, ex.Message);
                             continue;
                     }
 
-                    Log.Fatal(ex, "[STORAGE] [{name}] Error querying disk: {msg}", Name, ex.Message);
+                    Log.Fatal(ex, "[STORAGE] [{name}] Error querying disk: {msg}", EntityName, ex.Message);
                 }
             }
 
             var driveCountId = $"{parentSensorSafeName}_total_disk_count";
-            var driveCountSensor = new DataTypeIntSensor(_updateInterval, "Total Disk Count", driveCountId, string.Empty, "mdi:harddisk", string.Empty, Name);
+            var driveCountSensor = new DataTypeIntSensor(_updateInterval, "Total Disk Count", driveCountId, string.Empty, "mdi:harddisk", string.Empty, EntityName);
             driveCountSensor.SetState(driveCount);
 
             AddUpdateSensor(driveCountId, driveCountSensor);

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/StorageSensors.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/StorageSensors.cs
@@ -85,7 +85,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
 
                     var info = JsonConvert.SerializeObject(storageInfo, Formatting.Indented);
                     var driveInfoId = $"{parentSensorSafeName}_{driveNameLower}";
-                    var driveInfoSensor = new DataTypeStringSensor(_updateInterval, driveName, driveInfoId, string.Empty, "mdi:harddisk", string.Empty, EntityName, true);
+                    var driveInfoSensor = new DataTypeStringSensor(_updateInterval, driveInfoId, driveName, driveInfoId, string.Empty, "mdi:harddisk", string.Empty, EntityName, true);
 
                     driveInfoSensor.SetState(sensorValue);
                     driveInfoSensor.SetAttributes(info);
@@ -115,7 +115,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
             }
 
             var driveCountId = $"{parentSensorSafeName}_total_disk_count";
-            var driveCountSensor = new DataTypeIntSensor(_updateInterval, "Total Disk Count", driveCountId, string.Empty, "mdi:harddisk", string.Empty, EntityName);
+            var driveCountSensor = new DataTypeIntSensor(_updateInterval, driveCountId, "Total Disk Count", driveCountId, string.Empty, "mdi:harddisk", string.Empty, EntityName);
             driveCountSensor.SetState(driveCount);
 
             AddUpdateSensor(driveCountId, driveCountSensor);

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/WindowsUpdatesSensors.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/WindowsUpdatesSensors.cs
@@ -41,27 +41,27 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
 
             var driverUpdateCount = driverUpdates.Count;
             var driverUpdateCountId = $"{parentSensorSafeName}_driver_updates_pending";
-            var driverUpdateCountSensor = new DataTypeIntSensor(_updateInterval, "Driver Updates Pending", driverUpdateCountId, string.Empty, "mdi:microsoft-windows", string.Empty, EntityName);
+            var driverUpdateCountSensor = new DataTypeIntSensor(_updateInterval, driverUpdateCountId, "Driver Updates Pending", driverUpdateCountId, string.Empty, "mdi:microsoft-windows", string.Empty, EntityName);
             driverUpdateCountSensor.SetState(driverUpdateCount);
             AddUpdateSensor(driverUpdateCountId, driverUpdateCountSensor);
 
             var softwareUpdateCount = softwareUpdates.Count;
             var softwareUpdateCountId = $"{parentSensorSafeName}_software_updates_pending";
-            var softwareUpdateCountSensor = new DataTypeIntSensor(_updateInterval, "Software Updates Pending", softwareUpdateCountId, string.Empty, "mdi:microsoft-windows", string.Empty, EntityName);
+            var softwareUpdateCountSensor = new DataTypeIntSensor(_updateInterval, softwareUpdateCountId, "Software Updates Pending", softwareUpdateCountId, string.Empty, "mdi:microsoft-windows", string.Empty, EntityName);
             softwareUpdateCountSensor.SetState(softwareUpdateCount);
             AddUpdateSensor(softwareUpdateCountId, softwareUpdateCountSensor);
 
             var driverUpdatesList = new WindowsUpdateInfoCollection(driverUpdates);
             var driverUpdatesStr = JsonConvert.SerializeObject(driverUpdatesList, Formatting.Indented);
             var driverUpdatesId = $"{parentSensorSafeName}_driver_updates";
-            var driverUpdatesSensor = new DataTypeIntSensor(_updateInterval, "Available Driver Updates", driverUpdatesId, string.Empty, "mdi:microsoft-windows", string.Empty, EntityName, true);
+            var driverUpdatesSensor = new DataTypeIntSensor(_updateInterval, driverUpdatesId, "Available Driver Updates", driverUpdatesId, string.Empty, "mdi:microsoft-windows", string.Empty, EntityName, true);
             driverUpdatesSensor.SetState(driverUpdates.Count);
             driverUpdatesSensor.SetAttributes(driverUpdatesStr);
             AddUpdateSensor(driverUpdatesId, driverUpdatesSensor);
 
             var softwareUpdatesStr = JsonConvert.SerializeObject(new WindowsUpdateInfoCollection(softwareUpdates), Formatting.Indented);
             var softwareUpdatesId = $"{parentSensorSafeName}_software_updates";
-            var softwareUpdatesSensor = new DataTypeIntSensor(_updateInterval, "Available Software Updates", softwareUpdatesId, string.Empty, "mdi:microsoft-windows", string.Empty, EntityName, true);
+            var softwareUpdatesSensor = new DataTypeIntSensor(_updateInterval, softwareUpdatesId, "Available Software Updates", softwareUpdatesId, string.Empty, "mdi:microsoft-windows", string.Empty, EntityName, true);
             softwareUpdatesSensor.SetState(softwareUpdates.Count);
             softwareUpdatesSensor.SetAttributes(softwareUpdatesStr);
             AddUpdateSensor(softwareUpdatesId, softwareUpdatesSensor);

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/WindowsUpdatesSensors.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/WindowsUpdatesSensors.cs
@@ -18,7 +18,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
 
         public sealed override Dictionary<string, AbstractSingleValueSensor> Sensors { get; protected set; } = new Dictionary<string, AbstractSingleValueSensor>();
 
-        public WindowsUpdatesSensors(int? updateInterval = null, string name = DefaultName, string friendlyName = DefaultName, string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 900, id)
+        public WindowsUpdatesSensors(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 900, id)
         {
             _updateInterval = updateInterval ?? 900;
 
@@ -35,33 +35,33 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
 
         public sealed override void UpdateSensorValues()
         {
-            var parentSensorSafeName = SharedHelperFunctions.GetSafeValue(Name);
+            var parentSensorSafeName = SharedHelperFunctions.GetSafeValue(EntityName);
 
             var (driverUpdates, softwareUpdates) = WindowsUpdatesManager.GetAvailableUpdates();
 
             var driverUpdateCount = driverUpdates.Count;
             var driverUpdateCountId = $"{parentSensorSafeName}_driver_updates_pending";
-            var driverUpdateCountSensor = new DataTypeIntSensor(_updateInterval, "Driver Updates Pending", driverUpdateCountId, string.Empty, "mdi:microsoft-windows", string.Empty, Name);
+            var driverUpdateCountSensor = new DataTypeIntSensor(_updateInterval, "Driver Updates Pending", driverUpdateCountId, string.Empty, "mdi:microsoft-windows", string.Empty, EntityName);
             driverUpdateCountSensor.SetState(driverUpdateCount);
             AddUpdateSensor(driverUpdateCountId, driverUpdateCountSensor);
 
             var softwareUpdateCount = softwareUpdates.Count;
             var softwareUpdateCountId = $"{parentSensorSafeName}_software_updates_pending";
-            var softwareUpdateCountSensor = new DataTypeIntSensor(_updateInterval, "Software Updates Pending", softwareUpdateCountId, string.Empty, "mdi:microsoft-windows", string.Empty, Name);
+            var softwareUpdateCountSensor = new DataTypeIntSensor(_updateInterval, "Software Updates Pending", softwareUpdateCountId, string.Empty, "mdi:microsoft-windows", string.Empty, EntityName);
             softwareUpdateCountSensor.SetState(softwareUpdateCount);
             AddUpdateSensor(softwareUpdateCountId, softwareUpdateCountSensor);
 
             var driverUpdatesList = new WindowsUpdateInfoCollection(driverUpdates);
             var driverUpdatesStr = JsonConvert.SerializeObject(driverUpdatesList, Formatting.Indented);
             var driverUpdatesId = $"{parentSensorSafeName}_driver_updates";
-            var driverUpdatesSensor = new DataTypeIntSensor(_updateInterval, "Available Driver Updates", driverUpdatesId, string.Empty, "mdi:microsoft-windows", string.Empty, Name, true);
+            var driverUpdatesSensor = new DataTypeIntSensor(_updateInterval, "Available Driver Updates", driverUpdatesId, string.Empty, "mdi:microsoft-windows", string.Empty, EntityName, true);
             driverUpdatesSensor.SetState(driverUpdates.Count);
             driverUpdatesSensor.SetAttributes(driverUpdatesStr);
             AddUpdateSensor(driverUpdatesId, driverUpdatesSensor);
 
             var softwareUpdatesStr = JsonConvert.SerializeObject(new WindowsUpdateInfoCollection(softwareUpdates), Formatting.Indented);
             var softwareUpdatesId = $"{parentSensorSafeName}_software_updates";
-            var softwareUpdatesSensor = new DataTypeIntSensor(_updateInterval, "Available Software Updates", softwareUpdatesId, string.Empty, "mdi:microsoft-windows", string.Empty, Name, true);
+            var softwareUpdatesSensor = new DataTypeIntSensor(_updateInterval, "Available Software Updates", softwareUpdatesId, string.Empty, "mdi:microsoft-windows", string.Empty, EntityName, true);
             softwareUpdatesSensor.SetState(softwareUpdates.Count);
             softwareUpdatesSensor.SetAttributes(softwareUpdatesStr);
             AddUpdateSensor(softwareUpdatesId, softwareUpdatesSensor);

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/ActiveWindowSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/ActiveWindowSensor.cs
@@ -12,7 +12,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
     {
         private const string DefaultName = "activewindow";
 
-        public ActiveWindowSensor(int? updateInterval = null, string name = DefaultName, string friendlyName = DefaultName, string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 15, id) { }
+        public ActiveWindowSensor(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 15, id) { }
 
         public override DiscoveryConfigModel GetAutoDiscoveryConfig()
         {
@@ -23,8 +23,8 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
 
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
-                Name = Name,
-                FriendlyName = FriendlyName,
+                EntityName = EntityName,
+                Name = EntityName,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/ActiveWindowSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/ActiveWindowSensor.cs
@@ -24,7 +24,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
                 EntityName = EntityName,
-                Name = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/CurrentVolumeSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/CurrentVolumeSensor.cs
@@ -24,7 +24,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
                 EntityName = EntityName,
-                Name = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/CurrentVolumeSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/CurrentVolumeSensor.cs
@@ -12,7 +12,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
     {
         private const string DefaultName = "currentvolume";
 
-        public CurrentVolumeSensor(int? updateInterval = null, string name = DefaultName, string friendlyName = DefaultName, string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 15, id) { }
+        public CurrentVolumeSensor(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 15, id) { }
 
         public override DiscoveryConfigModel GetAutoDiscoveryConfig()
         {
@@ -23,8 +23,8 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
 
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
-                Name = Name,
-                FriendlyName = FriendlyName,
+                EntityName = EntityName,
+                Name = EntityName,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/DummySensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/DummySensor.cs
@@ -9,7 +9,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
     {
         private const string DefaultName = "dummy";
 
-        public DummySensor(int? updateInterval = null, string name = DefaultName, string friendlyName = DefaultName, string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 5, id) { }
+        public DummySensor(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 5, id) { }
 
         public override DiscoveryConfigModel GetAutoDiscoveryConfig()
         {
@@ -20,8 +20,8 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
 
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
-                Name = Name,
-                FriendlyName = FriendlyName,
+                EntityName = EntityName,
+                Name = EntityName,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/DummySensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/DummySensor.cs
@@ -21,7 +21,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
                 EntityName = EntityName,
-                Name = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/GpuLoadSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/GpuLoadSensor.cs
@@ -35,7 +35,7 @@ public class GpuLoadSensor : AbstractSingleValueSensor
 		return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
 		{
 			EntityName = EntityName,
-			Name = EntityName,
+			Name = Name,
 			Unique_id = Id,
 			Device = deviceConfig,
 			State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/GpuLoadSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/GpuLoadSensor.cs
@@ -14,7 +14,7 @@ public class GpuLoadSensor : AbstractSingleValueSensor
 	private const string DefaultName = "gpuload";
 	private readonly IHardware _gpu;
 
-	public GpuLoadSensor(int? updateInterval = null, string name = DefaultName, string friendlyName = DefaultName, string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 30, id)
+	public GpuLoadSensor(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 30, id)
 	{
 		_gpu = HardwareManager.Hardware.FirstOrDefault(
 			h => h.HardwareType == HardwareType.GpuAmd ||
@@ -34,8 +34,8 @@ public class GpuLoadSensor : AbstractSingleValueSensor
 
 		return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
 		{
-			Name = Name,
-			FriendlyName = FriendlyName,
+			EntityName = EntityName,
+			Name = EntityName,
 			Unique_id = Id,
 			Device = deviceConfig,
 			State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/GpuTemperatureSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/GpuTemperatureSensor.cs
@@ -14,7 +14,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
         private const string DefaultName = "gputemperature";
         private readonly IHardware _gpu;
 
-        public GpuTemperatureSensor(int? updateInterval = null, string name = DefaultName, string friendlyName = DefaultName, string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 30, id)
+        public GpuTemperatureSensor(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 30, id)
         {
 			_gpu = HardwareManager.Hardware.FirstOrDefault(
 				h => h.HardwareType == HardwareType.GpuAmd ||
@@ -32,8 +32,8 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
 
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
-                Name = Name,
-                FriendlyName = FriendlyName,
+                EntityName = EntityName,
+                Name = EntityName,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/GpuTemperatureSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/GpuTemperatureSensor.cs
@@ -33,7 +33,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
                 EntityName = EntityName,
-                Name = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/LastActiveSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/LastActiveSensor.cs
@@ -41,7 +41,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
                 EntityName = EntityName,
-                Name = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/LastActiveSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/LastActiveSensor.cs
@@ -23,7 +23,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
         public bool ApplyRounding { get; private set; }
         public int Round { get; private set; }
 
-        public LastActiveSensor(bool updateOnResume, int? updateOnResumeTimeWindow, int? updateInterval = 10, string name = DefaultName, string friendlyName = DefaultName, string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 10, id)
+        public LastActiveSensor(bool updateOnResume, int? updateOnResumeTimeWindow, int? updateInterval = 10, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 10, id)
         {
             ApplyRounding = updateOnResume;
             Round = updateOnResumeTimeWindow ?? 30;
@@ -40,8 +40,8 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
 
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
-                Name = Name,
-                FriendlyName = FriendlyName,
+                EntityName = EntityName,
+                Name = EntityName,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/LastBootSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/LastBootSensor.cs
@@ -25,7 +25,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
                 EntityName = EntityName,
-                Name = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/LastBootSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/LastBootSensor.cs
@@ -13,7 +13,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
     {
         private const string DefaultName = "lastboot";
 
-        public LastBootSensor(int? updateInterval = 10, string name = DefaultName, string friendlyName = DefaultName, string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 10, id) { }
+        public LastBootSensor(int? updateInterval = 10, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 10, id) { }
 
         public override DiscoveryConfigModel GetAutoDiscoveryConfig()
         {
@@ -24,8 +24,8 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
 
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
-                Name = Name,
-                FriendlyName = FriendlyName,
+                EntityName = EntityName,
+                Name = EntityName,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/LastSystemStateChangeSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/LastSystemStateChangeSensor.cs
@@ -22,7 +22,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
                 EntityName = EntityName,
-                Name = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/LastSystemStateChangeSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/LastSystemStateChangeSensor.cs
@@ -10,7 +10,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
     {
         private const string DefaultName = "lastsystemstatechange";
 
-        public LastSystemStateChangeSensor(int? updateInterval = 10, string name = DefaultName, string friendlyName = DefaultName, string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 10, id) { }
+        public LastSystemStateChangeSensor(int? updateInterval = 10, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 10, id) { }
 
         public override DiscoveryConfigModel GetAutoDiscoveryConfig()
         {
@@ -21,8 +21,8 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
 
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
-                Name = Name,
-                FriendlyName = FriendlyName,
+                EntityName = EntityName,
+                Name = EntityName,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/LoggedUserSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/LoggedUserSensor.cs
@@ -22,7 +22,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
                 EntityName = EntityName,
-                Name = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/LoggedUserSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/LoggedUserSensor.cs
@@ -10,7 +10,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
     {
         private const string DefaultName = "loggeduser";
 
-        public LoggedUserSensor(int? updateInterval = null, string name = DefaultName, string friendlyName = DefaultName, string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 10, id) { }
+        public LoggedUserSensor(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 10, id) { }
 
         public override DiscoveryConfigModel GetAutoDiscoveryConfig()
         {
@@ -21,8 +21,8 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
 
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
-                Name = Name,
-                FriendlyName = FriendlyName,
+                EntityName = EntityName,
+                Name = EntityName,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/LoggedUsersSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/LoggedUsersSensor.cs
@@ -30,7 +30,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
                 EntityName = EntityName,
-                Name = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/LoggedUsersSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/LoggedUsersSensor.cs
@@ -18,7 +18,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
     {
         private const string DefaultName = "loggedusers";
 
-        public LoggedUsersSensor(int? updateInterval = null, string name = DefaultName, string friendlyName = DefaultName, string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 30, id) { }
+        public LoggedUsersSensor(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 30, id) { }
 
         public override DiscoveryConfigModel GetAutoDiscoveryConfig()
         {
@@ -29,8 +29,8 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
 
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
-                Name = Name,
-                FriendlyName = FriendlyName,
+                EntityName = EntityName,
+                Name = EntityName,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/MicrophoneActiveSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/MicrophoneActiveSensor.cs
@@ -28,7 +28,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
                 EntityName = EntityName,
-                Name = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/MicrophoneActiveSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/MicrophoneActiveSensor.cs
@@ -11,7 +11,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
     {
         private const string DefaultName = "microphoneactive";
 
-        public MicrophoneActiveSensor(int? updateInterval = null, string name = DefaultName, string friendlyName = DefaultName, string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 10, id)
+        public MicrophoneActiveSensor(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 10, id)
         {
             Domain = "binary_sensor";
         }
@@ -27,8 +27,8 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
 
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
-                Name = Name,
-                FriendlyName = FriendlyName,
+                EntityName = EntityName,
+                Name = EntityName,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/MicrophoneProcessSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/MicrophoneProcessSensor.cs
@@ -44,7 +44,7 @@ public class MicrophoneProcessSensor : AbstractSingleValueSensor
         var model = new SensorDiscoveryConfigModel()
         {
             EntityName = EntityName,
-            Name = EntityName,
+            Name = Name,
             Unique_id = Id,
             Device = deviceConfig,
             State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/MicrophoneProcessSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/MicrophoneProcessSensor.cs
@@ -15,7 +15,7 @@ public class MicrophoneProcessSensor : AbstractSingleValueSensor
     private const string DefaultName = "microphoneprocess";
     
     private const string LastUsedTimeStop = "LastUsedTimeStop";
-    public MicrophoneProcessSensor(int? updateInterval = null, string name = DefaultName, string friendlyName = DefaultName, string id = default, bool useAttributes = true) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 10, id, useAttributes)
+    public MicrophoneProcessSensor(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default, bool useAttributes = true) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 10, id, useAttributes)
     {
         //
     }
@@ -43,8 +43,8 @@ public class MicrophoneProcessSensor : AbstractSingleValueSensor
 
         var model = new SensorDiscoveryConfigModel()
         {
-            Name = Name,
-            FriendlyName = FriendlyName,
+            EntityName = EntityName,
+            Name = EntityName,
             Unique_id = Id,
             Device = deviceConfig,
             State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/NamedWindowSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/NamedWindowSensor.cs
@@ -12,7 +12,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
         private const string DefaultName = "namedwindow";
         public string WindowName { get; protected set; }
 
-        public NamedWindowSensor(string windowName, string name = DefaultName, string friendlyName = DefaultName, int? updateInterval = 10, string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 30, id)
+        public NamedWindowSensor(string windowName, string entityName = DefaultName, string name = DefaultName, int? updateInterval = 10, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 30, id)
         {
             Domain = "binary_sensor";
             WindowName = windowName;
@@ -27,8 +27,8 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
 
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
-                Name = Name,
-                FriendlyName = FriendlyName,
+                EntityName = EntityName,
+                Name = EntityName,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/NamedWindowSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/NamedWindowSensor.cs
@@ -28,7 +28,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
                 EntityName = EntityName,
-                Name = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/ProcessActiveSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/ProcessActiveSensor.cs
@@ -32,7 +32,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
                 EntityName = EntityName,
-                Name = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/ProcessActiveSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/ProcessActiveSensor.cs
@@ -13,7 +13,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
         private const string DefaultName = "processactive";
         public string ProcessName { get; protected set; }
 
-        public ProcessActiveSensor(string processName, int? updateInterval = null, string name = DefaultName, string friendlyName = DefaultName, string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 10, id)
+        public ProcessActiveSensor(string processName, int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 10, id)
         {
             ProcessName = processName;
 
@@ -31,8 +31,8 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
 
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
-                Name = Name,
-                FriendlyName = FriendlyName,
+                EntityName = EntityName,
+                Name = EntityName,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/ServiceStateSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/ServiceStateSensor.cs
@@ -27,7 +27,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
                 EntityName = EntityName,
-                Name = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/ServiceStateSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/ServiceStateSensor.cs
@@ -12,7 +12,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
         private const string DefaultName = "servicestate";
         public string ServiceName { get; protected set; }
 
-        public ServiceStateSensor(string serviceName, int? updateInterval = null, string name = DefaultName, string friendlyName = DefaultName, string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 10, id)
+        public ServiceStateSensor(string serviceName, int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 10, id)
         {
             ServiceName = serviceName;
         }
@@ -26,8 +26,8 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
 
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
-                Name = Name,
-                FriendlyName = FriendlyName,
+                EntityName = EntityName,
+                Name = EntityName,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/SessionStateSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/SessionStateSensor.cs
@@ -22,7 +22,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
                 EntityName = EntityName,
-                Name = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/SessionStateSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/SessionStateSensor.cs
@@ -10,7 +10,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
     {
         private const string DefaultName = "sessionstate";
 
-        public SessionStateSensor(int? updateInterval = null, string name = DefaultName, string friendlyName = DefaultName, string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 10, id) { }
+        public SessionStateSensor(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 10, id) { }
 
         public override DiscoveryConfigModel GetAutoDiscoveryConfig()
         {
@@ -21,8 +21,8 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
 
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
-                Name = Name,
-                FriendlyName = FriendlyName,
+                EntityName = EntityName,
+                Name = EntityName,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/UserNotificationStateSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/UserNotificationStateSensor.cs
@@ -23,7 +23,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
                 EntityName = EntityName,
-                Name = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{EntityName}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/UserNotificationStateSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/UserNotificationStateSensor.cs
@@ -11,7 +11,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
     {
         private const string DefaultName = "notificationstate";
 
-        public UserNotificationStateSensor(int? updateInterval = null, string name = DefaultName, string friendlyName = DefaultName, string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 10, id) { }
+        public UserNotificationStateSensor(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 10, id) { }
 
         public override DiscoveryConfigModel GetAutoDiscoveryConfig()
         {
@@ -22,11 +22,11 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
 
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
-                Name = Name,
-                FriendlyName = FriendlyName,
+                EntityName = EntityName,
+                Name = EntityName,
                 Unique_id = Id,
                 Device = deviceConfig,
-                State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{Name}/state",
+                State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{EntityName}/state",
                 Icon = "mdi:laptop",
                 Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/availability"
             });

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/WebcamActiveSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/WebcamActiveSensor.cs
@@ -33,7 +33,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
                 EntityName = EntityName,
-                Name = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{EntityName}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/WebcamActiveSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/WebcamActiveSensor.cs
@@ -11,7 +11,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
     {
         private const string DefaultName = "webcamactive";
 
-        public WebcamActiveSensor(int? updateInterval = null, string name = DefaultName, string friendlyName = DefaultName, string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 10, id)
+        public WebcamActiveSensor(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 10, id)
         {
             Domain = "binary_sensor";
         }
@@ -32,11 +32,11 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
 
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
-                Name = Name,
-                FriendlyName = FriendlyName,
+                EntityName = EntityName,
+                Name = EntityName,
                 Unique_id = Id,
                 Device = deviceConfig,
-                State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{Name}/state",
+                State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{EntityName}/state",
                 Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/sensor/{deviceConfig.Name}/availability",
                 Icon = "mdi:webcam"
             });

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/WebcamProcessSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/WebcamProcessSensor.cs
@@ -37,7 +37,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
             var model = new SensorDiscoveryConfigModel()
             {
                 EntityName = EntityName,
-                Name = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/WebcamProcessSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/WebcamProcessSensor.cs
@@ -14,7 +14,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
     {
         private const string DefaultName = "webcamprocess";
 
-        public WebcamProcessSensor(int? updateInterval = null, string name = DefaultName, string friendlyName = DefaultName, string id = default, bool useAttributes = true) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 10, id, useAttributes)
+        public WebcamProcessSensor(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default, bool useAttributes = true) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 10, id, useAttributes)
         {
             //
         }
@@ -36,8 +36,8 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
 
             var model = new SensorDiscoveryConfigModel()
             {
-                Name = Name,
-                FriendlyName = FriendlyName,
+                EntityName = EntityName,
+                Name = EntityName,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/WindowStateSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/WindowStateSensor.cs
@@ -30,7 +30,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
                 EntityName = EntityName,
-                Name = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/WindowStateSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/WindowStateSensor.cs
@@ -15,7 +15,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
         private const string DefaultName = "windowstate";
         public string ProcessName { get; protected set; }
 
-        public WindowStateSensor(string processName, string name = DefaultName, string friendlyName = DefaultName, int? updateInterval = 10, string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 30, id)
+        public WindowStateSensor(string processName, string entityName = DefaultName, string name = DefaultName, int? updateInterval = 10, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 30, id)
         {
             ProcessName = processName;
         }
@@ -29,8 +29,8 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
 
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
-                Name = Name,
-                FriendlyName = FriendlyName,
+                EntityName = EntityName,
+                Name = EntityName,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/PerfCounterSensors/SingleValue/CpuLoadSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/PerfCounterSensors/SingleValue/CpuLoadSensor.cs
@@ -23,7 +23,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.PerfCounterSensors.SingleValue
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
                 EntityName = EntityName,
-                Name = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/PerfCounterSensors/SingleValue/CpuLoadSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/PerfCounterSensors/SingleValue/CpuLoadSensor.cs
@@ -9,7 +9,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.PerfCounterSensors.SingleValue
     {
         private const string DefaultName = "cpuload";
 
-        public CpuLoadSensor(int? updateInterval = null, string name = DefaultName, string friendlyName = DefaultName, string id = default, bool applyRounding = false, int? round = null) : base("Processor", "% Processor Time", "_Total", applyRounding, round, updateInterval ?? 30, name ?? DefaultName, friendlyName ?? null, id) { }
+        public CpuLoadSensor(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default, bool applyRounding = false, int? round = null) : base("Processor", "% Processor Time", "_Total", applyRounding, round, updateInterval ?? 30, entityName ?? DefaultName, name ?? null, id) { }
 
         public override DiscoveryConfigModel GetAutoDiscoveryConfig()
         {
@@ -18,10 +18,12 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.PerfCounterSensors.SingleValue
             var deviceConfig = Variables.MqttManager.GetDeviceConfigModel();
             if (deviceConfig == null) return null;
 
+            var asd = ObjectId;
+
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
-                Name = Name,
-                FriendlyName = FriendlyName,
+                EntityName = EntityName,
+                Name = EntityName,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/PerformanceCounterSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/PerformanceCounterSensor.cs
@@ -50,7 +50,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel
             {
                 EntityName = EntityName,
-                Name = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{EntityName}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/PerformanceCounterSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/PerformanceCounterSensor.cs
@@ -22,7 +22,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors
         public bool ApplyRounding { get; private set; }
         public int? Round { get; private set; }
 
-        public PerformanceCounterSensor(string categoryName, string counterName, string instanceName, bool applyRounding = false, int? round = null, int? updateInterval = null, string name = DefaultName, string friendlyName = DefaultName, string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 10, id)
+        public PerformanceCounterSensor(string categoryName, string counterName, string instanceName, bool applyRounding = false, int? round = null, int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 10, id)
         {
             CategoryName = categoryName;
             CounterName = counterName;
@@ -49,11 +49,11 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors
 
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel
             {
-                Name = Name,
-                FriendlyName = FriendlyName,
+                EntityName = EntityName,
+                Name = EntityName,
                 Unique_id = Id,
                 Device = deviceConfig,
-                State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{Name}/state",
+                State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{EntityName}/state",
                 Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/availability"
             });
         }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/PowershellSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/PowershellSensor.cs
@@ -18,7 +18,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors
         public bool ApplyRounding { get; private set; }
         public int? Round { get; private set; }
 
-        public PowershellSensor(string command, bool applyRounding = false, int? round = null, int? updateInterval = null, string name = DefaultName, string friendlyName = DefaultName, string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 10, id)
+        public PowershellSensor(string command, bool applyRounding = false, int? round = null, int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 10, id)
         {
             Command = command;
             ApplyRounding = applyRounding;
@@ -34,11 +34,11 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors
 
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
-                Name = Name,
-                FriendlyName = FriendlyName,
+                EntityName = EntityName,
+                Name = EntityName,
                 Unique_id = Id,
                 Device = deviceConfig,
-                State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{Name}/state",
+                State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{EntityName}/state",
                 Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/availability"
             });
         }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/PowershellSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/PowershellSensor.cs
@@ -35,7 +35,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
                 EntityName = EntityName,
-                Name = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{EntityName}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/WmiQuerySensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/WmiQuerySensor.cs
@@ -20,7 +20,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors
         protected readonly ObjectQuery ObjectQuery;
         protected readonly ManagementObjectSearcher Searcher;
 
-        public WmiQuerySensor(string query, string scope = "", bool applyRounding = false, int? round = null, int? updateInterval = null, string name = DefaultName, string friendlyName = DefaultName, string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 10, id)
+        public WmiQuerySensor(string query, string scope = "", bool applyRounding = false, int? round = null, int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 10, id)
         {
             Query = query;
             Scope = scope;
@@ -50,11 +50,11 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors
 
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
-                Name = Name,
-                FriendlyName = FriendlyName,
+                EntityName = EntityName,
+                Name = EntityName,
                 Unique_id = Id,
                 Device = deviceConfig,
-                State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{Name}/state",
+                State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{EntityName}/state",
                 Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/availability"
             });
         }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/WmiQuerySensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/WmiQuerySensor.cs
@@ -51,7 +51,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
                 EntityName = EntityName,
-                Name = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{EntityName}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/WmiSensors/SingleValue/CurrentClockSpeedSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/WmiSensors/SingleValue/CurrentClockSpeedSensor.cs
@@ -30,7 +30,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.WmiSensors.SingleValue
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
                 EntityName = EntityName,
-                Name = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/WmiSensors/SingleValue/CurrentClockSpeedSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/WmiSensors/SingleValue/CurrentClockSpeedSensor.cs
@@ -17,7 +17,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.WmiSensors.SingleValue
         private protected DateTime LastFetched = DateTime.MinValue;
         private protected string LastValue = string.Empty;
 
-        public CurrentClockSpeedSensor(int? updateInterval = null, string name = DefaultName, string friendlyName = DefaultName, string id = default, bool applyRounding = false, int? round = null) : base(string.Empty, string.Empty, applyRounding, round, updateInterval ?? 300, name ?? DefaultName, friendlyName ?? null, id) 
+        public CurrentClockSpeedSensor(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default, bool applyRounding = false, int? round = null) : base(string.Empty, string.Empty, applyRounding, round, updateInterval ?? 300, entityName ?? DefaultName, name ?? null, id) 
             => _managementObject = new ManagementObject("Win32_Processor.DeviceID='CPU0'");
 
         public override DiscoveryConfigModel GetAutoDiscoveryConfig()
@@ -29,8 +29,8 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.WmiSensors.SingleValue
 
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
-                Name = Name,
-                FriendlyName = FriendlyName,
+                EntityName = EntityName,
+                Name = EntityName,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",
@@ -55,7 +55,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.WmiSensors.SingleValue
             }
             catch (Exception ex)
             {
-                Log.Error("[CURRENTCLOCKSPEED] [{name}] Error getting current clockspeed: {msg}", Name, ex.Message);
+                Log.Error("[CURRENTCLOCKSPEED] [{name}] Error getting current clockspeed: {msg}", EntityName, ex.Message);
                 return "0";
             }
         }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/WmiSensors/SingleValue/MemoryUsageSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/WmiSensors/SingleValue/MemoryUsageSensor.cs
@@ -23,7 +23,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.WmiSensors.SingleValue
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
                 EntityName = EntityName,
-                Name = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/WmiSensors/SingleValue/MemoryUsageSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/WmiSensors/SingleValue/MemoryUsageSensor.cs
@@ -11,7 +11,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.WmiSensors.SingleValue
     {
         private const string DefaultName = "memoryusage";
 
-        public MemoryUsageSensor(int? updateInterval = null, string name = DefaultName, string friendlyName = DefaultName, string id = default, bool applyRounding = false, int? round = null) : base("SELECT FreePhysicalMemory,TotalVisibleMemorySize FROM Win32_OperatingSystem", string.Empty, applyRounding, round, updateInterval ?? 30, name ?? DefaultName, friendlyName ?? null, id) { }
+        public MemoryUsageSensor(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default, bool applyRounding = false, int? round = null) : base("SELECT FreePhysicalMemory,TotalVisibleMemorySize FROM Win32_OperatingSystem", string.Empty, applyRounding, round, updateInterval ?? 30, entityName ?? DefaultName, name ?? null, id) { }
 
         public override DiscoveryConfigModel GetAutoDiscoveryConfig()
         {
@@ -22,8 +22,8 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.WmiSensors.SingleValue
 
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
-                Name = Name,
-                FriendlyName = FriendlyName,
+                EntityName = EntityName,
+                Name = EntityName,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent.Shared/Models/Config/ConfiguredCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Models/Config/ConfiguredCommand.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using HASS.Agent.Shared.Enums;
+using HASS.Agent.Shared.Models.Config.Old;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using static HASS.Agent.Shared.Functions.Inputs;
@@ -13,9 +14,7 @@ namespace HASS.Agent.Shared.Models.Config
     public class ConfiguredCommand
     {
         public Guid Id { get; set; } = Guid.Empty;
-        [JsonProperty("FriendlyName")]
         public string Name { get; set; } = string.Empty;
-        [JsonProperty("Name")]
         public string EntityName { get; set; } = string.Empty;
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -29,5 +28,37 @@ namespace HASS.Agent.Shared.Models.Config
         public VirtualKeyShort KeyCode { get; set; }
         public bool RunAsLowIntegrity { get; set; } = false;
         public List<string> Keys { get; set; } = new List<string>();
+
+        public static ConfiguredCommand FromLAB02(ConfiguredCommandLAB02 oldConfig)
+        {
+            return new ConfiguredCommand()
+            {
+                Id = oldConfig.Id,
+                Name = oldConfig.Name,
+                EntityName = oldConfig.Name,
+                Type = oldConfig.Type,
+                EntityType = oldConfig.EntityType,
+                Command = oldConfig.Command,
+                KeyCode = (VirtualKeyShort)oldConfig.KeyCode,
+                RunAsLowIntegrity = oldConfig.RunAsLowIntegrity,
+                Keys = oldConfig.Keys
+            };
+        }
+
+        public static ConfiguredCommand From2023Beta(ConfiguredCommand2023Beta oldConfig)
+        {
+            return new ConfiguredCommand()
+            {
+                Id = oldConfig.Id,
+                Name = oldConfig.Name,
+                EntityName = oldConfig.EntityName,
+                Type = oldConfig.Type,
+                EntityType = oldConfig.EntityType,
+                Command = oldConfig.Command,
+                KeyCode = oldConfig.KeyCode,
+                RunAsLowIntegrity = oldConfig.RunAsLowIntegrity,
+                Keys = oldConfig.Keys  
+            };
+        }
     }
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/Models/Config/ConfiguredCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Models/Config/ConfiguredCommand.cs
@@ -13,8 +13,8 @@ namespace HASS.Agent.Shared.Models.Config
     public class ConfiguredCommand
     {
         public Guid Id { get; set; } = Guid.Empty;
-        public string FriendlyName { get; set; } = string.Empty;
         public string Name { get; set; } = string.Empty;
+        public string EntityName { get; set; } = string.Empty;
 
         [JsonConverter(typeof(StringEnumConverter))]
         public CommandType Type { get; set; }

--- a/src/HASS.Agent/HASS.Agent.Shared/Models/Config/ConfiguredCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Models/Config/ConfiguredCommand.cs
@@ -13,7 +13,9 @@ namespace HASS.Agent.Shared.Models.Config
     public class ConfiguredCommand
     {
         public Guid Id { get; set; } = Guid.Empty;
+        [JsonProperty("FriendlyName")]
         public string Name { get; set; } = string.Empty;
+        [JsonProperty("Name")]
         public string EntityName { get; set; } = string.Empty;
 
         [JsonConverter(typeof(StringEnumConverter))]

--- a/src/HASS.Agent/HASS.Agent.Shared/Models/Config/ConfiguredSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Models/Config/ConfiguredSensor.cs
@@ -13,6 +13,7 @@ namespace HASS.Agent.Shared.Models.Config
         [JsonConverter(typeof(StringEnumConverter))]
         public SensorType Type { get; set; }
         public Guid Id { get; set; } = Guid.Empty;
+        [JsonProperty("FriendlyName")]
         public string Name { get; set; } = string.Empty;
         public int? UpdateInterval { get; set; }
         public string Query { get; set; } = string.Empty;
@@ -21,6 +22,7 @@ namespace HASS.Agent.Shared.Models.Config
         public string Category { get; set; } = string.Empty;
         public string Counter { get; set; } = string.Empty;
         public string Instance { get; set; } = string.Empty;
+        [JsonProperty("Name")]
         public string EntityName { get; set; } = string.Empty;
         public bool IgnoreAvailability { get; set; } = false;
         public bool ApplyRounding { get; set; } = false;

--- a/src/HASS.Agent/HASS.Agent.Shared/Models/Config/ConfiguredSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Models/Config/ConfiguredSensor.cs
@@ -13,7 +13,7 @@ namespace HASS.Agent.Shared.Models.Config
         [JsonConverter(typeof(StringEnumConverter))]
         public SensorType Type { get; set; }
         public Guid Id { get; set; } = Guid.Empty;
-        public string FriendlyName { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
         public int? UpdateInterval { get; set; }
         public string Query { get; set; } = string.Empty;
         public string Scope { get; set; }
@@ -21,7 +21,7 @@ namespace HASS.Agent.Shared.Models.Config
         public string Category { get; set; } = string.Empty;
         public string Counter { get; set; } = string.Empty;
         public string Instance { get; set; } = string.Empty;
-        public string Name { get; set; } = string.Empty;
+        public string EntityName { get; set; } = string.Empty;
         public bool IgnoreAvailability { get; set; } = false;
         public bool ApplyRounding { get; set; } = false;
         public int? Round { get; set; }

--- a/src/HASS.Agent/HASS.Agent.Shared/Models/Config/ConfiguredSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Models/Config/ConfiguredSensor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using HASS.Agent.Shared.Enums;
+using HASS.Agent.Shared.Models.Config.Old;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
@@ -13,7 +14,6 @@ namespace HASS.Agent.Shared.Models.Config
         [JsonConverter(typeof(StringEnumConverter))]
         public SensorType Type { get; set; }
         public Guid Id { get; set; } = Guid.Empty;
-        [JsonProperty("FriendlyName")]
         public string Name { get; set; } = string.Empty;
         public int? UpdateInterval { get; set; }
         public string Query { get; set; } = string.Empty;
@@ -22,10 +22,51 @@ namespace HASS.Agent.Shared.Models.Config
         public string Category { get; set; } = string.Empty;
         public string Counter { get; set; } = string.Empty;
         public string Instance { get; set; } = string.Empty;
-        [JsonProperty("Name")]
         public string EntityName { get; set; } = string.Empty;
         public bool IgnoreAvailability { get; set; } = false;
         public bool ApplyRounding { get; set; } = false;
         public int? Round { get; set; }
+
+        public static ConfiguredSensor FromLAB02(ConfiguredSensorLAB02 oldConfig)
+        {
+            return new ConfiguredSensor()
+            {
+                Type = oldConfig.Type,
+                Id = oldConfig.Id,
+                Name = oldConfig.Name,
+                UpdateInterval = oldConfig.UpdateInterval,
+                Query = oldConfig.Query,
+                Scope = oldConfig.Scope,
+                WindowName = oldConfig.WindowName,
+                Category = oldConfig.Category,
+                Counter = oldConfig.Counter,
+                Instance = oldConfig.Instance,
+                ApplyRounding = oldConfig.ApplyRounding,
+                Round = oldConfig.Round,
+                EntityName = oldConfig.Name,
+            };
+        }
+
+        public static ConfiguredSensor From2023Beta(ConfiguredSensor2023Beta oldConfig)
+        {
+            return new ConfiguredSensor()
+            {
+                Type = oldConfig.Type,
+                Id = oldConfig.Id,
+                Name = oldConfig.Name,
+                UpdateInterval = oldConfig.UpdateInterval,
+                Query = oldConfig.Query,
+                Scope = oldConfig.Scope,
+                WindowName = oldConfig.WindowName,
+                Category = oldConfig.Category,
+                Counter = oldConfig.Counter,
+                Instance = oldConfig.Instance,
+                ApplyRounding = oldConfig.ApplyRounding,
+                Round = oldConfig.Round,
+                EntityName = oldConfig.EntityName,
+            };
+        }
     }
+
+
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/Models/Config/Old/ConfiguredCommand2023Beta.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Models/Config/Old/ConfiguredCommand2023Beta.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using HASS.Agent.Shared.Enums;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using static HASS.Agent.Shared.Functions.Inputs;
+
+namespace HASS.Agent.Shared.Models.Config.Old
+{
+    /// <summary>
+    /// Storable version of command objects for the HASS.Agent 2023 Beta
+    /// </summary>
+    public class ConfiguredCommand2023Beta
+    {
+        public Guid Id { get; set; } = Guid.Empty;
+        [JsonProperty("FriendlyName")]
+        public string Name { get; set; } = string.Empty;
+        [JsonProperty("Name")]
+        public string EntityName { get; set; } = string.Empty;
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        public CommandType Type { get; set; }
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        public CommandEntityType EntityType { get; set; } = CommandEntityType.Switch;
+
+        public string Command { get; set; } = string.Empty;
+
+        public VirtualKeyShort KeyCode { get; set; }
+        public bool RunAsLowIntegrity { get; set; } = false;
+        public List<string> Keys { get; set; } = new List<string>();
+
+        public static bool InJsonData(string jsonData)
+        {
+            return jsonData.Contains("FriendlyName");
+        }
+    }
+}

--- a/src/HASS.Agent/HASS.Agent.Shared/Models/Config/Old/ConfiguredCommandLAB02.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Models/Config/Old/ConfiguredCommandLAB02.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using HASS.Agent.Shared.Enums;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using static HASS.Agent.Shared.Functions.Inputs;
+
+namespace HASS.Agent.Shared.Models.Config.Old
+{
+    /// <summary>
+    /// Storable version of command objects for the original HASS.Agent
+    /// </summary>
+    public class ConfiguredCommandLAB02
+    {
+        public Guid Id { get; set; } = Guid.Empty;
+        public string FriendlyName { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        public CommandType Type { get; set; }
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        public CommandEntityType EntityType { get; set; } = CommandEntityType.Switch;
+
+        public string Command { get; set; } = string.Empty;
+
+        public byte KeyCode { get; set; }
+        public bool RunAsLowIntegrity { get; set; } = false;
+        public List<string> Keys { get; set; } = new List<string>();
+
+        public static bool InJsonData(string jsonData)
+        {
+            return !jsonData.Contains("FriendlyName")
+                && !jsonData.Contains("EntityName");
+        }
+    }
+}

--- a/src/HASS.Agent/HASS.Agent.Shared/Models/Config/Old/ConfiguredSensor2023Beta.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Models/Config/Old/ConfiguredSensor2023Beta.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using HASS.Agent.Shared.Enums;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace HASS.Agent.Shared.Models.Config.Old
+{
+    /// <summary>
+    /// Storable version of sensor objects for the HASS.Agent 2023 Beta
+    /// </summary>
+    public class ConfiguredSensor2023Beta
+    {
+        [JsonConverter(typeof(StringEnumConverter))]
+        public SensorType Type { get; set; }
+        public Guid Id { get; set; } = Guid.Empty;
+        [JsonProperty("FriendlyName")]
+        public string Name { get; set; } = string.Empty;
+        public int? UpdateInterval { get; set; }
+        public string Query { get; set; } = string.Empty;
+        public string Scope { get; set; }
+        public string WindowName { get; set; } = string.Empty;
+        public string Category { get; set; } = string.Empty;
+        public string Counter { get; set; } = string.Empty;
+        public string Instance { get; set; } = string.Empty;
+        [JsonProperty("Name")]
+        public string EntityName { get; set; } = string.Empty;
+        public bool IgnoreAvailability { get; set; } = false;
+        public bool ApplyRounding { get; set; } = false;
+        public int? Round { get; set; }
+
+        public static bool InJsonData(string jsonData)
+        {
+            return jsonData.Contains("FriendlyName");
+        }
+    }
+}

--- a/src/HASS.Agent/HASS.Agent.Shared/Models/Config/Old/ConfiguredSensorLAB02.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Models/Config/Old/ConfiguredSensorLAB02.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using HASS.Agent.Shared.Enums;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace HASS.Agent.Shared.Models.Config.Old
+{
+    /// <summary>
+    /// Storable version of sensor objects for the original HASS.Agent
+    /// </summary>
+    public class ConfiguredSensorLAB02
+    {
+        [JsonConverter(typeof(StringEnumConverter))]
+        public SensorType Type { get; set; }
+        public Guid Id { get; set; } = Guid.Empty;
+        public int? UpdateInterval { get; set; }
+        public string Query { get; set; } = string.Empty;
+        public string Scope { get; set; }
+        public string WindowName { get; set; } = string.Empty;
+        public string Category { get; set; } = string.Empty;
+        public string Counter { get; set; } = string.Empty;
+        public string Instance { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public bool ApplyRounding { get; set; } = false;
+        public int? Round { get; set; }
+
+        public static bool InJsonData(string jsonData)
+        {
+            return !jsonData.Contains("FriendlyName")
+                && !jsonData.Contains("EntityName");
+        }
+    }
+}

--- a/src/HASS.Agent/HASS.Agent.Shared/Models/HomeAssistant/AbstractCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Models/HomeAssistant/AbstractCommand.cs
@@ -17,11 +17,11 @@ namespace HASS.Agent.Shared.Models.HomeAssistant
         public string PreviousPublishedState { get; set; } = string.Empty;
         public CommandEntityType EntityType { get; set; }
 
-        protected AbstractCommand(string name, string friendlyName, CommandEntityType entityType = CommandEntityType.Switch, string id = default)
+        protected AbstractCommand(string entityName, string name, CommandEntityType entityType = CommandEntityType.Switch, string id = default)
         {
             Id = id == null || id == Guid.Empty.ToString() ? Guid.NewGuid().ToString() : id;
-            Name = name;
-            FriendlyName = friendlyName;
+            EntityName = entityName;
+            EntityName = name;
             Domain = entityType.GetEnumMemberValue();
             EntityType = entityType;
         }
@@ -73,7 +73,7 @@ namespace HASS.Agent.Shared.Models.HomeAssistant
             }
             catch (Exception ex)
             {
-                Log.Fatal("[COMMAND] [{name}] Error publishing state: {err}", Name, ex.Message);
+                Log.Fatal("[COMMAND] [{name}] Error publishing state: {err}", EntityName, ex.Message);
             }
         }
 

--- a/src/HASS.Agent/HASS.Agent.Shared/Models/HomeAssistant/AbstractCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Models/HomeAssistant/AbstractCommand.cs
@@ -21,7 +21,7 @@ namespace HASS.Agent.Shared.Models.HomeAssistant
         {
             Id = id == null || id == Guid.Empty.ToString() ? Guid.NewGuid().ToString() : id;
             EntityName = entityName;
-            EntityName = name;
+            Name = name;
             Domain = entityType.GetEnumMemberValue();
             EntityType = entityType;
         }

--- a/src/HASS.Agent/HASS.Agent.Shared/Models/HomeAssistant/AbstractDiscoverable.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Models/HomeAssistant/AbstractDiscoverable.cs
@@ -8,8 +8,8 @@ namespace HASS.Agent.Shared.Models.HomeAssistant
     public abstract class AbstractDiscoverable
     {
         public string Domain { get; set; } = "switch";
-        public string Name { get; set; } = string.Empty;
-        public string FriendlyName { get; set; } = null;
+        public string EntityName { get; set; } = string.Empty;
+        public string Name { get; set; } = null;
         public string TopicName { get; set; } = string.Empty;
 
         private string _objectId = string.Empty;
@@ -20,7 +20,7 @@ namespace HASS.Agent.Shared.Models.HomeAssistant
             {
                 if (!string.IsNullOrEmpty(_objectId)) return _objectId;
 
-                _objectId = Regex.Replace(Name, "[^a-zA-Z0-9_-]", "_");
+                _objectId = Regex.Replace(EntityName, "[^a-zA-Z0-9_-]", "_");
                 return _objectId;
             }
 

--- a/src/HASS.Agent/HASS.Agent.Shared/Models/HomeAssistant/AbstractMultiValueSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Models/HomeAssistant/AbstractMultiValueSensor.cs
@@ -16,11 +16,11 @@ namespace HASS.Agent.Shared.Models.HomeAssistant
 
         public abstract Dictionary<string, AbstractSingleValueSensor> Sensors { get; protected set; }
 
-        protected AbstractMultiValueSensor(string name, string friendlyName, int updateIntervalSeconds = 10, string id = default)
+        protected AbstractMultiValueSensor(string entityName, string name, int updateIntervalSeconds = 10, string id = default)
         {
             Id = id == null || id == Guid.Empty.ToString() ? Guid.NewGuid().ToString() : id;
-            Name = name;
-            FriendlyName = friendlyName;
+            EntityName = entityName;
+            EntityName = name;
             UpdateIntervalSeconds = updateIntervalSeconds;
             Domain = "sensor";
         }
@@ -59,7 +59,7 @@ namespace HASS.Agent.Shared.Models.HomeAssistant
             }
             catch (Exception ex)
             {
-                Log.Fatal("[SENSOR] [{name}] Error publishing state: {err}", Name, ex.Message);
+                Log.Fatal("[SENSOR] [{name}] Error publishing state: {err}", EntityName, ex.Message);
             }
         }
 

--- a/src/HASS.Agent/HASS.Agent.Shared/Models/HomeAssistant/AbstractMultiValueSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Models/HomeAssistant/AbstractMultiValueSensor.cs
@@ -20,7 +20,7 @@ namespace HASS.Agent.Shared.Models.HomeAssistant
         {
             Id = id == null || id == Guid.Empty.ToString() ? Guid.NewGuid().ToString() : id;
             EntityName = entityName;
-            EntityName = name;
+            Name = name;
             UpdateIntervalSeconds = updateIntervalSeconds;
             Domain = "sensor";
         }

--- a/src/HASS.Agent/HASS.Agent.Shared/Models/HomeAssistant/AbstractSingleValueSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Models/HomeAssistant/AbstractSingleValueSensor.cs
@@ -16,11 +16,11 @@ namespace HASS.Agent.Shared.Models.HomeAssistant
         public string PreviousPublishedState { get; protected set; } = string.Empty;
         public string PreviousPublishedAttributes { get; protected set; } = string.Empty;
 
-        protected AbstractSingleValueSensor(string name, string friendlyName, int updateIntervalSeconds = 10, string id = default, bool useAttributes = false)
+        protected AbstractSingleValueSensor(string entityName, string name, int updateIntervalSeconds = 10, string id = default, bool useAttributes = false)
         {
             Id = id == null || id == Guid.Empty.ToString() ? Guid.NewGuid().ToString() : id;
-            Name = name;
-            FriendlyName = friendlyName;
+            EntityName = entityName;
+            EntityName = name;
             UpdateIntervalSeconds = updateIntervalSeconds;
             Domain = "sensor";
             UseAttributes = useAttributes;
@@ -117,7 +117,7 @@ namespace HASS.Agent.Shared.Models.HomeAssistant
             }
             catch (Exception ex)
             {
-                Log.Fatal("[SENSOR] [{name}] Error publishing state: {err}", Name, ex.Message);
+                Log.Fatal("[SENSOR] [{name}] Error publishing state: {err}", EntityName, ex.Message);
             }
         }
 

--- a/src/HASS.Agent/HASS.Agent.Shared/Models/HomeAssistant/AbstractSingleValueSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Models/HomeAssistant/AbstractSingleValueSensor.cs
@@ -20,7 +20,7 @@ namespace HASS.Agent.Shared.Models.HomeAssistant
         {
             Id = id == null || id == Guid.Empty.ToString() ? Guid.NewGuid().ToString() : id;
             EntityName = entityName;
-            EntityName = name;
+            Name = name;
             UpdateIntervalSeconds = updateIntervalSeconds;
             Domain = "sensor";
             UseAttributes = useAttributes;

--- a/src/HASS.Agent/HASS.Agent.Shared/Models/HomeAssistant/DiscoveryConfigModel.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Models/HomeAssistant/DiscoveryConfigModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
 
 namespace HASS.Agent.Shared.Models.HomeAssistant
 {
@@ -26,13 +27,14 @@ namespace HASS.Agent.Shared.Models.HomeAssistant
         /// (Optional) The name of the MQTT entity. Defaults to its name.
         /// </summary>
         /// <value></value>
-        public string Name { get; set; }
+        [JsonIgnore]
+        public string EntityName { get; set; }
 
         /// <summary>
         /// (Optional) The friendly name of the MQTT entity. Defaults to its name.
         /// </summary>
         /// <value></value>
-        public string FriendlyName { get; set; }
+        public string Name { get; set; }
 
         /// <summary>
         /// The MQTT topic subscribed to receive entity values.
@@ -120,10 +122,10 @@ namespace HASS.Agent.Shared.Models.HomeAssistant
 
                 // backward compatibility with HASS.Agent and HA versions below 2023.8 where device name was part of the entity ID
                 // will not mess with the "Home Assistant entity ID" if user already has their own naming convention with device ID included
-                if (Name.Contains(Device.Name))
-                    return Name;
+                if (EntityName.Contains(Device.Name))
+                    return EntityName;
 
-                return $"{Device.Name}_{Name}";
+                return $"{Device.Name}_{EntityName}";
             }
             set { _objectId = value; }
         }
@@ -232,10 +234,10 @@ namespace HASS.Agent.Shared.Models.HomeAssistant
 
                 // backward compatibility with HASS.Agent and HA versions below 2023.8 where device name was part of the entity ID
                 // will not mess with the "Home Assistant entity ID" if user already has their own naming convention with device ID included
-                if (Name.Contains(Device.Name))
-                    return Name;
+                if (EntityName.Contains(Device.Name))
+                    return EntityName;
 
-                return $"{Device.Name}_{Name}";
+                return $"{Device.Name}_{EntityName}";
             }
             set { _objectId = value; }
         }

--- a/src/HASS.Agent/HASS.Agent/Commands/CommandsManager.cs
+++ b/src/HASS.Agent/HASS.Agent/Commands/CommandsManager.cs
@@ -168,14 +168,14 @@ namespace HASS.Agent.Commands
                     return;
                 }
 
-                if (Variables.Commands.All(x => x.Name != name))
+                if (Variables.Commands.All(x => x.EntityName != name))
                 {
                     Log.Warning("[COMMANDSMANAGER] [{command}] Command not found, unable to execute", name);
 
                     return;
                 }
 
-                var command = Variables.Commands.First(x => x.Name == name);
+                var command = Variables.Commands.First(x => x.EntityName == name);
                 command.TurnOn();
             }
             catch (Exception ex)
@@ -211,11 +211,11 @@ namespace HASS.Agent.Commands
                             await Variables.MqttManager.UnsubscribeAsync(abstractCommand);
                             Variables.Commands.RemoveAt(commandIndex);
 
-                            Log.Information("[COMMANDS] Removed command: {command}", abstractCommand.Name);
+                            Log.Information("[COMMANDS] Removed command: {command}", abstractCommand.EntityName);
                         }
                         else
                         {
-                            Log.Information("[COMMANDS] Command not removed, not activated: {command}", abstractCommand.Name);
+                            Log.Information("[COMMANDS] Command not removed, not activated: {command}", abstractCommand.EntityName);
                         }
                     }
                 }
@@ -233,15 +233,15 @@ namespace HASS.Agent.Commands
                         await abstractCommand.PublishAutoDiscoveryConfigAsync();
                         await abstractCommand.PublishStateAsync(false);
 
-                        Log.Information("[COMMANDS] Added command: {command}", abstractCommand.Name);
+                        Log.Information("[COMMANDS] Added command: {command}", abstractCommand.EntityName);
                         continue;
                     }
 
                     // existing, update and re-register
                     var currentCommandIndex = Variables.Commands.FindIndex(x => x.Id == abstractCommand.Id);
-                    if (Variables.Commands[currentCommandIndex].Name != abstractCommand.Name || Variables.Commands[currentCommandIndex].EntityType != abstractCommand.EntityType)
+                    if (Variables.Commands[currentCommandIndex].EntityName != abstractCommand.EntityName || Variables.Commands[currentCommandIndex].EntityType != abstractCommand.EntityType)
                     {
-                        Log.Information("[COMMANDS] Command changed, re-registering as new entity: {old} to {new}", Variables.Commands[currentCommandIndex].Name, abstractCommand.Name);
+                        Log.Information("[COMMANDS] Command changed, re-registering as new entity: {old} to {new}", Variables.Commands[currentCommandIndex].EntityName, abstractCommand.EntityName);
 
                         await Variables.Commands[currentCommandIndex].UnPublishAutoDiscoveryConfigAsync();
                         await Variables.MqttManager.UnsubscribeAsync(Variables.Commands[currentCommandIndex]);
@@ -252,7 +252,7 @@ namespace HASS.Agent.Commands
                     await abstractCommand.PublishAutoDiscoveryConfigAsync();
                     await abstractCommand.PublishStateAsync(false);
 
-                    Log.Information("[COMMANDS] Modified command: {command}", abstractCommand.Name);
+                    Log.Information("[COMMANDS] Modified command: {command}", abstractCommand.EntityName);
                 }
 
                 await Variables.MqttManager.AnnounceAvailabilityAsync();

--- a/src/HASS.Agent/HASS.Agent/Commands/CommandsManager.cs
+++ b/src/HASS.Agent/HASS.Agent/Commands/CommandsManager.cs
@@ -7,441 +7,449 @@ using Serilog;
 
 namespace HASS.Agent.Commands
 {
-	/// <summary>
-	/// Continuously performs command autodiscovery and state publishing
-	/// </summary>
-	internal static class CommandsManager
-	{
-		internal static readonly Dictionary<CommandType, CommandInfoCard> CommandInfoCards = new();
-
-		private static bool _active = true;
-		private static bool _pause;
-
-		private static DateTime _lastAutoDiscoPublish = DateTime.MinValue;
-
-		/// <summary>
-		/// Initializes the command manager
-		/// </summary>
-		internal static async void Initialize()
-		{
-			if (!Variables.AppSettings.MqttEnabled)
-			{
-				Variables.MainForm?.SetCommandsStatus(ComponentStatus.Stopped);
-
-				return;
-			}
-
-			while (Variables.MqttManager.GetStatus() == MqttStatus.Connecting)
-				await Task.Delay(250);
-
-			_ = Task.Run(Process);
-		}
-
-		/// <summary>
-		/// Stop processing commands
-		/// </summary>
-		internal static void Stop() => _active = false;
-
-		/// <summary>
-		/// Pause processing commands
-		/// </summary>
-		internal static void Pause() => _pause = true;
-
-		/// <summary>
-		/// Resume processing commands
-		/// </summary>
-		internal static void Unpause() => _pause = false;
-
-		/// <summary>
-		/// Unpublishes all commands
-		/// </summary>
-		/// <returns></returns>
-		internal static async Task UnpublishAllCommands()
-		{
-			if (!CommandsPresent())
-				return;
-
-			foreach (var command in Variables.Commands)
-			{
-				await command.UnPublishAutoDiscoveryConfigAsync();
-				await Variables.MqttManager.UnsubscribeAsync(command);
-			}
-		}
-
-		/// <summary>
-		/// Generates new ID's for all commands
-		/// </summary>
-		internal static void ResetCommandIds()
-		{
-			if (!CommandsPresent())
-				return;
-
-			foreach (var command in Variables.Commands)
-				command.Id = Guid.NewGuid().ToString();
-
-			StoredCommands.Store();
-		}
-
-		/// <summary>
-		/// Continuously processes commands (autodiscovery, state)
-		/// </summary>
-		private static async void Process()
-		{
-			var firstRun = true;
-			var subscribed = false;
-
-			while (_active)
-			{
-				try
-				{
-					// on the first run, just wait 1 sec - this is to make sure we're announcing ourselves,
-					// when there are no sensors or when the sensor manager's still initialising
-					await Task.Delay(firstRun ? TimeSpan.FromSeconds(1) : TimeSpan.FromMilliseconds(750));
-
-					if (_pause || Variables.MqttManager.GetStatus() != MqttStatus.Connected || !CommandsPresent())
-						continue;
-
-					firstRun = false;
-
-					if ((DateTime.Now - _lastAutoDiscoPublish).TotalSeconds > 30)
-					{
-						await Variables.MqttManager.AnnounceAvailabilityAsync();
-
-						foreach (var command in Variables.Commands
-							.TakeWhile(_ => !_pause)
-							.TakeWhile(_ => _active))
-						{
-							if (_pause || Variables.MqttManager.GetStatus() != MqttStatus.Connected)
-								continue;
-
-							await command.PublishAutoDiscoveryConfigAsync();
-						}
-
-						if (!subscribed)
-						{
-							foreach (var command in Variables.Commands
-								.TakeWhile(_ => !_pause)
-								.TakeWhile(_ => _active))
-							{
-								if (_pause || Variables.MqttManager.GetStatus() != MqttStatus.Connected)
-									continue;
-
-								await Variables.MqttManager.SubscribeAsync(command);
-							}
-
-							subscribed = true;
-						}
-
-						_lastAutoDiscoPublish = DateTime.Now;
-					}
-
-					// publish command states (they have their own time-based scheduling)
-					foreach (var command in Variables.Commands
-						.TakeWhile(_ => !_pause)
-						.TakeWhile(_ => _active))
-					{
-						if (_pause || Variables.MqttManager.GetStatus() != MqttStatus.Connected)
-							continue;
-
-						await command.PublishStateAsync();
-					}
-				}
-				catch (Exception ex)
-				{
-					Log.Fatal(ex, "[COMMANDSMANAGER] Error while publishing: {err}", ex.Message);
-				}
-			}
-		}
-
-		/// <summary>
-		/// Looks for the command by name, and executes it
-		/// </summary>
-		/// <param name="name"></param>
-		internal static void ExecuteCommandByName(string name)
-		{
-			try
-			{
-				if (!CommandsPresent())
-				{
-					Log.Warning("[COMMANDSMANAGER] [{command}] No commands configured, unable to execute", name);
-
-					return;
-				}
-
-				if (Variables.Commands.All(x => x.Name != name))
-				{
-					Log.Warning("[COMMANDSMANAGER] [{command}] Command not found, unable to execute", name);
-
-					return;
-				}
-
-				var command = Variables.Commands.First(x => x.Name == name);
-				command.TurnOn();
-			}
-			catch (Exception ex)
-			{
-				Log.Fatal(ex, "[COMMANDSMANAGER] [{command}] Error while executing: {err}", name, ex.Message);
-			}
-		}
-
-		/// <summary>
-		/// Stores the provided commands, and (re)publishes them
-		/// </summary>
-		/// <param name="commands"></param>
-		/// <param name="toBeDeletedCommands"></param>
-		/// <returns></returns>
-		internal static async Task<bool> StoreAsync(List<ConfiguredCommand> commands, List<ConfiguredCommand> toBeDeletedCommands = null)
-		{
-			toBeDeletedCommands ??= new List<ConfiguredCommand>();
-
-			try
-			{
-				Pause();
-
-				if (toBeDeletedCommands.Any())
-				{
-					foreach (var abstractCommand in toBeDeletedCommands
-						.Select(StoredCommands.ConvertConfiguredToAbstract)
-						.Where(abstractCommand => abstractCommand != null))
-					{
-						await abstractCommand.UnPublishAutoDiscoveryConfigAsync();
-						await Variables.MqttManager.UnsubscribeAsync(abstractCommand);
-						Variables.Commands.RemoveAt(Variables.Commands.FindIndex(x => x.Id == abstractCommand.Id));
-
-						Log.Information("[COMMANDS] Removed command: {command}", abstractCommand.Name);
-					}
-				}
-
-				// copy our list to the main one
-				foreach (var abstractCommand in commands
-					.Select(StoredCommands.ConvertConfiguredToAbstract)
-					.Where(abstractCommand => abstractCommand != null))
-				{
-					// new, add and register
-					if (Variables.Commands.All(x => x.Id != abstractCommand.Id))
-					{
-						Variables.Commands.Add(abstractCommand);
-						await Variables.MqttManager.SubscribeAsync(abstractCommand);
-						await abstractCommand.PublishAutoDiscoveryConfigAsync();
-						await abstractCommand.PublishStateAsync(false);
-
-						Log.Information("[COMMANDS] Added command: {command}", abstractCommand.Name);
-						continue;
-					}
-
-					// existing, update and re-register
-					var currentCommandIndex = Variables.Commands.FindIndex(x => x.Id == abstractCommand.Id);
-					if (Variables.Commands[currentCommandIndex].Name != abstractCommand.Name || Variables.Commands[currentCommandIndex].EntityType != abstractCommand.EntityType)
-					{
-						Log.Information("[COMMANDS] Command changed, re-registering as new entity: {old} to {new}", Variables.Commands[currentCommandIndex].Name, abstractCommand.Name);
-
-						await Variables.Commands[currentCommandIndex].UnPublishAutoDiscoveryConfigAsync();
-						await Variables.MqttManager.UnsubscribeAsync(Variables.Commands[currentCommandIndex]);
-						await Variables.MqttManager.SubscribeAsync(abstractCommand);
-					}
-
-					Variables.Commands[currentCommandIndex] = abstractCommand;
-					await abstractCommand.PublishAutoDiscoveryConfigAsync();
-					await abstractCommand.PublishStateAsync(false);
-
-					Log.Information("[COMMANDS] Modified command: {command}", abstractCommand.Name);
-				}
-
-				await Variables.MqttManager.AnnounceAvailabilityAsync();
-				StoredCommands.Store();
-
-				return true;
-			}
-			catch (Exception ex)
-			{
-				Log.Fatal(ex, "[COMMANDSMANAGER] Error while storing: {err}", ex.Message);
-
-				return false;
-			}
-			finally
-			{
-				Unpause();
-			}
-		}
-
-		private static bool CommandsPresent() => Variables.Commands != null && Variables.Commands.Any();
-
-		/// <summary>
-		/// Returns default information for the specified command type, or null if not found
-		/// </summary>
-		/// <param name="type"></param>
-		/// <returns></returns>
-		internal static CommandInfoCard GetCommandDefaultInfo(CommandType type)
-		{
-			return CommandInfoCards.ContainsKey(type) ? CommandInfoCards[type] : null;
-		}
-
-		/// <summary>
-		/// Loads info regarding the various command types
-		/// </summary>
-		internal static void LoadCommandInfo()
-		{
-			// =================================
-
-			var commandInfoCard = new CommandInfoCard(CommandType.CustomCommand,
-				Languages.CommandsManager_CustomCommandDescription,
-				true, true, true);
-
-			CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
-
-			// =================================
-
-			commandInfoCard = new CommandInfoCard(CommandType.CustomExecutorCommand,
-				Languages.CommandsManager_CustomExecutorCommandDescription,
-				true, true, true);
-
-			CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
-
-			// =================================
-
-			commandInfoCard = new CommandInfoCard(CommandType.HibernateCommand,
-				Languages.CommandsManager_HibernateCommandDescription,
-				true, true, false);
-
-			CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
-
-			// =================================
-
-			commandInfoCard = new CommandInfoCard(CommandType.KeyCommand,
-				Languages.CommandsManager_KeyCommandDescription,
-				true, false, false);
+    /// <summary>
+    /// Continuously performs command autodiscovery and state publishing
+    /// </summary>
+    internal static class CommandsManager
+    {
+        internal static readonly Dictionary<CommandType, CommandInfoCard> CommandInfoCards = new();
+
+        private static bool _active = true;
+        private static bool _pause;
+
+        private static DateTime _lastAutoDiscoPublish = DateTime.MinValue;
+
+        /// <summary>
+        /// Initializes the command manager
+        /// </summary>
+        internal static async void Initialize()
+        {
+            if (!Variables.AppSettings.MqttEnabled)
+            {
+                Variables.MainForm?.SetCommandsStatus(ComponentStatus.Stopped);
+
+                return;
+            }
+
+            while (Variables.MqttManager.GetStatus() == MqttStatus.Connecting)
+                await Task.Delay(250);
+
+            _ = Task.Run(Process);
+        }
+
+        /// <summary>
+        /// Stop processing commands
+        /// </summary>
+        internal static void Stop() => _active = false;
+
+        /// <summary>
+        /// Pause processing commands
+        /// </summary>
+        internal static void Pause() => _pause = true;
+
+        /// <summary>
+        /// Resume processing commands
+        /// </summary>
+        internal static void Unpause() => _pause = false;
+
+        /// <summary>
+        /// Unpublishes all commands
+        /// </summary>
+        /// <returns></returns>
+        internal static async Task UnpublishAllCommands()
+        {
+            if (!CommandsPresent())
+                return;
+
+            foreach (var command in Variables.Commands)
+            {
+                await command.UnPublishAutoDiscoveryConfigAsync();
+                await Variables.MqttManager.UnsubscribeAsync(command);
+            }
+        }
+
+        /// <summary>
+        /// Generates new ID's for all commands
+        /// </summary>
+        internal static void ResetCommandIds()
+        {
+            if (!CommandsPresent())
+                return;
+
+            foreach (var command in Variables.Commands)
+                command.Id = Guid.NewGuid().ToString();
+
+            StoredCommands.Store();
+        }
+
+        /// <summary>
+        /// Continuously processes commands (autodiscovery, state)
+        /// </summary>
+        private static async void Process()
+        {
+            var firstRun = true;
+            var subscribed = false;
+
+            while (_active)
+            {
+                try
+                {
+                    // on the first run, just wait 1 sec - this is to make sure we're announcing ourselves,
+                    // when there are no sensors or when the sensor manager's still initialising
+                    await Task.Delay(firstRun ? TimeSpan.FromSeconds(1) : TimeSpan.FromMilliseconds(750));
+
+                    if (_pause || Variables.MqttManager.GetStatus() != MqttStatus.Connected || !CommandsPresent())
+                        continue;
+
+                    firstRun = false;
+
+                    if ((DateTime.Now - _lastAutoDiscoPublish).TotalSeconds > 30)
+                    {
+                        await Variables.MqttManager.AnnounceAvailabilityAsync();
+
+                        foreach (var command in Variables.Commands
+                            .TakeWhile(_ => !_pause)
+                            .TakeWhile(_ => _active))
+                        {
+                            if (_pause || Variables.MqttManager.GetStatus() != MqttStatus.Connected)
+                                continue;
+
+                            await command.PublishAutoDiscoveryConfigAsync();
+                        }
+
+                        if (!subscribed)
+                        {
+                            foreach (var command in Variables.Commands
+                                .TakeWhile(_ => !_pause)
+                                .TakeWhile(_ => _active))
+                            {
+                                if (_pause || Variables.MqttManager.GetStatus() != MqttStatus.Connected)
+                                    continue;
+
+                                await Variables.MqttManager.SubscribeAsync(command);
+                            }
+
+                            subscribed = true;
+                        }
+
+                        _lastAutoDiscoPublish = DateTime.Now;
+                    }
+
+                    // publish command states (they have their own time-based scheduling)
+                    foreach (var command in Variables.Commands
+                        .TakeWhile(_ => !_pause)
+                        .TakeWhile(_ => _active))
+                    {
+                        if (_pause || Variables.MqttManager.GetStatus() != MqttStatus.Connected)
+                            continue;
+
+                        await command.PublishStateAsync();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Log.Fatal(ex, "[COMMANDSMANAGER] Error while publishing: {err}", ex.Message);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Looks for the command by name, and executes it
+        /// </summary>
+        /// <param name="name"></param>
+        internal static void ExecuteCommandByName(string name)
+        {
+            try
+            {
+                if (!CommandsPresent())
+                {
+                    Log.Warning("[COMMANDSMANAGER] [{command}] No commands configured, unable to execute", name);
+
+                    return;
+                }
+
+                if (Variables.Commands.All(x => x.Name != name))
+                {
+                    Log.Warning("[COMMANDSMANAGER] [{command}] Command not found, unable to execute", name);
+
+                    return;
+                }
+
+                var command = Variables.Commands.First(x => x.Name == name);
+                command.TurnOn();
+            }
+            catch (Exception ex)
+            {
+                Log.Fatal(ex, "[COMMANDSMANAGER] [{command}] Error while executing: {err}", name, ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Stores the provided commands, and (re)publishes them
+        /// </summary>
+        /// <param name="commands"></param>
+        /// <param name="toBeDeletedCommands"></param>
+        /// <returns></returns>
+        internal static async Task<bool> StoreAsync(List<ConfiguredCommand> commands, List<ConfiguredCommand> toBeDeletedCommands = null)
+        {
+            toBeDeletedCommands ??= new List<ConfiguredCommand>();
+
+            try
+            {
+                Pause();
+
+                if (toBeDeletedCommands.Any())
+                {
+                    foreach (var abstractCommand in toBeDeletedCommands
+                        .Select(StoredCommands.ConvertConfiguredToAbstract)
+                        .Where(abstractCommand => abstractCommand != null))
+                    {
+                        var commandIndex = Variables.Commands.FindIndex(x => x.Id == abstractCommand.Id);
+                        if (commandIndex != -1)
+                        {
+                            await abstractCommand.UnPublishAutoDiscoveryConfigAsync();
+                            await Variables.MqttManager.UnsubscribeAsync(abstractCommand);
+                            Variables.Commands.RemoveAt(commandIndex);
+
+                            Log.Information("[COMMANDS] Removed command: {command}", abstractCommand.Name);
+                        }
+                        else
+                        {
+                            Log.Information("[COMMANDS] Command not removed, not activated: {command}", abstractCommand.Name);
+                        }
+                    }
+                }
+
+                // copy our list to the main one
+                foreach (var abstractCommand in commands
+                    .Select(StoredCommands.ConvertConfiguredToAbstract)
+                    .Where(abstractCommand => abstractCommand != null))
+                {
+                    // new, add and register
+                    if (Variables.Commands.All(x => x.Id != abstractCommand.Id))
+                    {
+                        Variables.Commands.Add(abstractCommand);
+                        await Variables.MqttManager.SubscribeAsync(abstractCommand);
+                        await abstractCommand.PublishAutoDiscoveryConfigAsync();
+                        await abstractCommand.PublishStateAsync(false);
+
+                        Log.Information("[COMMANDS] Added command: {command}", abstractCommand.Name);
+                        continue;
+                    }
+
+                    // existing, update and re-register
+                    var currentCommandIndex = Variables.Commands.FindIndex(x => x.Id == abstractCommand.Id);
+                    if (Variables.Commands[currentCommandIndex].Name != abstractCommand.Name || Variables.Commands[currentCommandIndex].EntityType != abstractCommand.EntityType)
+                    {
+                        Log.Information("[COMMANDS] Command changed, re-registering as new entity: {old} to {new}", Variables.Commands[currentCommandIndex].Name, abstractCommand.Name);
+
+                        await Variables.Commands[currentCommandIndex].UnPublishAutoDiscoveryConfigAsync();
+                        await Variables.MqttManager.UnsubscribeAsync(Variables.Commands[currentCommandIndex]);
+                        await Variables.MqttManager.SubscribeAsync(abstractCommand);
+                    }
+
+                    Variables.Commands[currentCommandIndex] = abstractCommand;
+                    await abstractCommand.PublishAutoDiscoveryConfigAsync();
+                    await abstractCommand.PublishStateAsync(false);
+
+                    Log.Information("[COMMANDS] Modified command: {command}", abstractCommand.Name);
+                }
+
+                await Variables.MqttManager.AnnounceAvailabilityAsync();
+                StoredCommands.Store();
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Log.Fatal(ex, "[COMMANDSMANAGER] Error while storing: {err}", ex.Message);
+
+                return false;
+            }
+            finally
+            {
+                Unpause();
+            }
+        }
+
+        private static bool CommandsPresent() => Variables.Commands != null && Variables.Commands.Any();
+
+        /// <summary>
+        /// Returns default information for the specified command type, or null if not found
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        internal static CommandInfoCard GetCommandDefaultInfo(CommandType type)
+        {
+            return CommandInfoCards.ContainsKey(type) ? CommandInfoCards[type] : null;
+        }
+
+        /// <summary>
+        /// Loads info regarding the various command types
+        /// </summary>
+        internal static void LoadCommandInfo()
+        {
+            // =================================
+
+            var commandInfoCard = new CommandInfoCard(CommandType.CustomCommand,
+                Languages.CommandsManager_CustomCommandDescription,
+                true, true, true);
+
+            CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
+
+            // =================================
+
+            commandInfoCard = new CommandInfoCard(CommandType.CustomExecutorCommand,
+                Languages.CommandsManager_CustomExecutorCommandDescription,
+                true, true, true);
+
+            CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
+
+            // =================================
+
+            commandInfoCard = new CommandInfoCard(CommandType.HibernateCommand,
+                Languages.CommandsManager_HibernateCommandDescription,
+                true, true, false);
+
+            CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
+
+            // =================================
+
+            commandInfoCard = new CommandInfoCard(CommandType.KeyCommand,
+                Languages.CommandsManager_KeyCommandDescription,
+                true, false, false);
+
+            CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
+
+            // =================================
+
+            commandInfoCard = new CommandInfoCard(CommandType.LaunchUrlCommand,
+                Languages.CommandsManager_LaunchUrlCommandDescription,
+                true, false, true);
+
+            CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
+
+            // =================================
+
+            commandInfoCard = new CommandInfoCard(CommandType.LockCommand,
+                Languages.CommandsManager_LockCommandDescription,
+                true, false, false);
 
-			CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
+            CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
 
-			// =================================
+            // =================================
 
-			commandInfoCard = new CommandInfoCard(CommandType.LaunchUrlCommand,
-				Languages.CommandsManager_LaunchUrlCommandDescription,
-				true, false, true);
+            commandInfoCard = new CommandInfoCard(CommandType.LogOffCommand,
+                Languages.CommandsManager_LogOffCommandDescription,
+                true, false, false);
 
-			CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
+            CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
 
-			// =================================
+            // =================================
 
-			commandInfoCard = new CommandInfoCard(CommandType.LockCommand,
-				Languages.CommandsManager_LockCommandDescription,
-				true, false, false);
+            commandInfoCard = new CommandInfoCard(CommandType.MediaMuteCommand,
+                Languages.CommandsManager_MediaMuteCommandDescription,
+                true, false, false);
 
-			CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
+            CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
 
-			// =================================
+            // =================================
 
-			commandInfoCard = new CommandInfoCard(CommandType.LogOffCommand,
-				Languages.CommandsManager_LogOffCommandDescription,
-				true, false, false);
+            commandInfoCard = new CommandInfoCard(CommandType.MediaNextCommand,
+                Languages.CommandsManager_MediaNextCommandDescription,
+                true, false, false);
 
-			CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
+            CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
 
-			// =================================
+            // =================================
 
-			commandInfoCard = new CommandInfoCard(CommandType.MediaMuteCommand,
-				Languages.CommandsManager_MediaMuteCommandDescription,
-				true, false, false);
+            commandInfoCard = new CommandInfoCard(CommandType.MediaPlayPauseCommand,
+                Languages.CommandsManager_MediaPlayPauseCommandDescription,
+                true, false, false);
 
-			CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
+            CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
 
-			// =================================
+            // =================================
 
-			commandInfoCard = new CommandInfoCard(CommandType.MediaNextCommand,
-				Languages.CommandsManager_MediaNextCommandDescription,
-				true, false, false);
+            commandInfoCard = new CommandInfoCard(CommandType.MediaPreviousCommand,
+                Languages.CommandsManager_MediaPreviousCommandDescription,
+                true, false, false);
 
-			CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
+            CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
 
-			// =================================
+            // =================================
 
-			commandInfoCard = new CommandInfoCard(CommandType.MediaPlayPauseCommand,
-				Languages.CommandsManager_MediaPlayPauseCommandDescription,
-				true, false, false);
+            commandInfoCard = new CommandInfoCard(CommandType.MediaVolumeDownCommand,
+                Languages.CommandsManager_MediaVolumeDownCommandDescription,
+                true, false, false);
 
-			CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
+            CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
 
-			// =================================
+            // =================================
 
-			commandInfoCard = new CommandInfoCard(CommandType.MediaPreviousCommand,
-				Languages.CommandsManager_MediaPreviousCommandDescription,
-				true, false, false);
+            commandInfoCard = new CommandInfoCard(CommandType.MediaVolumeUpCommand,
+                Languages.CommandsManager_MediaVolumeUpCommandDescription,
+                true, false, false);
 
-			CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
+            CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
 
-			// =================================
+            // =================================
 
-			commandInfoCard = new CommandInfoCard(CommandType.MediaVolumeDownCommand,
-				Languages.CommandsManager_MediaVolumeDownCommandDescription,
-				true, false, false);
+            commandInfoCard = new CommandInfoCard(CommandType.MonitorSleepCommand,
+                Languages.CommandsManager_MonitorSleepCommandDescription,
+                true, false, false);
 
-			CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
+            CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
 
-			// =================================
+            // =================================
 
-			commandInfoCard = new CommandInfoCard(CommandType.MediaVolumeUpCommand,
-				Languages.CommandsManager_MediaVolumeUpCommandDescription,
-				true, false, false);
+            commandInfoCard = new CommandInfoCard(CommandType.MonitorWakeCommand,
+                Languages.CommandsManager_MonitorWakeCommandDescription,
+                true, false, false);
 
-			CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
+            CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
 
-			// =================================
+            // =================================
 
-			commandInfoCard = new CommandInfoCard(CommandType.MonitorSleepCommand,
-				Languages.CommandsManager_MonitorSleepCommandDescription,
-				true, false, false);
+            commandInfoCard = new CommandInfoCard(CommandType.MultipleKeysCommand,
+                Languages.CommandsManager_MultipleKeysCommandDescription,
+                true, false, false);
 
-			CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
+            CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
 
-			// =================================
+            // =================================
 
-			commandInfoCard = new CommandInfoCard(CommandType.MonitorWakeCommand,
-				Languages.CommandsManager_MonitorWakeCommandDescription,
-				true, false, false);
+            commandInfoCard = new CommandInfoCard(CommandType.PowershellCommand,
+                Languages.CommandsManager_PowershellCommandDescription,
+                true, true, true);
 
-			CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
+            CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
 
-			// =================================
+            // =================================
 
-			commandInfoCard = new CommandInfoCard(CommandType.MultipleKeysCommand,
-				Languages.CommandsManager_MultipleKeysCommandDescription,
-				true, false, false);
+            commandInfoCard = new CommandInfoCard(CommandType.PublishAllSensorsCommand,
+                Languages.CommandsManager_PublishAllSensorsCommandDescription,
+                true, true, false);
 
-			CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
+            CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
 
-			// =================================
+            // =================================
 
-			commandInfoCard = new CommandInfoCard(CommandType.PowershellCommand,
-				Languages.CommandsManager_PowershellCommandDescription,
-				true, true, true);
+            commandInfoCard = new CommandInfoCard(CommandType.RestartCommand,
+                Languages.CommandsManager_RestartCommandDescription,
+                true, true, false);
 
-			CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
+            CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
 
-			// =================================
+            // =================================
 
-			commandInfoCard = new CommandInfoCard(CommandType.PublishAllSensorsCommand,
-				Languages.CommandsManager_PublishAllSensorsCommandDescription,
-				true, true, false);
+            commandInfoCard = new CommandInfoCard(CommandType.SendWindowToFrontCommand,
+                Languages.CommandsManager_CommandsManager_SendWindowToFrontCommandDescription,
+                true, false, true);
 
-			CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
+            CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
 
-			// =================================
-
-			commandInfoCard = new CommandInfoCard(CommandType.RestartCommand,
-				Languages.CommandsManager_RestartCommandDescription,
-				true, true, false);
-
-			CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
-
-			// =================================
-
-			commandInfoCard = new CommandInfoCard(CommandType.SendWindowToFrontCommand,
-				Languages.CommandsManager_CommandsManager_SendWindowToFrontCommandDescription,
-				true, false, true);
-
-			CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
-
-			// =================================
+            // =================================
 
             commandInfoCard = new CommandInfoCard(CommandType.SwitchDesktopCommand,
                 Languages.CommandsManager_SwitchDesktopCommandDescription,
@@ -455,39 +463,39 @@ namespace HASS.Agent.Commands
                 Languages.CommandsManager_SetVolumeCommandDescription,
                 true, true, true);
 
-			CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
+            CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
 
-			// =================================
+            // =================================
 
-			commandInfoCard = new CommandInfoCard(CommandType.ShutdownCommand,
-				Languages.CommandsManager_ShutdownCommandDescription,
-				true, true, false);
+            commandInfoCard = new CommandInfoCard(CommandType.ShutdownCommand,
+                Languages.CommandsManager_ShutdownCommandDescription,
+                true, true, false);
 
-			CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
+            CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
 
-			// =================================
+            // =================================
 
-			commandInfoCard = new CommandInfoCard(CommandType.SleepCommand,
-				Languages.CommandsManager_SleepCommandDescription,
-				true, true, false);
+            commandInfoCard = new CommandInfoCard(CommandType.SleepCommand,
+                Languages.CommandsManager_SleepCommandDescription,
+                true, true, false);
 
-			CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
+            CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
 
-			// =================================
+            // =================================
 
-			commandInfoCard = new CommandInfoCard(CommandType.WebViewCommand,
-				Languages.CommandsManager_WebViewCommandDescription,
-				true, false, true);
+            commandInfoCard = new CommandInfoCard(CommandType.WebViewCommand,
+                Languages.CommandsManager_WebViewCommandDescription,
+                true, false, true);
 
-			CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
+            CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
 
-			// =================================
+            // =================================
 
-			commandInfoCard = new CommandInfoCard(CommandType.RadioCommand,
-				Languages.CommandsManager_RadioCommandDescription,
-				true, false, true);
+            commandInfoCard = new CommandInfoCard(CommandType.RadioCommand,
+                Languages.CommandsManager_RadioCommandDescription,
+                true, false, true);
 
-			CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
-		}
-	}
+            CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
+        }
+    }
 }

--- a/src/HASS.Agent/HASS.Agent/Compatibility/MigrateCompatibilityTask.cs
+++ b/src/HASS.Agent/HASS.Agent/Compatibility/MigrateCompatibilityTask.cs
@@ -53,7 +53,10 @@ namespace HASS.Agent.Compatibility
             Directory.CreateDirectory(destination);
 
             foreach (var file in oldConfigFiles)
+            {
+                Log.Information("[COMPATTASK] Migrating {fn}", file.FullName);
                 file.CopyTo(Path.Combine(destination, file.Name), true);
+            }
 
             Log.Information("[COMPATTASK] Configuration migrated");
         }
@@ -73,8 +76,8 @@ namespace HASS.Agent.Compatibility
 
             MigrateConfig(oldServiceInstallationPath, configPath);
 
-            MigrateSensors(Path.Combine(configPath, Variables.SensorsFile));
-            MigrateCommands(Path.Combine(configPath, Variables.CommandsFile));
+            MigrateSensors(Path.Combine(configPath, Path.GetFileName(Variables.SensorsFile)));
+            MigrateCommands(Path.Combine(configPath, Path.GetFileName(Variables.CommandsFile)));
 
             Log.Information("[COMPATTASK] Service configuration migration end");
         }
@@ -166,7 +169,7 @@ namespace HASS.Agent.Compatibility
             {
                 if (!File.Exists(sensorsFile))
                 {
-                    Log.Warning("[COMPATTASK] Sensors configuration file does not exit");
+                    Log.Warning("[COMPATTASK] Sensors configuration file '{sf}' does not exit", sensorsFile);
                     return;
                 }
 
@@ -222,7 +225,7 @@ namespace HASS.Agent.Compatibility
             {
                 if (!File.Exists(commandsFile))
                 {
-                    Log.Warning("[COMPATTASK] Commands configuration file does not exit");
+                    Log.Warning("[COMPATTASK] Commands configuration file '{cf}' does not exit", commandsFile);
                     return;
                 }
 

--- a/src/HASS.Agent/HASS.Agent/Compatibility/NameCompatibilityTask.cs
+++ b/src/HASS.Agent/HASS.Agent/Compatibility/NameCompatibilityTask.cs
@@ -33,21 +33,21 @@ namespace HASS.Agent.Compatibility
                     ? StoredSensors.ConvertAbstractSingleValueToConfigured(sensor as AbstractSingleValueSensor)
                     : StoredSensors.ConvertAbstractMultiValueToConfigured(sensor as AbstractMultiValueSensor);
 
-                if (!sensor.Name.Contains(SharedHelperFunctions.GetSafeConfiguredDeviceName()))
+                if (!sensor.EntityName.Contains(SharedHelperFunctions.GetSafeConfiguredDeviceName()))
                 {
                     configuredSensors.Add(currentConfiguredSensor);
                     continue;
                 }
 
-                var newName = sensor.Name.Replace($"{SharedHelperFunctions.GetSafeConfiguredDeviceName()}_", "");
+                var newName = sensor.EntityName.Replace($"{SharedHelperFunctions.GetSafeConfiguredDeviceName()}_", "");
                 var objectId = $"{SharedHelperFunctions.GetSafeConfiguredDeviceName()}_{newName}";
-                if (objectId == sensor.Name)
+                if (objectId == sensor.EntityName)
                 {
                     var newConfiguredSensor = sensor is AbstractSingleValueSensor
                     ? StoredSensors.ConvertAbstractSingleValueToConfigured(sensor as AbstractSingleValueSensor)
                     : StoredSensors.ConvertAbstractMultiValueToConfigured(sensor as AbstractMultiValueSensor);
 
-                    newConfiguredSensor.Name = newName;
+                    newConfiguredSensor.EntityName = newName;
                     configuredSensors.Add(newConfiguredSensor);
 
                     toBeDeletedSensors.Add(currentConfiguredSensor);
@@ -70,18 +70,18 @@ namespace HASS.Agent.Compatibility
             {
                 var currentConfiguredCommand = StoredCommands.ConvertAbstractToConfigured(command);
 
-                if (!command.Name.Contains(SharedHelperFunctions.GetSafeConfiguredDeviceName()))
+                if (!command.EntityName.Contains(SharedHelperFunctions.GetSafeConfiguredDeviceName()))
                 {
                     configuredCommands.Add(currentConfiguredCommand);
                     continue;
                 }
 
-                var newName = command.Name.Replace($"{SharedHelperFunctions.GetSafeConfiguredDeviceName()}_", "");
+                var newName = command.EntityName.Replace($"{SharedHelperFunctions.GetSafeConfiguredDeviceName()}_", "");
                 var objectId = $"{SharedHelperFunctions.GetSafeConfiguredDeviceName()}_{newName}";
-                if (objectId == command.Name)
+                if (objectId == command.EntityName)
                 {
                     var newConfiguredCommand = StoredCommands.ConvertAbstractToConfigured(command);
-                    newConfiguredCommand.Name = newName;
+                    newConfiguredCommand.EntityName = newName;
                     configuredCommands.Add(newConfiguredCommand);
 
                     toBeDeletedCommands.Add(currentConfiguredCommand);

--- a/src/HASS.Agent/HASS.Agent/Compatibility/NameCompatibilityTask.cs
+++ b/src/HASS.Agent/HASS.Agent/Compatibility/NameCompatibilityTask.cs
@@ -1,12 +1,17 @@
 ﻿using HASS.Agent.Commands;
+using HASS.Agent.Extensions;
+using HASS.Agent.Managers;
 using HASS.Agent.MQTT;
 using HASS.Agent.Resources.Localization;
 using HASS.Agent.Sensors;
+using HASS.Agent.Service;
 using HASS.Agent.Settings;
 using HASS.Agent.Shared;
 using HASS.Agent.Shared.Functions;
 using HASS.Agent.Shared.Models.Config;
 using HASS.Agent.Shared.Models.HomeAssistant;
+using HidSharp.Utility;
+using LibreHardwareMonitor.Hardware;
 using Octokit;
 using Serilog;
 using System;
@@ -22,7 +27,7 @@ namespace HASS.Agent.Compatibility
     {
         public string Name => Languages.Compat_NameTask_Name;
 
-        private (List<ConfiguredSensor>, List<ConfiguredSensor>) ConvertSensors(IEnumerable<AbstractDiscoverable> sensors)
+        private (List<ConfiguredSensor>, List<ConfiguredSensor>) ConvertClientSensors(IEnumerable<AbstractDiscoverable> sensors)
         {
             var configuredSensors = new List<ConfiguredSensor>();
             var toBeDeletedSensors = new List<ConfiguredSensor>();
@@ -64,7 +69,7 @@ namespace HASS.Agent.Compatibility
             return (configuredSensors, toBeDeletedSensors);
         }
 
-        private (List<ConfiguredCommand>, List<ConfiguredCommand>) ConvertCommands(List<AbstractCommand> commands)
+        private (List<ConfiguredCommand>, List<ConfiguredCommand>) ConvertClientCommands(List<AbstractCommand> commands)
         {
             var configuredCommands = new List<ConfiguredCommand>();
             var toBeDeletedCommands = new List<ConfiguredCommand>();
@@ -101,64 +106,180 @@ namespace HASS.Agent.Compatibility
             return (configuredCommands, toBeDeletedCommands);
         }
 
+        private async Task<string> ConvertClient()
+        {
+            var errorMessage = string.Empty;
+
+            AgentSharedBase.Initialize(Variables.AppSettings.DeviceName, Variables.MqttManager, Variables.AppSettings.CustomExecutorBinary);
+
+            await SettingsManager.LoadEntitiesAsync();
+            Variables.MqttManager.Initialize();
+
+            while (!Variables.MqttManager.IsConnected())
+                await Task.Delay(1000);
+
+            SensorsManager.Initialize();
+            SensorsManager.Pause();
+            CommandsManager.Initialize();
+            CommandsManager.Pause();
+
+            Log.Information("[COMPATTASK] Client: modifying stored single value sensors");
+            var (sensors, toBeDeletedSensors) = ConvertClientSensors(Variables.SingleValueSensors);
+            var result = await SensorsManager.StoreAsync(sensors, toBeDeletedSensors);
+            SensorsManager.Pause();
+            if (!result)
+            {
+                Log.Error("[COMPATTASK] Client: error modifying stored single value sensors");
+                errorMessage += Languages.Compat_NameTask_Error_SingleValueSensors;
+            }
+
+            Log.Information("[COMPATTASK] Client: modifying stored multi value sensors");
+            (sensors, toBeDeletedSensors) = ConvertClientSensors(Variables.MultiValueSensors);
+            result = await SensorsManager.StoreAsync(sensors, toBeDeletedSensors);
+            SensorsManager.Pause();
+            if (!result)
+            {
+                Log.Error("[COMPATTASK] Client: error modifying stored multi value sensors");
+                errorMessage += Languages.Compat_NameTask_Error_MultiValueSensors;
+            }
+
+            Log.Information("[COMPATTASK] Client: modifying stored commands");
+            var (commands, toBeDeletedCommands) = ConvertClientCommands(Variables.Commands);
+            result = await CommandsManager.StoreAsync(commands, toBeDeletedCommands);
+            CommandsManager.Pause();
+            if (!result)
+            {
+                Log.Error("[COMPATTASK] Client: error modifying stored commands");
+                errorMessage += Languages.Compat_NameTask_Error_Commands;
+            }
+
+            return errorMessage;
+        }
+
+        private List<ConfiguredSensor> ConvertServiceSensors(IEnumerable<ConfiguredSensor> sensors, string safeServiceDeviceName)
+        {
+            var newServiceConfiguredSensors = new List<ConfiguredSensor>();
+            foreach (var sensor in sensors)
+            {
+                if (!sensor.EntityName.Contains(safeServiceDeviceName)
+                 && !sensor.Name.Contains(safeServiceDeviceName))
+                {
+                    newServiceConfiguredSensors.Add(sensor);
+                    continue;
+                }
+
+                var newEntityName = sensor.EntityName.Replace($"{safeServiceDeviceName}_", "");
+                var newName = sensor.Name.Replace($"{safeServiceDeviceName}_", "");
+                var objectId = $"{safeServiceDeviceName}_{newName}";
+                if (objectId == sensor.EntityName)
+                {
+                    sensor.EntityName = newEntityName;
+                    sensor.Name = newName;
+                }
+
+                newServiceConfiguredSensors.Add(sensor);
+            }
+
+            return newServiceConfiguredSensors;
+        }
+
+        private List<ConfiguredCommand> ConvertServiceCommands(IEnumerable<ConfiguredCommand> commands, string safeServiceDeviceName)
+        {
+            var newServiceConfiguredCommands = new List<ConfiguredCommand>();
+            foreach (var command in commands)
+            {
+                if (!command.EntityName.Contains(safeServiceDeviceName)
+                 && !command.Name.Contains(safeServiceDeviceName))
+                {
+                    newServiceConfiguredCommands.Add(command);
+                    continue;
+                }
+
+                var newEntityName = command.EntityName.Replace($"{safeServiceDeviceName}_", "");
+                var newName = command.Name.Replace($"{safeServiceDeviceName}_", "");
+                var objectId = $"{safeServiceDeviceName}_{newName}";
+                if (objectId == command.EntityName)
+                {
+                    command.EntityName = newEntityName;
+                    command.Name = newName;
+                }
+
+                newServiceConfiguredCommands.Add(command);
+            }
+
+            return newServiceConfiguredCommands;
+        }
+
+        private async Task<string> ConvertService()
+        {
+            var errorMessage = string.Empty;
+
+            ServiceManager.Initialize();
+            if (ServiceControllerManager.GetServiceState() != System.ServiceProcess.ServiceControllerStatus.Running)
+            {
+                Log.Information("[COMPATTASK] Service: not running, attempting start");
+                await ServiceControllerManager.StartServiceAsync();
+            }
+
+            if (ServiceControllerManager.GetServiceState() != System.ServiceProcess.ServiceControllerStatus.Running)
+            {
+                Log.Error("[COMPATTASK] Service: cannot be started, service entities not parsed");
+                errorMessage += Languages.Compat_NameTask_Error_ServiceStart;
+                return errorMessage;
+            }
+
+            var (serviceDeviceNameOk, serviceDeviceName, _) = await Variables.RpcClient.GetDeviceNameAsync().WaitAsync(Variables.RpcConnectionTimeout);
+            var (serviceCommandsOk, serviceConfiguredCommands, _) = await Variables.RpcClient.GetConfiguredCommandsAsync().WaitAsync(Variables.RpcConnectionTimeout);
+            var (serviceSensorsOk, serviceConfiguredSensors, _) = await Variables.RpcClient.GetConfiguredSensorsAsync().WaitAsync(Variables.RpcConnectionTimeout);
+            if (!serviceDeviceNameOk || !serviceCommandsOk || !serviceSensorsOk)
+            {
+                Log.Warning("[COMPATTASK] Service: error communicating with service");
+                errorMessage += Languages.Compat_NameTask_Error_ServiceCommunication;
+                return errorMessage;
+            }
+
+            var safeServiceDeviceName = SharedHelperFunctions.GetSafeValue(serviceDeviceName);
+
+            Log.Information("[COMPATTASK] Service: modifying stored sensors");
+            var newServiceConfiguredSensors = ConvertServiceSensors(serviceConfiguredSensors, safeServiceDeviceName);
+            var (storedServiceSensorsOk, storedServiceSensorsError) = await Variables.RpcClient.SetConfiguredSensorsAsync(newServiceConfiguredSensors).WaitAsync(Variables.RpcConnectionTimeout);
+            if (!storedServiceSensorsOk)
+            {
+                Log.Error("[COMPATTASK] Service: error modifying stored sensors: {msg}", storedServiceSensorsError);
+                errorMessage += Languages.Compat_NameTask_Error_SingleValueSensors;
+                return errorMessage;
+            }
+
+            Log.Information("[COMPATTASK] Service: modifying stored commands");
+            var newServiceConfiguredCommands = ConvertServiceCommands(serviceConfiguredCommands, safeServiceDeviceName);
+            var (storedServiceCommandsOk, storedServiceCommandsError) = await Variables.RpcClient.SetConfiguredCommandsAsync(newServiceConfiguredCommands).WaitAsync(Variables.RpcConnectionTimeout);
+            if (!storedServiceCommandsOk)
+            {
+                Log.Error("[COMPATTASK] Service: error modifying stored commands: {msg}", storedServiceCommandsError);
+                errorMessage += Languages.Compat_NameTask_Error_Commands;
+                return errorMessage;
+            }
+
+            return errorMessage;
+        }
+
         public async Task<(bool, string)> Perform()
         {
             try
             {
+                Log.Information("[COMPATTASK] Entity name compatibility task started");
+
                 var errorMessage = string.Empty;
+                errorMessage += await ConvertClient();
+                errorMessage += await ConvertService();
 
-                Log.Information("[COMPATTASK] Sensor name compatibility task started");
-
-                AgentSharedBase.Initialize(Variables.AppSettings.DeviceName, Variables.MqttManager, Variables.AppSettings.CustomExecutorBinary);
-
-                await SettingsManager.LoadEntitiesAsync();
-                Variables.MqttManager.Initialize();
-
-                while (!Variables.MqttManager.IsConnected())
-                    await Task.Delay(1000);
-
-                SensorsManager.Initialize();
-                SensorsManager.Pause();
-                CommandsManager.Initialize();
-                CommandsManager.Pause();
-
-                Log.Information("[COMPATTASK] Modifying stored single value sensors");
-                var (sensors, toBeDeletedSensors) = ConvertSensors(Variables.SingleValueSensors);
-                var result = await SensorsManager.StoreAsync(sensors, toBeDeletedSensors);
-                SensorsManager.Pause();
-                if (!result)
-                {
-                    Log.Error("[COMPATTASK] Error modifying stored single value sensors");
-                    errorMessage += Languages.Compat_NameTask_Error_SingleValueSensors;
-                }
-
-                Log.Information("[COMPATTASK] Modifying stored multi value sensors");
-                (sensors, toBeDeletedSensors) = ConvertSensors(Variables.MultiValueSensors);
-                result = await SensorsManager.StoreAsync(sensors, toBeDeletedSensors);
-                SensorsManager.Pause();
-                if (!result)
-                {
-                    Log.Error("[COMPATTASK] Error modifying stored multi value sensors");
-                    errorMessage += Languages.Compat_NameTask_Error_MultiValueSensors;
-                }
-
-                Log.Information("[COMPATTASK] Modifying stored commands");
-                var (commands, toBeDeletedCommands) = ConvertCommands(Variables.Commands);
-                result = await CommandsManager.StoreAsync(commands, toBeDeletedCommands);
-                CommandsManager.Pause();
-                if (!result)
-                {
-                    Log.Error("[COMPATTASK] Error modifying stored commands");
-                    errorMessage += Languages.Compat_NameTask_Error_Commands;
-                }
-
-                Log.Information("[COMPATTASK] Sensor name compatibility task ended");
+                Log.Information("[COMPATTASK] Entity name compatibility task ended");
 
                 return string.IsNullOrWhiteSpace(errorMessage) ? (true, string.Empty) : (false, errorMessage);
             }
             catch (Exception ex)
             {
-                Log.Fatal(ex, "[COMPATTASK] Error performing sensor name compatibility task: {err}", ex.Message);
+                Log.Fatal(ex, "[COMPATTASK] Error performing entity name compatibility task: {err}", ex.Message);
                 return (false, Languages.Compat_Error_CheckLogs);
             }
         }

--- a/src/HASS.Agent/HASS.Agent/Compatibility/NameCompatibilityTask.cs
+++ b/src/HASS.Agent/HASS.Agent/Compatibility/NameCompatibilityTask.cs
@@ -33,13 +33,15 @@ namespace HASS.Agent.Compatibility
                     ? StoredSensors.ConvertAbstractSingleValueToConfigured(sensor as AbstractSingleValueSensor)
                     : StoredSensors.ConvertAbstractMultiValueToConfigured(sensor as AbstractMultiValueSensor);
 
-                if (!sensor.EntityName.Contains(SharedHelperFunctions.GetSafeConfiguredDeviceName()))
+                if (!sensor.EntityName.Contains(SharedHelperFunctions.GetSafeConfiguredDeviceName())
+                    && !sensor.Name.Contains(SharedHelperFunctions.GetSafeConfiguredDeviceName()))
                 {
                     configuredSensors.Add(currentConfiguredSensor);
                     continue;
                 }
 
-                var newName = sensor.EntityName.Replace($"{SharedHelperFunctions.GetSafeConfiguredDeviceName()}_", "");
+                var newEntityName = sensor.EntityName.Replace($"{SharedHelperFunctions.GetSafeConfiguredDeviceName()}_", "");
+                var newName = sensor.Name.Replace($"{SharedHelperFunctions.GetSafeConfiguredDeviceName()}_", "");
                 var objectId = $"{SharedHelperFunctions.GetSafeConfiguredDeviceName()}_{newName}";
                 if (objectId == sensor.EntityName)
                 {
@@ -47,7 +49,8 @@ namespace HASS.Agent.Compatibility
                     ? StoredSensors.ConvertAbstractSingleValueToConfigured(sensor as AbstractSingleValueSensor)
                     : StoredSensors.ConvertAbstractMultiValueToConfigured(sensor as AbstractMultiValueSensor);
 
-                    newConfiguredSensor.EntityName = newName;
+                    newConfiguredSensor.EntityName = newEntityName;
+                    newConfiguredSensor.Name = newName;
                     configuredSensors.Add(newConfiguredSensor);
 
                     toBeDeletedSensors.Add(currentConfiguredSensor);
@@ -70,18 +73,21 @@ namespace HASS.Agent.Compatibility
             {
                 var currentConfiguredCommand = StoredCommands.ConvertAbstractToConfigured(command);
 
-                if (!command.EntityName.Contains(SharedHelperFunctions.GetSafeConfiguredDeviceName()))
+                if (!command.EntityName.Contains(SharedHelperFunctions.GetSafeConfiguredDeviceName())
+                    && !command.Name.Contains(SharedHelperFunctions.GetSafeConfiguredDeviceName()))
                 {
                     configuredCommands.Add(currentConfiguredCommand);
                     continue;
                 }
 
-                var newName = command.EntityName.Replace($"{SharedHelperFunctions.GetSafeConfiguredDeviceName()}_", "");
-                var objectId = $"{SharedHelperFunctions.GetSafeConfiguredDeviceName()}_{newName}";
+                var newEntityName = command.EntityName.Replace($"{SharedHelperFunctions.GetSafeConfiguredDeviceName()}_", "");
+                var newName = command.Name.Replace($"{SharedHelperFunctions.GetSafeConfiguredDeviceName()}_", "");
+                var objectId = $"{SharedHelperFunctions.GetSafeConfiguredDeviceName()}_{newEntityName}";
                 if (objectId == command.EntityName)
                 {
                     var newConfiguredCommand = StoredCommands.ConvertAbstractToConfigured(command);
-                    newConfiguredCommand.EntityName = newName;
+                    newConfiguredCommand.EntityName = newEntityName;
+                    newConfiguredCommand.Name = newName;
                     configuredCommands.Add(newConfiguredCommand);
 
                     toBeDeletedCommands.Add(currentConfiguredCommand);

--- a/src/HASS.Agent/HASS.Agent/Controls/Service/ServiceCommands.cs
+++ b/src/HASS.Agent/HASS.Agent/Controls/Service/ServiceCommands.cs
@@ -68,7 +68,7 @@ namespace HASS.Agent.Controls.Service
                 foreach (var command in _commands)
                 {
                     var lviCommand = new ListViewItem(command.Id.ToString());
-                    lviCommand.SubItems.Add(command.Name);
+                    lviCommand.SubItems.Add(command.EntityName);
                     lviCommand.SubItems.Add(CommandsManager.CommandInfoCards[command.Type].Name);
                     lviCommand.SubItems.Add(command.RunAsLowIntegrity ? "√" : string.Empty);
 

--- a/src/HASS.Agent/HASS.Agent/Controls/Service/ServiceSensors.cs
+++ b/src/HASS.Agent/HASS.Agent/Controls/Service/ServiceSensors.cs
@@ -68,7 +68,7 @@ namespace HASS.Agent.Controls.Service
                 foreach (var sensor in _sensors)
                 {
                     var lviSensor = new ListViewItem(sensor.Id.ToString());
-                    lviSensor.SubItems.Add(sensor.Name);
+                    lviSensor.SubItems.Add(sensor.EntityName);
                     lviSensor.SubItems.Add(SensorsManager.SensorInfoCards[sensor.Type].Name);
                     lviSensor.SubItems.Add(sensor.UpdateInterval.ToString());
 

--- a/src/HASS.Agent/HASS.Agent/Extensions/RpcExtensions.cs
+++ b/src/HASS.Agent/HASS.Agent/Extensions/RpcExtensions.cs
@@ -17,7 +17,9 @@ namespace HASS.Agent.Extensions
         /// <returns></returns>
         public static List<ConfiguredCommand> ConvertToConfiguredCommands(this RepeatedField<RpcConfiguredServerCommand> rpcConfiguredCommands)
         {
-            return rpcConfiguredCommands.Select(rpcConfiguredCommand => rpcConfiguredCommand.ConvertToConfiguredCommand()).ToList();
+            return rpcConfiguredCommands.Select(
+                rpcConfiguredCommand => rpcConfiguredCommand.ConvertToConfiguredCommand()
+            ).ToList();
         }
 
         /// <summary>
@@ -36,6 +38,7 @@ namespace HASS.Agent.Extensions
                 RunAsLowIntegrity = rpcConfiguredCommand.RunAsLowIntegrity,
                 EntityType = (CommandEntityType)rpcConfiguredCommand.CommandEntityType
             };
+
             return configuredCommand;
         }
 
@@ -47,7 +50,9 @@ namespace HASS.Agent.Extensions
         public static RepeatedField<RpcConfiguredServerCommand> ConvertToRpcConfiguredCommands(this List<ConfiguredCommand> configuredCommands)
         {
             var rpcConfguredCommands = new RepeatedField<RpcConfiguredServerCommand>();
-            foreach (var configuredCommand in configuredCommands) rpcConfguredCommands.Add(configuredCommand.ConvertToRpcConfiguredCommand());
+            foreach (var configuredCommand in configuredCommands)
+                rpcConfguredCommands.Add(configuredCommand.ConvertToRpcConfiguredCommand());
+            
             return rpcConfguredCommands;
         }
 
@@ -67,6 +72,7 @@ namespace HASS.Agent.Extensions
                 Name = configuredCommand.EntityName,
                 CommandEntityType = (int)configuredCommand.EntityType
             };
+
             return configuredRpcCommand;
         }
 
@@ -77,7 +83,9 @@ namespace HASS.Agent.Extensions
         /// <returns></returns>
         public static List<ConfiguredSensor> ConvertToConfiguredSensors(this RepeatedField<RpcConfiguredServerSensor> rpcConfiguredSensors)
         {
-            return rpcConfiguredSensors.Select(rpcConfiguredSensor => rpcConfiguredSensor.ConvertToConfiguredSensor()).ToList();
+            return rpcConfiguredSensors.Select(
+                rpcConfiguredSensor => rpcConfiguredSensor.ConvertToConfiguredSensor()
+            ).ToList();
         }
 
         /// <summary>
@@ -100,6 +108,7 @@ namespace HASS.Agent.Extensions
                 Instance = rpcConfiguredSensor.Instance,
                 EntityName = rpcConfiguredSensor.Name
             };
+
             return configuredSensor;
         }
 
@@ -111,7 +120,9 @@ namespace HASS.Agent.Extensions
         public static RepeatedField<RpcConfiguredServerSensor> ConvertToRpcConfiguredSensors(this List<ConfiguredSensor> configuredSensors)
         {
             var rpcConfguredSensors = new RepeatedField<RpcConfiguredServerSensor>();
-            foreach (var configuredSensor in configuredSensors) rpcConfguredSensors.Add(configuredSensor.ConvertToRpcConfiguredSensor());
+            foreach (var configuredSensor in configuredSensors)
+                rpcConfguredSensors.Add(configuredSensor.ConvertToRpcConfiguredSensor());
+            
             return rpcConfguredSensors;
         }
 
@@ -138,6 +149,7 @@ namespace HASS.Agent.Extensions
                 Name = configuredSensor.Name ?? string.Empty,
                 EntityName = configuredSensor.EntityName ?? string.Empty
             };
+
             return configuredRpcSensor;
         }
 
@@ -162,6 +174,7 @@ namespace HASS.Agent.Extensions
                 MqttClientCertificate = rpcServiceMqttSettings.MqttClientCertificate,
                 MqttClientId = rpcServiceMqttSettings.MqttClientId
             };
+
             return serviceMqttSettings;
         }
 
@@ -186,6 +199,7 @@ namespace HASS.Agent.Extensions
                 MqttClientCertificate = serviceMqttSettings.MqttClientCertificate,
                 MqttClientId = serviceMqttSettings.MqttClientId
             };
+
             return rpcServiceMqttSettings;
         }
 

--- a/src/HASS.Agent/HASS.Agent/Extensions/RpcExtensions.cs
+++ b/src/HASS.Agent/HASS.Agent/Extensions/RpcExtensions.cs
@@ -135,7 +135,8 @@ namespace HASS.Agent.Extensions
                 Category = configuredSensor.Category ?? string.Empty,
                 Counter = configuredSensor.Counter ?? string.Empty,
                 Instance = configuredSensor.Instance ?? string.Empty,
-                Name = configuredSensor.EntityName
+                Name = configuredSensor.Name ?? string.Empty,
+                EntityName = configuredSensor.EntityName ?? string.Empty
             };
             return configuredRpcSensor;
         }

--- a/src/HASS.Agent/HASS.Agent/Extensions/RpcExtensions.cs
+++ b/src/HASS.Agent/HASS.Agent/Extensions/RpcExtensions.cs
@@ -33,7 +33,8 @@ namespace HASS.Agent.Extensions
             {
                 Type = (CommandType)rpcConfiguredCommand.Type,
                 Id = Guid.Parse(rpcConfiguredCommand.Id),
-                EntityName = rpcConfiguredCommand.Name,
+                EntityName = rpcConfiguredCommand.EntityName,
+                Name = rpcConfiguredCommand.Name,
                 Command = rpcConfiguredCommand.Command,
                 RunAsLowIntegrity = rpcConfiguredCommand.RunAsLowIntegrity,
                 EntityType = (CommandEntityType)rpcConfiguredCommand.CommandEntityType
@@ -69,7 +70,8 @@ namespace HASS.Agent.Extensions
                 Id = configuredCommand.Id.ToString(),
                 Command = configuredCommand.Command ?? string.Empty,
                 RunAsLowIntegrity = configuredCommand.RunAsLowIntegrity,
-                Name = configuredCommand.EntityName,
+                Name = configuredCommand.Name,
+                EntityName = configuredCommand.EntityName,
                 CommandEntityType = (int)configuredCommand.EntityType
             };
 
@@ -106,7 +108,8 @@ namespace HASS.Agent.Extensions
                 Category = rpcConfiguredSensor.Category,
                 Counter = rpcConfiguredSensor.Counter,
                 Instance = rpcConfiguredSensor.Instance,
-                EntityName = rpcConfiguredSensor.Name
+                EntityName = rpcConfiguredSensor.EntityName,
+                Name = rpcConfiguredSensor.Name
             };
 
             return configuredSensor;

--- a/src/HASS.Agent/HASS.Agent/Extensions/RpcExtensions.cs
+++ b/src/HASS.Agent/HASS.Agent/Extensions/RpcExtensions.cs
@@ -31,7 +31,7 @@ namespace HASS.Agent.Extensions
             {
                 Type = (CommandType)rpcConfiguredCommand.Type,
                 Id = Guid.Parse(rpcConfiguredCommand.Id),
-                Name = rpcConfiguredCommand.Name,
+                EntityName = rpcConfiguredCommand.Name,
                 Command = rpcConfiguredCommand.Command,
                 RunAsLowIntegrity = rpcConfiguredCommand.RunAsLowIntegrity,
                 EntityType = (CommandEntityType)rpcConfiguredCommand.CommandEntityType
@@ -64,7 +64,7 @@ namespace HASS.Agent.Extensions
                 Id = configuredCommand.Id.ToString(),
                 Command = configuredCommand.Command ?? string.Empty,
                 RunAsLowIntegrity = configuredCommand.RunAsLowIntegrity,
-                Name = configuredCommand.Name,
+                Name = configuredCommand.EntityName,
                 CommandEntityType = (int)configuredCommand.EntityType
             };
             return configuredRpcCommand;
@@ -98,7 +98,7 @@ namespace HASS.Agent.Extensions
                 Category = rpcConfiguredSensor.Category,
                 Counter = rpcConfiguredSensor.Counter,
                 Instance = rpcConfiguredSensor.Instance,
-                Name = rpcConfiguredSensor.Name
+                EntityName = rpcConfiguredSensor.Name
             };
             return configuredSensor;
         }
@@ -135,7 +135,7 @@ namespace HASS.Agent.Extensions
                 Category = configuredSensor.Category ?? string.Empty,
                 Counter = configuredSensor.Counter ?? string.Empty,
                 Instance = configuredSensor.Instance ?? string.Empty,
-                Name = configuredSensor.Name
+                Name = configuredSensor.EntityName
             };
             return configuredRpcSensor;
         }

--- a/src/HASS.Agent/HASS.Agent/Forms/Commands/CommandsConfig.cs
+++ b/src/HASS.Agent/HASS.Agent/Forms/Commands/CommandsConfig.cs
@@ -66,7 +66,7 @@ namespace HASS.Agent.Forms.Commands
                 var commandCard = CommandsManager.CommandInfoCards[command.Type];
 
                 var lviCommand = new ListViewItem(command.Id.ToString());
-                lviCommand.SubItems.Add(command.Name);
+                lviCommand.SubItems.Add(command.EntityName);
                 lviCommand.SubItems.Add(commandCard.Name);
                 lviCommand.SubItems.Add(command.RunAsLowIntegrity ? "√" : string.Empty);
                 lviCommand.SubItems.Add(commandCard.ActionCompatible ? "√" : string.Empty);

--- a/src/HASS.Agent/HASS.Agent/Forms/Commands/CommandsMod.cs
+++ b/src/HASS.Agent/HASS.Agent/Forms/Commands/CommandsMod.cs
@@ -141,11 +141,11 @@ namespace HASS.Agent.Forms.Commands
 			if (!guiOk)
 				return;
 
-			TbName.Text = Command.Name;
+			TbName.Text = Command.EntityName;
 			if (!string.IsNullOrWhiteSpace(TbName.Text))
 				TbName.SelectionStart = TbName.Text.Length;
 
-			TbFriendlyName.Text = Command.FriendlyName;
+			TbFriendlyName.Text = Command.Name;
 
 			var entityId = (int)Command.EntityType;
 			CbEntityType.SelectedItem = new KeyValuePair<int, string>(entityId, _commandEntityTypes[entityId]);
@@ -263,7 +263,7 @@ namespace HASS.Agent.Forms.Commands
                 MessageBoxAdv.Show(this, Languages.CommandsMod_BtnStore_DeviceNameInSensorName, Variables.MessageBoxTitle, MessageBoxButtons.OK, MessageBoxIcon.Warning);
             }
 
-			var friendlyName = string.IsNullOrEmpty(TbName.Text.Trim()) ? null : TbName.Text.Trim();
+			var friendlyName = string.IsNullOrEmpty(TbName.Text.Trim()) ? name : TbName.Text.Trim();
 
 			var sanitized = SharedHelperFunctions.GetSafeValue(name);
 			if (sanitized != name)
@@ -280,7 +280,7 @@ namespace HASS.Agent.Forms.Commands
 				name = sanitized;
 			}
 
-			if (!_serviceMode && Variables.Commands.Any(x => string.Equals(x.Name, name, StringComparison.InvariantCultureIgnoreCase) && x.Id != Command.Id.ToString()))
+			if (!_serviceMode && Variables.Commands.Any(x => string.Equals(x.EntityName, name, StringComparison.InvariantCultureIgnoreCase) && x.Id != Command.Id.ToString()))
 			{
 				var confirm = MessageBoxAdv.Show(this, Languages.CommandsMod_BtnStore_MessageBox3, Variables.MessageBoxTitle, MessageBoxButtons.YesNo, MessageBoxIcon.Question);
 				if (confirm != DialogResult.Yes)
@@ -503,8 +503,8 @@ namespace HASS.Agent.Forms.Commands
 
 			Command.Type = commandCard.CommandType;
 			Command.EntityType = entityType;
-			Command.Name = name;
-			Command.FriendlyName = friendlyName;
+			Command.EntityName = name;
+			Command.Name = friendlyName;
 
 			DialogResult = DialogResult.OK;
 		}

--- a/src/HASS.Agent/HASS.Agent/Forms/QuickActions/QuickActionsMod.cs
+++ b/src/HASS.Agent/HASS.Agent/Forms/QuickActions/QuickActionsMod.cs
@@ -384,8 +384,8 @@ namespace HASS.Agent.Forms.QuickActions
                 case HassDomain.HASSAgentCommands:
                     foreach (var item in Variables.Commands)
                     {
-                        CbEntity.AutoCompleteCustomSource.Add(item.Name);
-                        CbEntity.Items.Add(item.Name);
+                        CbEntity.AutoCompleteCustomSource.Add(item.EntityName);
+                        CbEntity.Items.Add(item.EntityName);
                     }
                     break;
             }

--- a/src/HASS.Agent/HASS.Agent/Forms/Sensors/SensorsConfig.cs
+++ b/src/HASS.Agent/HASS.Agent/Forms/Sensors/SensorsConfig.cs
@@ -70,7 +70,7 @@ namespace HASS.Agent.Forms.Sensors
             foreach (var sensor in _sensors)
             {
                 var lviSensor = new ListViewItem(sensor.Id.ToString());
-                lviSensor.SubItems.Add(sensor.Name);
+                lviSensor.SubItems.Add(sensor.EntityName);
                 lviSensor.SubItems.Add(SensorsManager.SensorInfoCards[sensor.Type].Name);
                 lviSensor.SubItems.Add(sensor.UpdateInterval.ToString());
 

--- a/src/HASS.Agent/HASS.Agent/Forms/Sensors/SensorsMod.cs
+++ b/src/HASS.Agent/HASS.Agent/Forms/Sensors/SensorsMod.cs
@@ -162,11 +162,11 @@ namespace HASS.Agent.Forms.Sensors
 			if (!guiOk) return;
 
 			// set the name
-			TbName.Text = Sensor.Name;
+			TbName.Text = Sensor.EntityName;
 			if (!string.IsNullOrWhiteSpace(TbName.Text)) TbName.SelectionStart = TbName.Text.Length;
 
 			// set the friendly name
-			TbFriendlyName.Text = Sensor.FriendlyName;
+			TbFriendlyName.Text = Sensor.Name;
 
 			// set interval
 			NumInterval.Text = Sensor.UpdateInterval?.ToString() ?? "10";
@@ -612,7 +612,7 @@ namespace HASS.Agent.Forms.Sensors
 			}
 
 			// get friendly name
-			var friendlyName = string.IsNullOrEmpty(TbFriendlyName.Text.Trim()) ? null : TbFriendlyName.Text.Trim();
+			var friendlyName = string.IsNullOrEmpty(TbFriendlyName.Text.Trim()) ? name : TbFriendlyName.Text.Trim();
 
 			// name contains illegal chars?
 			var sanitized = SharedHelperFunctions.GetSafeValue(name);
@@ -630,7 +630,7 @@ namespace HASS.Agent.Forms.Sensors
 			}
 
 			// name already used?
-			if (!_serviceMode && Variables.SingleValueSensors.Any(x => string.Equals(x.Name, name, StringComparison.InvariantCultureIgnoreCase) && x.Id != Sensor.Id.ToString()))
+			if (!_serviceMode && Variables.SingleValueSensors.Any(x => string.Equals(x.EntityName, name, StringComparison.InvariantCultureIgnoreCase) && x.Id != Sensor.Id.ToString()))
 			{
 				var confirm = MessageBoxAdv.Show(this, Languages.SensorsMod_BtnStore_MessageBox4, Variables.MessageBoxTitle, MessageBoxButtons.YesNo, MessageBoxIcon.Question);
 				if (confirm != DialogResult.Yes)
@@ -640,7 +640,7 @@ namespace HASS.Agent.Forms.Sensors
 				}
 			}
 
-			if (!_serviceMode && Variables.MultiValueSensors.Any(x => string.Equals(x.Name, name, StringComparison.InvariantCultureIgnoreCase) && x.Id != Sensor.Id.ToString()))
+			if (!_serviceMode && Variables.MultiValueSensors.Any(x => string.Equals(x.EntityName, name, StringComparison.InvariantCultureIgnoreCase) && x.Id != Sensor.Id.ToString()))
 			{
 				var confirm = MessageBoxAdv.Show(this, Languages.SensorsMod_BtnStore_MessageBox5, Variables.MessageBoxTitle, MessageBoxButtons.YesNo, MessageBoxIcon.Question);
 				if (confirm != DialogResult.Yes)
@@ -803,8 +803,8 @@ namespace HASS.Agent.Forms.Sensors
 
 			// set values
 			Sensor.Type = sensorCard.SensorType;
-			Sensor.Name = name;
-			Sensor.FriendlyName = friendlyName;
+			Sensor.EntityName = name;
+			Sensor.Name = friendlyName;
 			Sensor.UpdateInterval = interval;
 			Sensor.IgnoreAvailability = CbIgnoreAvailability.Checked;
 			Sensor.ApplyRounding = applyRounding;

--- a/src/HASS.Agent/HASS.Agent/HomeAssistant/Commands/CustomCommands/SwitchDesktopCommand.cs
+++ b/src/HASS.Agent/HASS.Agent/HomeAssistant/Commands/CustomCommands/SwitchDesktopCommand.cs
@@ -16,7 +16,7 @@ public class SwitchDesktopCommand : InternalCommand
 {
     private const string DefaultName = "switchdesktop";
 
-    public SwitchDesktopCommand(string name = DefaultName, string friendlyName = DefaultName, string desktopId = "", CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(name ?? DefaultName, friendlyName ?? null, desktopId, entityType, id)
+    public SwitchDesktopCommand(string entityName = DefaultName, string name = DefaultName, string desktopId = "", CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(entityName ?? DefaultName, name ?? null, desktopId, entityType, id)
     {
         CommandConfig = desktopId;
         State = "OFF";
@@ -28,7 +28,7 @@ public class SwitchDesktopCommand : InternalCommand
 
         if (string.IsNullOrWhiteSpace(CommandConfig))
         {
-            Log.Warning("[SWITCHDESKTOP] [{name}] Unable to launch command, it's configured as action-only", Name);
+            Log.Warning("[SWITCHDESKTOP] [{name}] Unable to launch command, it's configured as action-only", EntityName);
 
             State = "OFF";
             return;
@@ -45,7 +45,7 @@ public class SwitchDesktopCommand : InternalCommand
 
         if (string.IsNullOrWhiteSpace(action))
         {
-            Log.Warning("[SWITCHDESKTOP] [{name}] Unable to launch command, empty action provided", Name);
+            Log.Warning("[SWITCHDESKTOP] [{name}] Unable to launch command, empty action provided", EntityName);
 
             State = "OFF";
             return;
@@ -53,7 +53,7 @@ public class SwitchDesktopCommand : InternalCommand
 
         if (!string.IsNullOrWhiteSpace(CommandConfig))
         {
-            Log.Warning("[SWITCHDESKTOP] [{name}] Command launched by action, command-provided process will be ignored", Name);
+            Log.Warning("[SWITCHDESKTOP] [{name}] Command launched by action, command-provided process will be ignored", EntityName);
 
             State = "OFF";
             return;

--- a/src/HASS.Agent/HASS.Agent/HomeAssistant/Commands/InternalCommands/LaunchUrlCommand.cs
+++ b/src/HASS.Agent/HASS.Agent/HomeAssistant/Commands/InternalCommands/LaunchUrlCommand.cs
@@ -14,7 +14,7 @@ namespace HASS.Agent.HomeAssistant.Commands.InternalCommands
         private readonly string _url = string.Empty;
         private readonly bool _incognito;
 
-        internal LaunchUrlCommand(string name = DefaultName, string friendlyName = DefaultName, string urlInfo = "", CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(name ?? DefaultName, friendlyName ?? null, urlInfo, entityType, id)
+        internal LaunchUrlCommand(string entityName = DefaultName, string name = DefaultName, string urlInfo = "", CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(entityName ?? DefaultName, name ?? null, urlInfo, entityType, id)
         {
             CommandConfig = urlInfo;
             State = "OFF";
@@ -33,7 +33,7 @@ namespace HASS.Agent.HomeAssistant.Commands.InternalCommands
 
             if (string.IsNullOrWhiteSpace(_url))
             {
-                Log.Error("[LAUNCHURL] [{name}] Unable to launch URL, it's configured as action-only", Name);
+                Log.Error("[LAUNCHURL] [{name}] Unable to launch URL, it's configured as action-only", EntityName);
 
                 State = "OFF";
                 return;
@@ -50,7 +50,7 @@ namespace HASS.Agent.HomeAssistant.Commands.InternalCommands
 
             if (string.IsNullOrWhiteSpace(action) && string.IsNullOrWhiteSpace(_url))
             {
-                Log.Error("[LAUNCHURL] [{name}] Unable to launch URL, it's configured as action-only but no URL is provided.", Name);
+                Log.Error("[LAUNCHURL] [{name}] Unable to launch URL, it's configured as action-only but no URL is provided.", EntityName);
 
                 State = "OFF";
                 return;

--- a/src/HASS.Agent/HASS.Agent/HomeAssistant/Commands/InternalCommands/PublishAllSensorsCommand.cs
+++ b/src/HASS.Agent/HASS.Agent/HomeAssistant/Commands/InternalCommands/PublishAllSensorsCommand.cs
@@ -8,7 +8,7 @@ namespace HASS.Agent.HomeAssistant.Commands.InternalCommands
     {
         private const string DefaultName = "publishallsensors";
 
-        internal PublishAllSensorsCommand(string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(name ?? DefaultName, friendlyName ?? null, string.Empty, entityType, id)
+        internal PublishAllSensorsCommand(string entityName = DefaultName, string name = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(entityName ?? DefaultName, name ?? null, string.Empty, entityType, id)
         {
             State = "OFF";
         }

--- a/src/HASS.Agent/HASS.Agent/HomeAssistant/Commands/InternalCommands/RadioCommand.cs
+++ b/src/HASS.Agent/HASS.Agent/HomeAssistant/Commands/InternalCommands/RadioCommand.cs
@@ -15,7 +15,7 @@ namespace HASS.Agent.HomeAssistant.Commands.InternalCommands
 
         public string RadioName { get; set; }
 
-        internal RadioCommand(string radioName, string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(name ?? DefaultName, friendlyName ?? null, radioName, entityType, id)
+        internal RadioCommand(string radioName, string entityName = DefaultName, string name = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(entityName ?? DefaultName, name ?? null, radioName, entityType, id)
         {
             RadioName = radioName;
             _radio = RadioManager.AvailableRadio.First(r => r.Name == radioName);

--- a/src/HASS.Agent/HASS.Agent/HomeAssistant/Commands/InternalCommands/WebViewCommand.cs
+++ b/src/HASS.Agent/HASS.Agent/HomeAssistant/Commands/InternalCommands/WebViewCommand.cs
@@ -12,7 +12,7 @@ namespace HASS.Agent.HomeAssistant.Commands.InternalCommands
         private const string DefaultName = "webview";
         private readonly WebViewInfo _webViewInfo = new();
 
-        internal WebViewCommand(string name = DefaultName, string friendlyName = DefaultName, string webViewInfo = "", CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(name ?? DefaultName, friendlyName ?? null, webViewInfo, entityType, id)
+        internal WebViewCommand(string entityName = DefaultName, string name = DefaultName, string webViewInfo = "", CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(entityName ?? DefaultName, name ?? null, webViewInfo, entityType, id)
         {
             CommandConfig = webViewInfo;
             State = "OFF";
@@ -30,7 +30,7 @@ namespace HASS.Agent.HomeAssistant.Commands.InternalCommands
 
             if (string.IsNullOrWhiteSpace(_webViewInfo.Url))
             {
-                Log.Error("[WEBVIEW] [{name}] Unable to launch webview, it's configured as action-only", Name);
+                Log.Error("[WEBVIEW] [{name}] Unable to launch webview, it's configured as action-only", EntityName);
 
                 State = "OFF";
                 return;
@@ -47,7 +47,7 @@ namespace HASS.Agent.HomeAssistant.Commands.InternalCommands
 
             if (string.IsNullOrWhiteSpace(action) && string.IsNullOrWhiteSpace(_webViewInfo.Url))
             {
-                Log.Error("[WEBVIEW] [{name}] Unable to launch URL, it's configured as action-only but no URL is provided", Name);
+                Log.Error("[WEBVIEW] [{name}] Unable to launch URL, it's configured as action-only but no URL is provided", EntityName);
 
                 State = "OFF";
                 return;

--- a/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/MultiValue/PrintersSensors.cs
+++ b/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/MultiValue/PrintersSensors.cs
@@ -25,7 +25,7 @@ namespace HASS.Agent.HomeAssistant.Sensors.GeneralSensors.MultiValue
 
         public sealed override Dictionary<string, AbstractSingleValueSensor> Sensors { get; protected set; } = new();
 
-        public PrintersSensors(int? updateInterval = null, string name = DefaultName, string friendlyName = DefaultName, string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 20, id)
+        public PrintersSensors(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 20, id)
         {
             _updateInterval = updateInterval ?? 20;
 
@@ -44,22 +44,22 @@ namespace HASS.Agent.HomeAssistant.Sensors.GeneralSensors.MultiValue
         {
             try
             {
-                var parentSensorSafeName = SharedHelperFunctions.GetSafeValue(Name);
+                var parentSensorSafeName = SharedHelperFunctions.GetSafeValue(EntityName);
 
                 var printerInfo = GetPrinterInfo();
 
                 var printersCountId = $"{parentSensorSafeName}_printers_count";
-                var printersCountSensor = new DataTypeIntSensor(_updateInterval, "Printers Count", printersCountId, string.Empty, "mdi:printer", string.Empty, Name);
+                var printersCountSensor = new DataTypeIntSensor(_updateInterval, "Printers Count", printersCountId, string.Empty, "mdi:printer", string.Empty, EntityName);
                 printersCountSensor.SetState(printerInfo.PrintQueues.Count);
                 AddUpdateSensor(printersCountId, printersCountSensor);
 
                 var defaultQueueId = $"{parentSensorSafeName}_default_queue";
-                var defaultQueueSensor = new DataTypeStringSensor(_updateInterval, "Default Queue", defaultQueueId, string.Empty, "mdi:printer", string.Empty, Name);
+                var defaultQueueSensor = new DataTypeStringSensor(_updateInterval, "Default Queue", defaultQueueId, string.Empty, "mdi:printer", string.Empty, EntityName);
                 defaultQueueSensor.SetState(printerInfo.DefaultQueue);
                 AddUpdateSensor(defaultQueueId, defaultQueueSensor);
 
                 var defaultQueueJobsId = $"{parentSensorSafeName}_default_queue_jobs";
-                var defaultQueueJobsSensor = new DataTypeIntSensor(_updateInterval, "Default Queue Jobs", defaultQueueJobsId, string.Empty, "mdi:printer", string.Empty, Name);
+                var defaultQueueJobsSensor = new DataTypeIntSensor(_updateInterval, "Default Queue Jobs", defaultQueueJobsId, string.Empty, "mdi:printer", string.Empty, EntityName);
                 defaultQueueJobsSensor.SetState(printerInfo.DefaultQueueJobs);
                 AddUpdateSensor(defaultQueueJobsId, defaultQueueJobsSensor);
 
@@ -67,7 +67,7 @@ namespace HASS.Agent.HomeAssistant.Sensors.GeneralSensors.MultiValue
                 {
                     var printerQueueInfo = JsonConvert.SerializeObject(printer, Formatting.Indented);
                     var printerId = $"{parentSensorSafeName}_{SharedHelperFunctions.GetSafeValue(printer.Name)}";
-                    var printerSensor = new DataTypeIntSensor(_updateInterval, $"{printer.Name}", printerId, string.Empty, "mdi:printer", string.Empty, Name, true);
+                    var printerSensor = new DataTypeIntSensor(_updateInterval, $"{printer.Name}", printerId, string.Empty, "mdi:printer", string.Empty, EntityName, true);
 
                     printerSensor.SetState(printer.Jobs);
                     printerSensor.SetAttributes(printerQueueInfo);
@@ -86,7 +86,7 @@ namespace HASS.Agent.HomeAssistant.Sensors.GeneralSensors.MultiValue
 
                 _errorPrinted = true;
 
-                Log.Fatal(ex, "[PRINTERS] [{name}] Error while fetching audio info: {err}", Name, ex.Message);
+                Log.Fatal(ex, "[PRINTERS] [{name}] Error while fetching audio info: {err}", EntityName, ex.Message);
             }
         }
 
@@ -152,7 +152,7 @@ namespace HASS.Agent.HomeAssistant.Sensors.GeneralSensors.MultiValue
                                 catch (Exception ex)
                                 {
                                     if (!_errorPrinted)
-                                        Log.Fatal(ex, "[PRINTERS] [{name}] [{queue}] Exception while retrieving job: {err}", Name, queue.Name ?? "-", ex.Message);
+                                        Log.Fatal(ex, "[PRINTERS] [{name}] [{queue}] Exception while retrieving job: {err}", EntityName, queue.Name ?? "-", ex.Message);
 
                                     errors = true;
                                 }
@@ -197,7 +197,7 @@ namespace HASS.Agent.HomeAssistant.Sensors.GeneralSensors.MultiValue
                         catch (Exception ex)
                         {
                             if (!_errorPrinted)
-                                Log.Fatal(ex, "[PRINTERS] [{name}] [{queue}] Exception while retrieving queue: {err}", Name, queue.Name ?? "-", ex.Message);
+                                Log.Fatal(ex, "[PRINTERS] [{name}] [{queue}] Exception while retrieving queue: {err}", EntityName, queue.Name ?? "-", ex.Message);
 
                             errors = true;
                         }
@@ -210,7 +210,7 @@ namespace HASS.Agent.HomeAssistant.Sensors.GeneralSensors.MultiValue
                 catch (Exception ex)
                 {
                     if (!_errorPrinted)
-                        Log.Fatal(ex, "[PRINTERS] [{name}] Exception while retrieving info: {err}", Name, ex.Message);
+                        Log.Fatal(ex, "[PRINTERS] [{name}] Exception while retrieving info: {err}", EntityName, ex.Message);
 
                     errors = true;
                 }
@@ -234,7 +234,7 @@ namespace HASS.Agent.HomeAssistant.Sensors.GeneralSensors.MultiValue
                 
                 _errorPrinted = true;
 
-                Log.Fatal(ex, "[PRINTERS] [{name}] Fatal exception while getting info: {err}", Name, ex.Message);
+                Log.Fatal(ex, "[PRINTERS] [{name}] Fatal exception while getting info: {err}", EntityName, ex.Message);
             }
 
             return printerInfo;

--- a/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/MultiValue/PrintersSensors.cs
+++ b/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/MultiValue/PrintersSensors.cs
@@ -45,29 +45,34 @@ namespace HASS.Agent.HomeAssistant.Sensors.GeneralSensors.MultiValue
             try
             {
                 var parentSensorSafeName = SharedHelperFunctions.GetSafeValue(EntityName);
+                var deviceName = SharedHelperFunctions.GetSafeDeviceName();
 
                 var printerInfo = GetPrinterInfo();
 
-                var printersCountId = $"{parentSensorSafeName}_printers_count";
-                var printersCountSensor = new DataTypeIntSensor(_updateInterval, printersCountId, "Printers Count", printersCountId, string.Empty, "mdi:printer", string.Empty, EntityName);
+                var printersCountEntityName = $"{parentSensorSafeName}_printers_count";
+                var printersCountId = $"{Id}_printers_count";
+                var printersCountSensor = new DataTypeIntSensor(_updateInterval, printersCountEntityName, "Printers Count", printersCountId, string.Empty, "mdi:printer", string.Empty, EntityName);
                 printersCountSensor.SetState(printerInfo.PrintQueues.Count);
                 AddUpdateSensor(printersCountId, printersCountSensor);
 
-                var defaultQueueId = $"{parentSensorSafeName}_default_queue";
-                var defaultQueueSensor = new DataTypeStringSensor(_updateInterval, defaultQueueId, "Default Queue", defaultQueueId, string.Empty, "mdi:printer", string.Empty, EntityName);
+                var defaultQueueEntityName = $"{parentSensorSafeName}_default_queue";
+                var defaultQueueId = $"{Id}_default_queue";
+                var defaultQueueSensor = new DataTypeStringSensor(_updateInterval, defaultQueueEntityName, "Default Queue", defaultQueueId, string.Empty, "mdi:printer", string.Empty, EntityName);
                 defaultQueueSensor.SetState(printerInfo.DefaultQueue);
                 AddUpdateSensor(defaultQueueId, defaultQueueSensor);
 
-                var defaultQueueJobsId = $"{parentSensorSafeName}_default_queue_jobs";
-                var defaultQueueJobsSensor = new DataTypeIntSensor(_updateInterval, defaultQueueJobsId, "Default Queue Jobs", defaultQueueJobsId, string.Empty, "mdi:printer", string.Empty, EntityName);
+                var defaultQueueJobsEntityName = $"{parentSensorSafeName}_default_queue_jobs";
+                var defaultQueueJobsId = $"{Id}_default_queue_jobs";
+                var defaultQueueJobsSensor = new DataTypeIntSensor(_updateInterval, defaultQueueJobsEntityName, "Default Queue Jobs", defaultQueueJobsId, string.Empty, "mdi:printer", string.Empty, EntityName);
                 defaultQueueJobsSensor.SetState(printerInfo.DefaultQueueJobs);
                 AddUpdateSensor(defaultQueueJobsId, defaultQueueJobsSensor);
 
                 foreach (var printer in printerInfo.PrintQueues)
                 {
                     var printerQueueInfo = JsonConvert.SerializeObject(printer, Formatting.Indented);
-                    var printerId = $"{parentSensorSafeName}_{SharedHelperFunctions.GetSafeValue(printer.Name)}";
-                    var printerSensor = new DataTypeIntSensor(_updateInterval, printerId, $"{printer.Name}", printerId, string.Empty, "mdi:printer", string.Empty, EntityName, true);
+                    var printerEntityName = $"{parentSensorSafeName}_{SharedHelperFunctions.GetSafeValue(printer.Name)}";
+                    var printerId = $"{Id}_{SharedHelperFunctions.GetSafeValue(printer.Name)}";
+                    var printerSensor = new DataTypeIntSensor(_updateInterval, printerEntityName, $"{printer.Name}", printerId, string.Empty, "mdi:printer", string.Empty, EntityName, true);
 
                     printerSensor.SetState(printer.Jobs);
                     printerSensor.SetAttributes(printerQueueInfo);

--- a/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/MultiValue/PrintersSensors.cs
+++ b/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/MultiValue/PrintersSensors.cs
@@ -49,17 +49,17 @@ namespace HASS.Agent.HomeAssistant.Sensors.GeneralSensors.MultiValue
                 var printerInfo = GetPrinterInfo();
 
                 var printersCountId = $"{parentSensorSafeName}_printers_count";
-                var printersCountSensor = new DataTypeIntSensor(_updateInterval, "Printers Count", printersCountId, string.Empty, "mdi:printer", string.Empty, EntityName);
+                var printersCountSensor = new DataTypeIntSensor(_updateInterval, printersCountId, "Printers Count", printersCountId, string.Empty, "mdi:printer", string.Empty, EntityName);
                 printersCountSensor.SetState(printerInfo.PrintQueues.Count);
                 AddUpdateSensor(printersCountId, printersCountSensor);
 
                 var defaultQueueId = $"{parentSensorSafeName}_default_queue";
-                var defaultQueueSensor = new DataTypeStringSensor(_updateInterval, "Default Queue", defaultQueueId, string.Empty, "mdi:printer", string.Empty, EntityName);
+                var defaultQueueSensor = new DataTypeStringSensor(_updateInterval, defaultQueueId, "Default Queue", defaultQueueId, string.Empty, "mdi:printer", string.Empty, EntityName);
                 defaultQueueSensor.SetState(printerInfo.DefaultQueue);
                 AddUpdateSensor(defaultQueueId, defaultQueueSensor);
 
                 var defaultQueueJobsId = $"{parentSensorSafeName}_default_queue_jobs";
-                var defaultQueueJobsSensor = new DataTypeIntSensor(_updateInterval, "Default Queue Jobs", defaultQueueJobsId, string.Empty, "mdi:printer", string.Empty, EntityName);
+                var defaultQueueJobsSensor = new DataTypeIntSensor(_updateInterval, defaultQueueJobsId, "Default Queue Jobs", defaultQueueJobsId, string.Empty, "mdi:printer", string.Empty, EntityName);
                 defaultQueueJobsSensor.SetState(printerInfo.DefaultQueueJobs);
                 AddUpdateSensor(defaultQueueJobsId, defaultQueueJobsSensor);
 
@@ -67,7 +67,7 @@ namespace HASS.Agent.HomeAssistant.Sensors.GeneralSensors.MultiValue
                 {
                     var printerQueueInfo = JsonConvert.SerializeObject(printer, Formatting.Indented);
                     var printerId = $"{parentSensorSafeName}_{SharedHelperFunctions.GetSafeValue(printer.Name)}";
-                    var printerSensor = new DataTypeIntSensor(_updateInterval, $"{printer.Name}", printerId, string.Empty, "mdi:printer", string.Empty, EntityName, true);
+                    var printerSensor = new DataTypeIntSensor(_updateInterval, printerId, $"{printer.Name}", printerId, string.Empty, "mdi:printer", string.Empty, EntityName, true);
 
                     printerSensor.SetState(printer.Jobs);
                     printerSensor.SetAttributes(printerQueueInfo);
@@ -231,7 +231,7 @@ namespace HASS.Agent.HomeAssistant.Sensors.GeneralSensors.MultiValue
                 // something went wrong, only print once
                 if (_errorPrinted)
                     return printerInfo;
-                
+
                 _errorPrinted = true;
 
                 Log.Fatal(ex, "[PRINTERS] [{name}] Fatal exception while getting info: {err}", EntityName, ex.Message);

--- a/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/SingleValue/ActiveDesktopSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/SingleValue/ActiveDesktopSensor.cs
@@ -47,7 +47,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
                 EntityName = EntityName,
-                Name = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/SingleValue/ActiveDesktopSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/SingleValue/ActiveDesktopSensor.cs
@@ -26,7 +26,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
         private string _desktopName = string.Empty;
         private string _attributes = string.Empty;
 
-        public ActiveDesktopSensor(int? updateInterval = null, string name = _defaultName, string friendlyName = _defaultName, string id = default) : base(name ?? _defaultName, friendlyName ?? null, updateInterval ?? 15, id)
+        public ActiveDesktopSensor(int? updateInterval = null, string entityName = _defaultName, string name = _defaultName, string id = default) : base(entityName ?? _defaultName, name ?? null, updateInterval ?? 15, id)
         {
             UseAttributes = true;
         }
@@ -46,8 +46,8 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
 
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
-                Name = Name,
-                FriendlyName = FriendlyName,
+                EntityName = EntityName,
+                Name = EntityName,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/SingleValue/BluetoothDevicesSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/SingleValue/BluetoothDevicesSensor.cs
@@ -29,7 +29,7 @@ namespace HASS.Agent.HomeAssistant.Sensors.GeneralSensors.SingleValue
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
                 EntityName = EntityName,
-                Name = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/SingleValue/BluetoothDevicesSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/SingleValue/BluetoothDevicesSensor.cs
@@ -14,7 +14,7 @@ namespace HASS.Agent.HomeAssistant.Sensors.GeneralSensors.SingleValue
         private const string DefaultName = "bluetoothdevices";
         private string _attributes = "{}";
 
-        public BluetoothDevicesSensor(int? updateInterval = 30, string name = DefaultName, string friendlyName = DefaultName, string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 30, id)
+        public BluetoothDevicesSensor(int? updateInterval = 30, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 30, id)
         {
             UseAttributes = true;
         }
@@ -28,8 +28,8 @@ namespace HASS.Agent.HomeAssistant.Sensors.GeneralSensors.SingleValue
 
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
-                Name = Name,
-                FriendlyName = FriendlyName,
+                EntityName = EntityName,
+                Name = EntityName,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/SingleValue/BluetoothLeDevicesSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/SingleValue/BluetoothLeDevicesSensor.cs
@@ -32,7 +32,7 @@ namespace HASS.Agent.HomeAssistant.Sensors.GeneralSensors.SingleValue
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
                 EntityName = EntityName,
-                Name = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/SingleValue/BluetoothLeDevicesSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/SingleValue/BluetoothLeDevicesSensor.cs
@@ -14,7 +14,7 @@ namespace HASS.Agent.HomeAssistant.Sensors.GeneralSensors.SingleValue
         private const string DefaultName = "bluetoothledevices";
         private string _attributes = "{}";
 
-        public BluetoothLeDevicesSensor(int? updateInterval = 30, string name = DefaultName, string friendlyName = DefaultName, string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 30, id) 
+        public BluetoothLeDevicesSensor(int? updateInterval = 30, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 30, id) 
         {
             UseAttributes = true;
 
@@ -31,8 +31,8 @@ namespace HASS.Agent.HomeAssistant.Sensors.GeneralSensors.SingleValue
 
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
-                Name = Name,
-                FriendlyName = FriendlyName,
+                EntityName = EntityName,
+                Name = EntityName,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/SingleValue/GeoLocationSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/SingleValue/GeoLocationSensor.cs
@@ -9,7 +9,7 @@ namespace HASS.Agent.HomeAssistant.Sensors.GeneralSensors.SingleValue
     public class GeoLocationSensor : AbstractSingleValueSensor
     {
         private const string DefaultName = "geolocation";
-        public GeoLocationSensor(int? updateInterval = 10, string name = DefaultName, string friendlyName = DefaultName, string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 30, id) { }
+        public GeoLocationSensor(int? updateInterval = 10, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 30, id) { }
 
         public override DiscoveryConfigModel GetAutoDiscoveryConfig()
         {
@@ -20,8 +20,8 @@ namespace HASS.Agent.HomeAssistant.Sensors.GeneralSensors.SingleValue
 
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
-                Name = Name,
-                FriendlyName = FriendlyName,
+                EntityName = EntityName,
+                Name = EntityName,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/SingleValue/GeoLocationSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/SingleValue/GeoLocationSensor.cs
@@ -21,7 +21,7 @@ namespace HASS.Agent.HomeAssistant.Sensors.GeneralSensors.SingleValue
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
                 EntityName = EntityName,
-                Name = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/SingleValue/InternalDeviceSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/SingleValue/InternalDeviceSensor.cs
@@ -37,7 +37,7 @@ namespace HASS.Agent.HomeAssistant.Sensors.GeneralSensors.SingleValue
             var sensorDiscoveryConfigModel = new SensorDiscoveryConfigModel()
             {
                 EntityName = EntityName,
-                Name = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/SingleValue/InternalDeviceSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/SingleValue/InternalDeviceSensor.cs
@@ -17,7 +17,7 @@ namespace HASS.Agent.HomeAssistant.Sensors.GeneralSensors.SingleValue
 
         private readonly IInternalDeviceSensor _internalDeviceSensor;
 
-        public InternalDeviceSensor(string sensorType, int? updateInterval = 10, string name = DefaultName, string friendlyName = DefaultName, string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 30, id)
+        public InternalDeviceSensor(string sensorType, int? updateInterval = 10, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 30, id)
         {
             SensorType = Enum.Parse<InternalDeviceSensorType>(sensorType);
             _internalDeviceSensor = InternalDeviceSensorsManager.AvailableSensors.First(s => s.Type == SensorType);
@@ -36,8 +36,8 @@ namespace HASS.Agent.HomeAssistant.Sensors.GeneralSensors.SingleValue
 
             var sensorDiscoveryConfigModel = new SensorDiscoveryConfigModel()
             {
-                Name = Name,
-                FriendlyName = FriendlyName,
+                EntityName = EntityName,
+                Name = EntityName,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/SingleValue/MonitorPowerStateSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/SingleValue/MonitorPowerStateSensor.cs
@@ -22,7 +22,7 @@ namespace HASS.Agent.HomeAssistant.Sensors.GeneralSensors.SingleValue
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
                 EntityName = EntityName,
-                Name = EntityName,
+                Name = Name,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/SingleValue/MonitorPowerStateSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/SingleValue/MonitorPowerStateSensor.cs
@@ -10,7 +10,7 @@ namespace HASS.Agent.HomeAssistant.Sensors.GeneralSensors.SingleValue
     public class MonitorPowerStateSensor : AbstractSingleValueSensor
     {
         private const string DefaultName = "monitorpowerstate";
-        public MonitorPowerStateSensor(int? updateInterval = 10, string name = DefaultName, string friendlyName = DefaultName, string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 30, id) { }
+        public MonitorPowerStateSensor(int? updateInterval = 10, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 30, id) { }
 
         public override DiscoveryConfigModel GetAutoDiscoveryConfig()
         {
@@ -21,8 +21,8 @@ namespace HASS.Agent.HomeAssistant.Sensors.GeneralSensors.SingleValue
 
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
-                Name = Name,
-                FriendlyName = FriendlyName,
+                EntityName = EntityName,
+                Name = EntityName,
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",

--- a/src/HASS.Agent/HASS.Agent/Program.cs
+++ b/src/HASS.Agent/HASS.Agent/Program.cs
@@ -240,6 +240,12 @@ namespace HASS.Agent
                     Log.Information("[SYSTEM] Rename entity names mode activated [HA 2023.8]");
                     Variables.ChildApplicationMode = true;
 
+                    if (!SharedHelperFunctions.RunningElevated())
+                    {
+                        CommandLineManager.ExecuteElevated(Variables.ApplicationExecutable, LaunchParamCompatNames, TimeSpan.FromMinutes(5));
+                        return true;
+                    }
+
                     var compatibilityTask = new CompatibilityTask(new NameCompatibilityTask());
                     Application.Run(compatibilityTask);
 

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.Designer.cs
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.Designer.cs
@@ -1453,6 +1453,24 @@ namespace HASS.Agent.Resources.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Error communicating with the satellite service!.
+        /// </summary>
+        internal static string Compat_NameTask_Error_ServiceCommunication {
+            get {
+                return ResourceManager.GetString("Compat_NameTask_Error_ServiceCommunication", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error starting satellite service!.
+        /// </summary>
+        internal static string Compat_NameTask_Error_ServiceStart {
+            get {
+                return ResourceManager.GetString("Compat_NameTask_Error_ServiceStart", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Error converting single value sensors!.
         /// </summary>
         internal static string Compat_NameTask_Error_SingleValueSensors {

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.de.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.de.resx
@@ -3458,4 +3458,10 @@ aus der Originalversion</value>
   <data name="About_LblInfo4_1" xml:space="preserve">
     <value>Ein noch größeres Dankeschön an LAB02 Research und Sam für die Entwicklung der Originalversion von HASS.Agent – ohne HASS.Agent gäbe es das nicht!</value>
   </data>
+  <data name="Compat_NameTask_Error_ServiceCommunication" xml:space="preserve">
+    <value>Fehler bei der Kommunikation mit dem Satellitendienst!</value>
+  </data>
+  <data name="Compat_NameTask_Error_ServiceStart" xml:space="preserve">
+    <value>Fehler beim Starten des Satellitendienstes!</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.en.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.en.resx
@@ -3335,4 +3335,10 @@ from the original version</value>
   <data name="About_LblInfo4_1" xml:space="preserve">
     <value>Even bigger 'thank you' for LAB02 Research and Sam for developing the original version of HASS.Agent - this would wouldn't exist without it!</value>
   </data>
+  <data name="Compat_NameTask_Error_ServiceStart" xml:space="preserve">
+    <value>Error starting satellite service!</value>
+  </data>
+  <data name="Compat_NameTask_Error_ServiceCommunication" xml:space="preserve">
+    <value>Error communicating with the satellite service!</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.es.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.es.resx
@@ -3334,4 +3334,10 @@ HASS.Agent de la versión original</value>
   <data name="About_LblInfo4_1" xml:space="preserve">
     <value>Aún más agradecimiento a LAB02 Research y a Sam por desarrollar la versión original de HASS.Agent: ¡esto no existiría sin él!</value>
   </data>
+  <data name="Compat_NameTask_Error_ServiceCommunication" xml:space="preserve">
+    <value>¡Error al comunicarse con el servicio satelital!</value>
+  </data>
+  <data name="Compat_NameTask_Error_ServiceStart" xml:space="preserve">
+    <value>¡Error al iniciar el servicio satelital!</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.fr.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.fr.resx
@@ -3367,4 +3367,10 @@ HASS.Agent de la version originale</value>
   <data name="About_LblInfo4_1" xml:space="preserve">
     <value>Un plus grand merci encore à LAB02 Research et à Sam pour avoir développé la version originale de HASS.Agent - cela n'existerait pas sans cela !</value>
   </data>
+  <data name="Compat_NameTask_Error_ServiceCommunication" xml:space="preserve">
+    <value>Erreur de communication avec le service satellite !</value>
+  </data>
+  <data name="Compat_NameTask_Error_ServiceStart" xml:space="preserve">
+    <value>Erreur lors du démarrage du service satellite !</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.nl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.nl.resx
@@ -3355,4 +3355,10 @@ van de originele versie</value>
   <data name="About_LblInfo4_1" xml:space="preserve">
     <value>Nog groter dank aan LAB02 Research en Sam voor het ontwikkelen van de originele versie van HASS.Agent - zonder dit zou dit niet bestaan!</value>
   </data>
+  <data name="Compat_NameTask_Error_ServiceCommunication" xml:space="preserve">
+    <value>Fout bij communicatie met de satellietdienst!</value>
+  </data>
+  <data name="Compat_NameTask_Error_ServiceStart" xml:space="preserve">
+    <value>Fout bij starten satellietservice!</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pl.resx
@@ -3444,4 +3444,10 @@ z oryginalnej wersji</value>
   <data name="About_LblInfo4_1" xml:space="preserve">
     <value>Jeszcze większe podziękowania dla LAB02 Research i Sama za opracowanie oryginalnej wersji HASS.Agent – bez tego nie byłoby tego!</value>
   </data>
+  <data name="Compat_NameTask_Error_ServiceCommunication" xml:space="preserve">
+    <value>Błąd komunikacji z usługą satelity!</value>
+  </data>
+  <data name="Compat_NameTask_Error_ServiceStart" xml:space="preserve">
+    <value>Błąd podczas uruchamiania usługi satelity!</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pt-br.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pt-br.resx
@@ -3380,4 +3380,10 @@ HASS.Agent da versão original</value>
   <data name="About_LblInfo4_1" xml:space="preserve">
     <value>Um agradecimento ainda maior à LAB02 Research e ao Sam por desenvolverem a versão original do HASS.Agent - isto não existiria sem ele!</value>
   </data>
+  <data name="Compat_NameTask_Error_ServiceCommunication" xml:space="preserve">
+    <value>Erro na comunicação com o serviço de satélite!</value>
+  </data>
+  <data name="Compat_NameTask_Error_ServiceStart" xml:space="preserve">
+    <value>Erro ao iniciar o serviço de satélite!</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.resx
@@ -3347,4 +3347,10 @@ from the original version</value>
   <data name="About_LblInfo4_1" xml:space="preserve">
     <value>Even bigger 'thank you' for LAB02 Research and Sam for developing the original version of HASS.Agent - this would wouldn't exist without it!</value>
   </data>
+  <data name="Compat_NameTask_Error_ServiceStart" xml:space="preserve">
+    <value>Error starting satellite service!</value>
+  </data>
+  <data name="Compat_NameTask_Error_ServiceCommunication" xml:space="preserve">
+    <value>Error communicating with the satellite service!</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.ru.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.ru.resx
@@ -3403,4 +3403,10 @@ Home Assistant.
   <data name="About_LblInfo4_1" xml:space="preserve">
     <value>Еще большее «спасибо» LAB02 Research и Сэму за разработку оригинальной версии HASS.Agent — без нее его бы не существовало!</value>
   </data>
+  <data name="Compat_NameTask_Error_ServiceCommunication" xml:space="preserve">
+    <value>Ошибка связи со спутниковой службой!</value>
+  </data>
+  <data name="Compat_NameTask_Error_ServiceStart" xml:space="preserve">
+    <value>Ошибка при запуске спутниковой службы!</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.sl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.sl.resx
@@ -3483,4 +3483,10 @@ iz izvirne različice</value>
   <data name="About_LblInfo4_1" xml:space="preserve">
     <value>Še večji 'hvala' za LAB02 Research in Sama za razvoj izvirne različice HASS.Agenta - brez njega tega ne bi bilo!</value>
   </data>
+  <data name="Compat_NameTask_Error_ServiceCommunication" xml:space="preserve">
+    <value>Napaka pri komunikaciji s satelitsko storitvijo!</value>
+  </data>
+  <data name="Compat_NameTask_Error_ServiceStart" xml:space="preserve">
+    <value>Napaka pri zagonu satelitske storitve!</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.tr.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.tr.resx
@@ -2946,4 +2946,10 @@ taşınması orijinal versiyondan</value>
   <data name="About_LblInfo4_1" xml:space="preserve">
     <value>HASS.Agent'ın orijinal versiyonunu geliştirdikleri için LAB02 Research ve Sam'e daha da büyük bir 'teşekkür ederim' - bu olmasaydı bu olmazdı!</value>
   </data>
+  <data name="Compat_NameTask_Error_ServiceCommunication" xml:space="preserve">
+    <value>Uydu servisiyle iletişimde hata!</value>
+  </data>
+  <data name="Compat_NameTask_Error_ServiceStart" xml:space="preserve">
+    <value>Uydu hizmeti başlatılırken hata oluştu!</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Sensors/SensorsManager.cs
+++ b/src/HASS.Agent/HASS.Agent/Sensors/SensorsManager.cs
@@ -5,6 +5,7 @@ using HASS.Agent.Settings;
 using HASS.Agent.Shared.Enums;
 using HASS.Agent.Shared.Extensions;
 using HASS.Agent.Shared.Models.Config;
+using HASS.Agent.Shared.Models.HomeAssistant;
 using Serilog;
 
 namespace HASS.Agent.Sensors
@@ -215,22 +216,34 @@ namespace HASS.Agent.Sensors
                         if (sensor.IsSingleValue())
                         {
                             var abstractSensor = StoredSensors.ConvertConfiguredToAbstractSingleValue(sensor);
+                            var sensorIndex = Variables.SingleValueSensors.FindIndex(x => x.Id == abstractSensor.Id);
+                            if (sensorIndex != -1)
+                            {
+                                await abstractSensor.UnPublishAutoDiscoveryConfigAsync();
+                                Variables.SingleValueSensors.RemoveAt(sensorIndex);
 
-                            // remove and unregister
-                            await abstractSensor.UnPublishAutoDiscoveryConfigAsync();
-                            Variables.SingleValueSensors.RemoveAt(Variables.SingleValueSensors.FindIndex(x => x.Id == abstractSensor.Id));
-
-                            Log.Information("[SENSORS] Removed single-value sensor: {sensor}", abstractSensor.Name);
+                                Log.Information("[SENSORS] Removed single-value sensor: {sensor}", abstractSensor.Name);
+                            }
+                            else
+                            {
+                                Log.Information("[SENSORS] Single-value sensor not removed, not activated: {sensor}", abstractSensor.Name);
+                            }
                         }
                         else
                         {
                             var abstractSensor = StoredSensors.ConvertConfiguredToAbstractMultiValue(sensor);
+                            var sensorIndex = Variables.MultiValueSensors.FindIndex(x => x.Id == abstractSensor.Id);
+                            if (sensorIndex != -1)
+                            {
+                                await abstractSensor.UnPublishAutoDiscoveryConfigAsync();
+                                Variables.MultiValueSensors.RemoveAt(sensorIndex);
 
-                            // remove and unregister
-                            await abstractSensor.UnPublishAutoDiscoveryConfigAsync();
-                            Variables.MultiValueSensors.RemoveAt(Variables.MultiValueSensors.FindIndex(x => x.Id == abstractSensor.Id));
-
-                            Log.Information("[SENSORS] Removed multi-value sensor: {sensor}", abstractSensor.Name);
+                                Log.Information("[SENSORS] Removed multi-value sensor: {sensor}", abstractSensor.Name);
+                            }
+                            else
+                            {
+                                Log.Information("[SENSORS] Multi-value sensor not removed, not activated: {sensor}", abstractSensor.Name);
+                            }
                         }
                     }
                 }

--- a/src/HASS.Agent/HASS.Agent/Sensors/SensorsManager.cs
+++ b/src/HASS.Agent/HASS.Agent/Sensors/SensorsManager.cs
@@ -222,11 +222,11 @@ namespace HASS.Agent.Sensors
                                 await abstractSensor.UnPublishAutoDiscoveryConfigAsync();
                                 Variables.SingleValueSensors.RemoveAt(sensorIndex);
 
-                                Log.Information("[SENSORS] Removed single-value sensor: {sensor}", abstractSensor.Name);
+                                Log.Information("[SENSORS] Removed single-value sensor: {sensor}", abstractSensor.EntityName);
                             }
                             else
                             {
-                                Log.Information("[SENSORS] Single-value sensor not removed, not activated: {sensor}", abstractSensor.Name);
+                                Log.Information("[SENSORS] Single-value sensor not removed, not activated: {sensor}", abstractSensor.EntityName);
                             }
                         }
                         else
@@ -238,11 +238,11 @@ namespace HASS.Agent.Sensors
                                 await abstractSensor.UnPublishAutoDiscoveryConfigAsync();
                                 Variables.MultiValueSensors.RemoveAt(sensorIndex);
 
-                                Log.Information("[SENSORS] Removed multi-value sensor: {sensor}", abstractSensor.Name);
+                                Log.Information("[SENSORS] Removed multi-value sensor: {sensor}", abstractSensor.EntityName);
                             }
                             else
                             {
-                                Log.Information("[SENSORS] Multi-value sensor not removed, not activated: {sensor}", abstractSensor.Name);
+                                Log.Information("[SENSORS] Multi-value sensor not removed, not activated: {sensor}", abstractSensor.EntityName);
                             }
                         }
                     }
@@ -261,16 +261,16 @@ namespace HASS.Agent.Sensors
                             await abstractSensor.PublishAutoDiscoveryConfigAsync();
                             await abstractSensor.PublishStateAsync(false);
 
-                            Log.Information("[SENSORS] Added single-value sensor: {sensor}", abstractSensor.Name);
+                            Log.Information("[SENSORS] Added single-value sensor: {sensor}", abstractSensor.EntityName);
                             continue;
                         }
 
                         // existing, update and re-register
                         var currentSensorIndex = Variables.SingleValueSensors.FindIndex(x => x.Id == abstractSensor.Id);
-                        if (Variables.SingleValueSensors[currentSensorIndex].Name != abstractSensor.Name)
+                        if (Variables.SingleValueSensors[currentSensorIndex].EntityName != abstractSensor.EntityName)
                         {
                             // name changed, unregister
-                            Log.Information("[SENSORS] Single-value sensor changed name, re-registering as new entity: {old} to {new}", Variables.SingleValueSensors[currentSensorIndex].Name, abstractSensor.Name);
+                            Log.Information("[SENSORS] Single-value sensor changed name, re-registering as new entity: {old} to {new}", Variables.SingleValueSensors[currentSensorIndex].EntityName, abstractSensor.EntityName);
 
                             await Variables.SingleValueSensors[currentSensorIndex].UnPublishAutoDiscoveryConfigAsync();
                         }
@@ -279,7 +279,7 @@ namespace HASS.Agent.Sensors
                         await abstractSensor.PublishAutoDiscoveryConfigAsync();
                         await abstractSensor.PublishStateAsync(false);
 
-                        Log.Information("[SENSORS] Modified single-value sensor: {sensor}", abstractSensor.Name);
+                        Log.Information("[SENSORS] Modified single-value sensor: {sensor}", abstractSensor.EntityName);
                     }
                     else
                     {
@@ -291,16 +291,16 @@ namespace HASS.Agent.Sensors
                             await abstractSensor.PublishAutoDiscoveryConfigAsync();
                             await abstractSensor.PublishStatesAsync(false);
 
-                            Log.Information("[SENSORS] Added multi-value sensor: {sensor}", abstractSensor.Name);
+                            Log.Information("[SENSORS] Added multi-value sensor: {sensor}", abstractSensor.EntityName);
                             continue;
                         }
 
                         // existing, update and re-register
                         var currentSensorIndex = Variables.MultiValueSensors.FindIndex(x => x.Id == abstractSensor.Id);
-                        if (Variables.MultiValueSensors[currentSensorIndex].Name != abstractSensor.Name)
+                        if (Variables.MultiValueSensors[currentSensorIndex].EntityName != abstractSensor.EntityName)
                         {
                             // name changed, unregister
-                            Log.Information("[SENSORS] Multi-value sensor changed name, re-registering as new entity: {old} to {new}", Variables.MultiValueSensors[currentSensorIndex].Name, abstractSensor.Name);
+                            Log.Information("[SENSORS] Multi-value sensor changed name, re-registering as new entity: {old} to {new}", Variables.MultiValueSensors[currentSensorIndex].EntityName, abstractSensor.EntityName);
 
                             await Variables.MultiValueSensors[currentSensorIndex].UnPublishAutoDiscoveryConfigAsync();
                         }
@@ -309,7 +309,7 @@ namespace HASS.Agent.Sensors
                         await abstractSensor.PublishAutoDiscoveryConfigAsync();
                         await abstractSensor.PublishStatesAsync(false);
 
-                        Log.Information("[SENSORS] Modified multi-value sensor: {sensor}", abstractSensor.Name);
+                        Log.Information("[SENSORS] Modified multi-value sensor: {sensor}", abstractSensor.EntityName);
                     }
                 }
 

--- a/src/HASS.Agent/HASS.Agent/Service/Protos/hassagentsatellite.proto
+++ b/src/HASS.Agent/HASS.Agent/Service/Protos/hassagentsatellite.proto
@@ -143,4 +143,5 @@ message RpcConfiguredServerCommand {
   bool runAsLowIntegrity = 4;
   string name = 5;
   int32 commandEntityType = 6;
+  string entityName = 7;
 }

--- a/src/HASS.Agent/HASS.Agent/Service/Protos/hassagentsatellite.proto
+++ b/src/HASS.Agent/HASS.Agent/Service/Protos/hassagentsatellite.proto
@@ -133,6 +133,7 @@ message RpcConfiguredServerSensor {
   string counter = 8;
   string instance = 9;
   string name = 10;
+  string entityName = 11;
 }
 
 message RpcConfiguredServerCommand {

--- a/src/HASS.Agent/HASS.Agent/Service/Requests/RpcSetRequests.cs
+++ b/src/HASS.Agent/HASS.Agent/Service/Requests/RpcSetRequests.cs
@@ -24,9 +24,11 @@ namespace HASS.Agent.Service
                 };
 
                 var response = await _rpcClient.SetDeviceNameAsync(setDeviceNameRequest);
-                if (response.Ok) return (true, string.Empty);
+                if (response.Ok)
+                    return (true, string.Empty);
 
                 Log.Error("[SERVICE] SetDeviceName request failed: {err}", response.Error);
+                
                 return (false, response.Error);
             }
             catch (RpcException ex)
@@ -58,9 +60,11 @@ namespace HASS.Agent.Service
                 };
 
                 var response = await _rpcClient.SetServiceSettingsAsync(setServiceSettingsRequest);
-                if (response.Ok) return (true, string.Empty);
+                if (response.Ok)
+                    return (true, string.Empty);
 
                 Log.Error("[SERVICE] SetServiceSettings request failed: {err}", response.Error);
+                
                 return (false, response.Error);
             }
             catch (RpcException ex)
@@ -91,9 +95,11 @@ namespace HASS.Agent.Service
                 };
 
                 var response = await _rpcClient.SetServiceMqttSettingsAsync(setServiceMqttSettingsRequest);
-                if (response.Ok) return (true, string.Empty);
+                if (response.Ok)
+                    return (true, string.Empty);
 
                 Log.Error("[SERVICE] SetServiceMqttSettings request failed: {err}", response.Error);
+                
                 return (false, response.Error);
             }
             catch (RpcException ex)
@@ -122,12 +128,15 @@ namespace HASS.Agent.Service
                     Auth = Variables.AppSettings.ServiceAuthId
                 };
 
-                foreach (var configuredCommand in configuredCommands.ConvertToRpcConfiguredCommands()) setConfiguredCommandsRequest.ConfiguredServerCommands.Add(configuredCommand);
+                foreach (var configuredCommand in configuredCommands.ConvertToRpcConfiguredCommands())
+                    setConfiguredCommandsRequest.ConfiguredServerCommands.Add(configuredCommand);
 
                 var response = await _rpcClient.SetConfiguredCommandsAsync(setConfiguredCommandsRequest);
-                if (response.Ok) return (true, string.Empty);
+                if (response.Ok)
+                    return (true, string.Empty);
 
                 Log.Error("[SERVICE] SetConfiguredCommands request failed: {err}", response.Error);
+                
                 return (false, response.Error);
             }
             catch (RpcException ex)
@@ -164,6 +173,7 @@ namespace HASS.Agent.Service
                     return (true, string.Empty);
 
                 Log.Error("[SERVICE] SetConfiguredSensors request failed: {err}", response.Error);
+                
                 return (false, response.Error);
             }
             catch (RpcException ex)

--- a/src/HASS.Agent/HASS.Agent/Service/Requests/RpcSetRequests.cs
+++ b/src/HASS.Agent/HASS.Agent/Service/Requests/RpcSetRequests.cs
@@ -156,10 +156,12 @@ namespace HASS.Agent.Service
                     Auth = Variables.AppSettings.ServiceAuthId
                 };
 
-                foreach (var configuredSensor in configuredSensors.ConvertToRpcConfiguredSensors()) setConfiguredSensorsRequest.ConfiguredServerSensors.Add(configuredSensor);
+                foreach (var configuredSensor in configuredSensors.ConvertToRpcConfiguredSensors())
+                    setConfiguredSensorsRequest.ConfiguredServerSensors.Add(configuredSensor);
 
                 var response = await _rpcClient.SetConfiguredSensorsAsync(setConfiguredSensorsRequest);
-                if (response.Ok) return (true, string.Empty);
+                if (response.Ok)
+                    return (true, string.Empty);
 
                 Log.Error("[SERVICE] SetConfiguredSensors request failed: {err}", response.Error);
                 return (false, response.Error);

--- a/src/HASS.Agent/HASS.Agent/Settings/StoredCommands.cs
+++ b/src/HASS.Agent/HASS.Agent/Settings/StoredCommands.cs
@@ -95,88 +95,88 @@ namespace HASS.Agent.Settings
             switch (command.Type)
             {
                 case CommandType.ShutdownCommand:
-                    abstractCommand = new ShutdownCommand(command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new ShutdownCommand(command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.RestartCommand:
-                    abstractCommand = new RestartCommand(command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new RestartCommand(command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.HibernateCommand:
-                    abstractCommand = new HibernateCommand(command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new HibernateCommand(command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.SleepCommand:
-                    abstractCommand = new SleepCommand(command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new SleepCommand(command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.LogOffCommand:
-                    abstractCommand = new LogOffCommand(command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new LogOffCommand(command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.LockCommand:
-                    abstractCommand = new LockCommand(command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new LockCommand(command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.CustomCommand:
-                    abstractCommand = new CustomCommand(command.Command, command.RunAsLowIntegrity, command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new CustomCommand(command.Command, command.RunAsLowIntegrity, command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.PowershellCommand:
-                    abstractCommand = new PowershellCommand(command.Command, command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new PowershellCommand(command.Command, command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.MediaPlayPauseCommand:
-                    abstractCommand = new MediaPlayPauseCommand(command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new MediaPlayPauseCommand(command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.MediaNextCommand:
-                    abstractCommand = new MediaNextCommand(command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new MediaNextCommand(command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.MediaPreviousCommand:
-                    abstractCommand = new MediaPreviousCommand(command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new MediaPreviousCommand(command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.MediaVolumeUpCommand:
-                    abstractCommand = new MediaVolumeUpCommand(command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new MediaVolumeUpCommand(command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.MediaVolumeDownCommand:
-                    abstractCommand = new MediaVolumeDownCommand(command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new MediaVolumeDownCommand(command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.MediaMuteCommand:
-                    abstractCommand = new MediaMuteCommand(command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new MediaMuteCommand(command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.KeyCommand:
-                    abstractCommand = new KeyCommand(command.KeyCode, command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new KeyCommand(command.KeyCode, command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.PublishAllSensorsCommand:
-                    abstractCommand = new PublishAllSensorsCommand(command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new PublishAllSensorsCommand(command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.LaunchUrlCommand:
-                    abstractCommand = new LaunchUrlCommand(command.Name, command.FriendlyName, command.Command, command.EntityType, command.Id.ToString());
+                    abstractCommand = new LaunchUrlCommand(command.EntityName, command.Name, command.Command, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.CustomExecutorCommand:
-                    abstractCommand = new CustomExecutorCommand(command.Name, command.FriendlyName, command.Command, command.EntityType, command.Id.ToString());
+                    abstractCommand = new CustomExecutorCommand(command.EntityName, command.Name, command.Command, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.MultipleKeysCommand:
-                    abstractCommand = new MultipleKeysCommand(command.Keys, command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new MultipleKeysCommand(command.Keys, command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.SendWindowToFrontCommand:
-                    abstractCommand = new SendWindowToFrontCommand(command.Name, command.FriendlyName, command.Command, command.EntityType, command.Id.ToString());
+                    abstractCommand = new SendWindowToFrontCommand(command.EntityName, command.Name, command.Command, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.SwitchDesktopCommand:
-                    abstractCommand = new SwitchDesktopCommand(command.Name, command.FriendlyName, command.Command, command.EntityType, command.Id.ToString());
+                    abstractCommand = new SwitchDesktopCommand(command.EntityName, command.Name, command.Command, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.WebViewCommand:
-                    abstractCommand = new WebViewCommand(command.Name, command.FriendlyName, command.Command, command.EntityType, command.Id.ToString());
+                    abstractCommand = new WebViewCommand(command.EntityName, command.Name, command.Command, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.MonitorSleepCommand:
-                    abstractCommand = new MonitorSleepCommand(command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new MonitorSleepCommand(command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.MonitorWakeCommand:
-                    abstractCommand = new MonitorWakeCommand(command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new MonitorWakeCommand(command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.SetVolumeCommand:
-                    abstractCommand = new SetVolumeCommand(command.Name, command.FriendlyName, command.Command, command.EntityType, command.Id.ToString());
+                    abstractCommand = new SetVolumeCommand(command.EntityName, command.Name, command.Command, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.RadioCommand:
-                    abstractCommand = new RadioCommand(command.Command, command.Name, command.FriendlyName, command.EntityType, command.Id.ToString());
+                    abstractCommand = new RadioCommand(command.Command, command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
                 case CommandType.SetApplicationVolumeCommand:
-                    abstractCommand = new SetApplicationVolumeCommand(command.Name, command.FriendlyName, command.Command, command.EntityType, command.Id.ToString());
+                    abstractCommand = new SetApplicationVolumeCommand(command.EntityName, command.Name, command.Command, command.EntityType, command.Id.ToString());
                     break;
                 default:
-                    Log.Error("[SETTINGS_COMMANDS] [{name}] Unknown configured command type: {type}", command.Name, command.Type.ToString());
+                    Log.Error("[SETTINGS_COMMANDS] [{name}] Unknown configured command type: {type}", command.EntityName, command.Type.ToString());
                     break;
             }
 
@@ -198,8 +198,8 @@ namespace HASS.Agent.Settings
                         return new ConfiguredCommand()
                         {
                             Id = Guid.Parse(customCommand.Id),
-                            Name = customCommand.Name,
-                            FriendlyName = customCommand.FriendlyName,
+                            EntityName = customCommand.EntityName,
+                            Name = customCommand.EntityName,
                             Type = type,
                             EntityType = command.EntityType,
                             Command = customCommand.Command,
@@ -213,8 +213,8 @@ namespace HASS.Agent.Settings
                         return new ConfiguredCommand()
                         {
                             Id = Guid.Parse(powershellCommand.Id),
-                            Name = powershellCommand.Name,
-                            FriendlyName = powershellCommand.FriendlyName,
+                            EntityName = powershellCommand.EntityName,
+                            Name = powershellCommand.EntityName,
                             Type = type,
                             EntityType = command.EntityType,
                             Command = powershellCommand.Command
@@ -227,8 +227,8 @@ namespace HASS.Agent.Settings
                         return new ConfiguredCommand()
                         {
                             Id = Guid.Parse(customKeyCommand.Id),
-                            Name = customKeyCommand.Name,
-                            FriendlyName = customKeyCommand.FriendlyName,
+                            EntityName = customKeyCommand.EntityName,
+                            Name = customKeyCommand.EntityName,
                             Type = type,
                             EntityType = command.EntityType,
                             KeyCode = customKeyCommand.KeyCode
@@ -241,8 +241,8 @@ namespace HASS.Agent.Settings
                         return new ConfiguredCommand()
                         {
                             Id = Guid.Parse(internalCommand.Id),
-                            Name = internalCommand.Name,
-                            FriendlyName = internalCommand.FriendlyName,
+                            EntityName = internalCommand.EntityName,
+                            Name = internalCommand.EntityName,
                             Command = internalCommand.CommandConfig ?? string.Empty,
                             Type = type,
                             EntityType = command.EntityType,
@@ -255,8 +255,8 @@ namespace HASS.Agent.Settings
                         return new ConfiguredCommand()
                         {
                             Id = Guid.Parse(multipleKeysCommand.Id),
-                            Name = multipleKeysCommand.Name,
-                            FriendlyName = multipleKeysCommand.FriendlyName,
+                            EntityName = multipleKeysCommand.EntityName,
+                            Name = multipleKeysCommand.EntityName,
                             Keys = multipleKeysCommand.Keys ?? new List<string>(),
                             Type = type,
                             EntityType = command.EntityType,

--- a/src/HASS.Agent/HASS.Agent/Settings/StoredCommands.cs
+++ b/src/HASS.Agent/HASS.Agent/Settings/StoredCommands.cs
@@ -199,7 +199,7 @@ namespace HASS.Agent.Settings
                         {
                             Id = Guid.Parse(customCommand.Id),
                             EntityName = customCommand.EntityName,
-                            Name = customCommand.EntityName,
+                            Name = customCommand.Name,
                             Type = type,
                             EntityType = command.EntityType,
                             Command = customCommand.Command,
@@ -214,7 +214,7 @@ namespace HASS.Agent.Settings
                         {
                             Id = Guid.Parse(powershellCommand.Id),
                             EntityName = powershellCommand.EntityName,
-                            Name = powershellCommand.EntityName,
+                            Name = powershellCommand.Name,
                             Type = type,
                             EntityType = command.EntityType,
                             Command = powershellCommand.Command
@@ -228,7 +228,7 @@ namespace HASS.Agent.Settings
                         {
                             Id = Guid.Parse(customKeyCommand.Id),
                             EntityName = customKeyCommand.EntityName,
-                            Name = customKeyCommand.EntityName,
+                            Name = customKeyCommand.Name,
                             Type = type,
                             EntityType = command.EntityType,
                             KeyCode = customKeyCommand.KeyCode
@@ -242,7 +242,7 @@ namespace HASS.Agent.Settings
                         {
                             Id = Guid.Parse(internalCommand.Id),
                             EntityName = internalCommand.EntityName,
-                            Name = internalCommand.EntityName,
+                            Name = internalCommand.Name,
                             Command = internalCommand.CommandConfig ?? string.Empty,
                             Type = type,
                             EntityType = command.EntityType,
@@ -256,7 +256,7 @@ namespace HASS.Agent.Settings
                         {
                             Id = Guid.Parse(multipleKeysCommand.Id),
                             EntityName = multipleKeysCommand.EntityName,
-                            Name = multipleKeysCommand.EntityName,
+                            Name = multipleKeysCommand.Name,
                             Keys = multipleKeysCommand.Keys ?? new List<string>(),
                             Type = type,
                             EntityType = command.EntityType,

--- a/src/HASS.Agent/HASS.Agent/Settings/StoredSensors.cs
+++ b/src/HASS.Agent/HASS.Agent/Settings/StoredSensors.cs
@@ -266,7 +266,7 @@ namespace HASS.Agent.Settings
                     {
                         Id = Guid.Parse(wmiSensor.Id), 
                         EntityName = wmiSensor.EntityName,
-                        Name = wmiSensor.EntityName,
+                        Name = wmiSensor.Name,
                         Type = type,
                         UpdateInterval = wmiSensor.UpdateIntervalSeconds,
                         IgnoreAvailability = wmiSensor.IgnoreAvailability,
@@ -284,7 +284,7 @@ namespace HASS.Agent.Settings
                     {
                         Id = Guid.Parse(namedWindowSensor.Id), 
                         EntityName = namedWindowSensor.EntityName,
-                        Name = namedWindowSensor.EntityName,
+                        Name = namedWindowSensor.Name,
                         Type = type,
                         UpdateInterval = namedWindowSensor.UpdateIntervalSeconds,
                         IgnoreAvailability = namedWindowSensor.IgnoreAvailability,
@@ -299,7 +299,7 @@ namespace HASS.Agent.Settings
                     {
                         Id = Guid.Parse(performanceCounterSensor.Id),
                         EntityName = performanceCounterSensor.EntityName,
-                        Name = performanceCounterSensor.EntityName,
+                        Name = performanceCounterSensor.Name,
                         Type = type,
                         UpdateInterval = performanceCounterSensor.UpdateIntervalSeconds,
                         IgnoreAvailability = performanceCounterSensor.IgnoreAvailability,
@@ -318,7 +318,7 @@ namespace HASS.Agent.Settings
                     {
                         Id = Guid.Parse(processActiveSensor.Id),
                         EntityName = processActiveSensor.EntityName,
-                        Name = processActiveSensor.EntityName,
+                        Name = processActiveSensor.Name,
                         Type = type,
                         UpdateInterval = processActiveSensor.UpdateIntervalSeconds,
                         IgnoreAvailability = processActiveSensor.IgnoreAvailability,
@@ -333,7 +333,7 @@ namespace HASS.Agent.Settings
                     {
                         Id = Guid.Parse(serviceStateSensor.Id),
                         EntityName = serviceStateSensor.EntityName,
-                        Name = serviceStateSensor.EntityName,
+                        Name = serviceStateSensor.Name,
                         Type = type,
                         UpdateInterval = serviceStateSensor.UpdateIntervalSeconds,
                         IgnoreAvailability = serviceStateSensor.IgnoreAvailability,
@@ -348,7 +348,7 @@ namespace HASS.Agent.Settings
                     {
                         Id = Guid.Parse(powershellSensor.Id),
                         EntityName = powershellSensor.EntityName,
-                        Name = powershellSensor.EntityName,
+                        Name = powershellSensor.Name,
                         Type = type,
                         UpdateInterval = powershellSensor.UpdateIntervalSeconds,
                         IgnoreAvailability = powershellSensor.IgnoreAvailability,
@@ -365,7 +365,7 @@ namespace HASS.Agent.Settings
 						{
 							Id = Guid.Parse(lastActiveSensor.Id),
 							EntityName = lastActiveSensor.EntityName,
-							Name = lastActiveSensor.EntityName,
+							Name = lastActiveSensor.Name,
 							Type = type,
 							UpdateInterval = lastActiveSensor.UpdateIntervalSeconds,
 							IgnoreAvailability = lastActiveSensor.IgnoreAvailability,
@@ -381,7 +381,7 @@ namespace HASS.Agent.Settings
                     {
                         Id = Guid.Parse(windowStateSensor.Id),
                         EntityName = windowStateSensor.EntityName,
-                        Name = windowStateSensor.EntityName,
+                        Name = windowStateSensor.Name,
                         Type = type,
                         UpdateInterval = windowStateSensor.UpdateIntervalSeconds,
                         IgnoreAvailability = windowStateSensor.IgnoreAvailability,
@@ -396,7 +396,7 @@ namespace HASS.Agent.Settings
                         {
                             Id = Guid.Parse(internalDeviceSensor.Id),
                             EntityName = internalDeviceSensor.EntityName,
-                            Name = internalDeviceSensor.EntityName,
+                            Name = internalDeviceSensor.Name,
                             Type = type,
                             UpdateInterval = internalDeviceSensor.UpdateIntervalSeconds,
 							IgnoreAvailability = internalDeviceSensor.IgnoreAvailability,
@@ -411,7 +411,7 @@ namespace HASS.Agent.Settings
                     {
                         Id = Guid.Parse(sensor.Id), 
                         EntityName = sensor.EntityName,
-                        Name = sensor.EntityName,
+                        Name = sensor.Name,
                         Type = type, 
                         UpdateInterval = sensor.UpdateIntervalSeconds,
                         IgnoreAvailability = sensor.IgnoreAvailability

--- a/src/HASS.Agent/HASS.Agent/Settings/StoredSensors.cs
+++ b/src/HASS.Agent/HASS.Agent/Settings/StoredSensors.cs
@@ -103,103 +103,103 @@ namespace HASS.Agent.Settings
             switch (sensor.Type)
             {
                 case SensorType.UserNotificationStateSensor:
-                    abstractSensor = new UserNotificationStateSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new UserNotificationStateSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.DummySensor:
-                    abstractSensor = new DummySensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new DummySensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.CurrentClockSpeedSensor:
-                    abstractSensor = new CurrentClockSpeedSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new CurrentClockSpeedSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.CpuLoadSensor:
-                    abstractSensor = new CpuLoadSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new CpuLoadSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.MemoryUsageSensor:
-                    abstractSensor = new MemoryUsageSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new MemoryUsageSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.ActiveWindowSensor:
-                    abstractSensor = new ActiveWindowSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new ActiveWindowSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.ActiveDesktopSensor:
-                    abstractSensor = new ActiveDesktopSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new ActiveDesktopSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.NamedWindowSensor:
-                    abstractSensor = new NamedWindowSensor(sensor.WindowName, sensor.Name, sensor.FriendlyName, sensor.UpdateInterval, sensor.Id.ToString());
+                    abstractSensor = new NamedWindowSensor(sensor.WindowName, sensor.EntityName, sensor.Name, sensor.UpdateInterval, sensor.Id.ToString());
                     break;
 				case SensorType.LastActiveSensor:
-					abstractSensor = new LastActiveSensor(sensor.ApplyRounding, sensor.Round, sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+					abstractSensor = new LastActiveSensor(sensor.ApplyRounding, sensor.Round, sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
 					break;
 				case SensorType.LastSystemStateChangeSensor:
-                    abstractSensor = new LastSystemStateChangeSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new LastSystemStateChangeSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.LastBootSensor:
-                    abstractSensor = new LastBootSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new LastBootSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.WebcamActiveSensor:
-                    abstractSensor = new WebcamActiveSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new WebcamActiveSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.MicrophoneActiveSensor:
-                    abstractSensor = new MicrophoneActiveSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new MicrophoneActiveSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.SessionStateSensor:
-                    abstractSensor = new SessionStateSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new SessionStateSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.CurrentVolumeSensor:
-                    abstractSensor = new CurrentVolumeSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new CurrentVolumeSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.GpuLoadSensor:
-                    abstractSensor = new GpuLoadSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new GpuLoadSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.GpuTemperatureSensor:
-                    abstractSensor = new GpuTemperatureSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new GpuTemperatureSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.WmiQuerySensor:
-                    abstractSensor = new WmiQuerySensor(sensor.Query, sensor.Scope, sensor.ApplyRounding, sensor.Round, sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new WmiQuerySensor(sensor.Query, sensor.Scope, sensor.ApplyRounding, sensor.Round, sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.PerformanceCounterSensor:
-                    abstractSensor = new PerformanceCounterSensor(sensor.Category, sensor.Counter, sensor.Instance, sensor.ApplyRounding, sensor.Round, sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new PerformanceCounterSensor(sensor.Category, sensor.Counter, sensor.Instance, sensor.ApplyRounding, sensor.Round, sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.ProcessActiveSensor:
-                    abstractSensor = new ProcessActiveSensor(sensor.Query, sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new ProcessActiveSensor(sensor.Query, sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.ServiceStateSensor:
-                    abstractSensor = new ServiceStateSensor(sensor.Query, sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new ServiceStateSensor(sensor.Query, sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.LoggedUsersSensor:
-                    abstractSensor = new LoggedUsersSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new LoggedUsersSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.LoggedUserSensor:
-                    abstractSensor = new LoggedUserSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new LoggedUserSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.GeoLocationSensor:
-                    abstractSensor = new GeoLocationSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new GeoLocationSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.MonitorPowerStateSensor:
-                    abstractSensor = new MonitorPowerStateSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new MonitorPowerStateSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.PowershellSensor:
-                    abstractSensor = new PowershellSensor(sensor.Query, sensor.ApplyRounding, sensor.Round, sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new PowershellSensor(sensor.Query, sensor.ApplyRounding, sensor.Round, sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.WindowStateSensor:
-                    abstractSensor = new WindowStateSensor(sensor.Query, sensor.Name, sensor.FriendlyName, sensor.UpdateInterval, sensor.Id.ToString());
+                    abstractSensor = new WindowStateSensor(sensor.Query, sensor.EntityName, sensor.Name, sensor.UpdateInterval, sensor.Id.ToString());
                     break;
                 case SensorType.MicrophoneProcessSensor:
-                    abstractSensor = new MicrophoneProcessSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new MicrophoneProcessSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.WebcamProcessSensor:
-                    abstractSensor = new WebcamProcessSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new WebcamProcessSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.BluetoothDevicesSensor:
-                    abstractSensor = new BluetoothDevicesSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new BluetoothDevicesSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.BluetoothLeDevicesSensor:
-                    abstractSensor = new BluetoothLeDevicesSensor(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new BluetoothLeDevicesSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.InternalDeviceSensor:
-                    abstractSensor = new InternalDeviceSensor(sensor.Query, sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+                    abstractSensor = new InternalDeviceSensor(sensor.Query, sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 default:
-                    Log.Error("[SETTINGS_SENSORS] [{name}] Unknown configured single-value sensor type: {type}", sensor.Name, sensor.Type.ToString());
+                    Log.Error("[SETTINGS_SENSORS] [{name}] Unknown configured single-value sensor type: {type}", sensor.EntityName, sensor.Type.ToString());
                     break;
             }
 
@@ -220,28 +220,28 @@ namespace HASS.Agent.Settings
 			switch (sensor.Type)
 			{
 				case SensorType.StorageSensors:
-					abstractSensor = new StorageSensors(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+					abstractSensor = new StorageSensors(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
 					break;
 				case SensorType.NetworkSensors:
-					abstractSensor = new NetworkSensors(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Query, sensor.Id.ToString());
+					abstractSensor = new NetworkSensors(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Query, sensor.Id.ToString());
 					break;
 				case SensorType.WindowsUpdatesSensors:
-					abstractSensor = new WindowsUpdatesSensors(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+					abstractSensor = new WindowsUpdatesSensors(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
 					break;
 				case SensorType.BatterySensors:
-					abstractSensor = new BatterySensors(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+					abstractSensor = new BatterySensors(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
 					break;
 				case SensorType.DisplaySensors:
-					abstractSensor = new DisplaySensors(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+					abstractSensor = new DisplaySensors(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
 					break;
 				case SensorType.AudioSensors:
-					abstractSensor = new AudioSensors(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+					abstractSensor = new AudioSensors(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
 					break;
 				case SensorType.PrintersSensors:
-					abstractSensor = new PrintersSensors(sensor.UpdateInterval, sensor.Name, sensor.FriendlyName, sensor.Id.ToString());
+					abstractSensor = new PrintersSensors(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
 					break;
 				default:
-					Log.Error("[SETTINGS_SENSORS] [{name}] Unknown configured multi-value sensor type: {type}", sensor.Name, sensor.Type.ToString());
+					Log.Error("[SETTINGS_SENSORS] [{name}] Unknown configured multi-value sensor type: {type}", sensor.EntityName, sensor.Type.ToString());
 					break;
 			}
 
@@ -265,8 +265,8 @@ namespace HASS.Agent.Settings
                     return new ConfiguredSensor
                     {
                         Id = Guid.Parse(wmiSensor.Id), 
-                        Name = wmiSensor.Name,
-                        FriendlyName = wmiSensor.FriendlyName,
+                        EntityName = wmiSensor.EntityName,
+                        Name = wmiSensor.EntityName,
                         Type = type,
                         UpdateInterval = wmiSensor.UpdateIntervalSeconds,
                         IgnoreAvailability = wmiSensor.IgnoreAvailability,
@@ -283,8 +283,8 @@ namespace HASS.Agent.Settings
                     return new ConfiguredSensor
                     {
                         Id = Guid.Parse(namedWindowSensor.Id), 
-                        Name = namedWindowSensor.Name,
-                        FriendlyName = namedWindowSensor.FriendlyName,
+                        EntityName = namedWindowSensor.EntityName,
+                        Name = namedWindowSensor.EntityName,
                         Type = type,
                         UpdateInterval = namedWindowSensor.UpdateIntervalSeconds,
                         IgnoreAvailability = namedWindowSensor.IgnoreAvailability,
@@ -298,8 +298,8 @@ namespace HASS.Agent.Settings
                     return new ConfiguredSensor
                     {
                         Id = Guid.Parse(performanceCounterSensor.Id),
-                        Name = performanceCounterSensor.Name,
-                        FriendlyName = performanceCounterSensor.FriendlyName,
+                        EntityName = performanceCounterSensor.EntityName,
+                        Name = performanceCounterSensor.EntityName,
                         Type = type,
                         UpdateInterval = performanceCounterSensor.UpdateIntervalSeconds,
                         IgnoreAvailability = performanceCounterSensor.IgnoreAvailability,
@@ -317,8 +317,8 @@ namespace HASS.Agent.Settings
                     return new ConfiguredSensor
                     {
                         Id = Guid.Parse(processActiveSensor.Id),
-                        Name = processActiveSensor.Name,
-                        FriendlyName = processActiveSensor.FriendlyName,
+                        EntityName = processActiveSensor.EntityName,
+                        Name = processActiveSensor.EntityName,
                         Type = type,
                         UpdateInterval = processActiveSensor.UpdateIntervalSeconds,
                         IgnoreAvailability = processActiveSensor.IgnoreAvailability,
@@ -332,8 +332,8 @@ namespace HASS.Agent.Settings
                     return new ConfiguredSensor
                     {
                         Id = Guid.Parse(serviceStateSensor.Id),
-                        Name = serviceStateSensor.Name,
-                        FriendlyName = serviceStateSensor.FriendlyName,
+                        EntityName = serviceStateSensor.EntityName,
+                        Name = serviceStateSensor.EntityName,
                         Type = type,
                         UpdateInterval = serviceStateSensor.UpdateIntervalSeconds,
                         IgnoreAvailability = serviceStateSensor.IgnoreAvailability,
@@ -347,8 +347,8 @@ namespace HASS.Agent.Settings
                     return new ConfiguredSensor
                     {
                         Id = Guid.Parse(powershellSensor.Id),
-                        Name = powershellSensor.Name,
-                        FriendlyName = powershellSensor.FriendlyName,
+                        EntityName = powershellSensor.EntityName,
+                        Name = powershellSensor.EntityName,
                         Type = type,
                         UpdateInterval = powershellSensor.UpdateIntervalSeconds,
                         IgnoreAvailability = powershellSensor.IgnoreAvailability,
@@ -364,8 +364,8 @@ namespace HASS.Agent.Settings
 						return new ConfiguredSensor
 						{
 							Id = Guid.Parse(lastActiveSensor.Id),
-							Name = lastActiveSensor.Name,
-							FriendlyName = lastActiveSensor.FriendlyName,
+							EntityName = lastActiveSensor.EntityName,
+							Name = lastActiveSensor.EntityName,
 							Type = type,
 							UpdateInterval = lastActiveSensor.UpdateIntervalSeconds,
 							IgnoreAvailability = lastActiveSensor.IgnoreAvailability,
@@ -380,8 +380,8 @@ namespace HASS.Agent.Settings
                     return new ConfiguredSensor
                     {
                         Id = Guid.Parse(windowStateSensor.Id),
-                        Name = windowStateSensor.Name,
-                        FriendlyName = windowStateSensor.FriendlyName,
+                        EntityName = windowStateSensor.EntityName,
+                        Name = windowStateSensor.EntityName,
                         Type = type,
                         UpdateInterval = windowStateSensor.UpdateIntervalSeconds,
                         IgnoreAvailability = windowStateSensor.IgnoreAvailability,
@@ -395,8 +395,8 @@ namespace HASS.Agent.Settings
                         return new ConfiguredSensor
                         {
                             Id = Guid.Parse(internalDeviceSensor.Id),
-                            Name = internalDeviceSensor.Name,
-                            FriendlyName = internalDeviceSensor.FriendlyName,
+                            EntityName = internalDeviceSensor.EntityName,
+                            Name = internalDeviceSensor.EntityName,
                             Type = type,
                             UpdateInterval = internalDeviceSensor.UpdateIntervalSeconds,
 							IgnoreAvailability = internalDeviceSensor.IgnoreAvailability,
@@ -410,8 +410,8 @@ namespace HASS.Agent.Settings
                     return new ConfiguredSensor
                     {
                         Id = Guid.Parse(sensor.Id), 
-                        Name = sensor.Name,
-                        FriendlyName = sensor.FriendlyName,
+                        EntityName = sensor.EntityName,
+                        Name = sensor.EntityName,
                         Type = type, 
                         UpdateInterval = sensor.UpdateIntervalSeconds,
                         IgnoreAvailability = sensor.IgnoreAvailability
@@ -435,8 +435,8 @@ namespace HASS.Agent.Settings
                     return new ConfiguredSensor
                     {
                         Id = Guid.Parse(sensor.Id),
-                        Name = sensor.Name,
-                        FriendlyName = sensor.FriendlyName,
+                        EntityName = sensor.EntityName,
+                        Name = sensor.EntityName,
                         Type = type,
                         UpdateInterval = sensor.UpdateIntervalSeconds,
                         IgnoreAvailability = sensor.IgnoreAvailability
@@ -449,8 +449,8 @@ namespace HASS.Agent.Settings
                     return new ConfiguredSensor
                     {
                         Id = Guid.Parse(sensor.Id),
-                        Name = sensor.Name,
-                        FriendlyName = sensor.FriendlyName,
+                        EntityName = sensor.EntityName,
+                        Name = sensor.EntityName,
                         Query = networkSensors.NetworkCard,
                         Type = type,
                         UpdateInterval = sensor.UpdateIntervalSeconds,
@@ -464,8 +464,8 @@ namespace HASS.Agent.Settings
                     return new ConfiguredSensor
                     {
                         Id = Guid.Parse(sensor.Id),
-                        Name = sensor.Name,
-                        FriendlyName = sensor.FriendlyName,
+                        EntityName = sensor.EntityName,
+                        Name = sensor.EntityName,
                         Type = type,
                         UpdateInterval = sensor.UpdateIntervalSeconds,
                         IgnoreAvailability = sensor.IgnoreAvailability
@@ -478,8 +478,8 @@ namespace HASS.Agent.Settings
                     return new ConfiguredSensor
                     {
                         Id = Guid.Parse(sensor.Id),
-                        Name = sensor.Name,
-                        FriendlyName = sensor.FriendlyName,
+                        EntityName = sensor.EntityName,
+                        Name = sensor.EntityName,
                         Type = type,
                         UpdateInterval = sensor.UpdateIntervalSeconds,
                         IgnoreAvailability = sensor.IgnoreAvailability
@@ -492,8 +492,8 @@ namespace HASS.Agent.Settings
                     return new ConfiguredSensor
                     {
                         Id = Guid.Parse(sensor.Id),
-                        Name = sensor.Name,
-                        FriendlyName = sensor.FriendlyName,
+                        EntityName = sensor.EntityName,
+                        Name = sensor.EntityName,
                         Type = type,
                         UpdateInterval = sensor.UpdateIntervalSeconds,
                         IgnoreAvailability = sensor.IgnoreAvailability
@@ -506,8 +506,8 @@ namespace HASS.Agent.Settings
                     return new ConfiguredSensor
                     {
                         Id = Guid.Parse(sensor.Id),
-                        Name = sensor.Name,
-                        FriendlyName = sensor.FriendlyName,
+                        EntityName = sensor.EntityName,
+                        Name = sensor.EntityName,
                         Type = type,
                         UpdateInterval = sensor.UpdateIntervalSeconds,
                         IgnoreAvailability = sensor.IgnoreAvailability
@@ -520,8 +520,8 @@ namespace HASS.Agent.Settings
                     return new ConfiguredSensor
                     {
                         Id = Guid.Parse(sensor.Id),
-                        Name = sensor.Name,
-                        FriendlyName = sensor.FriendlyName,
+                        EntityName = sensor.EntityName,
+                        Name = sensor.EntityName,
                         Type = type,
                         UpdateInterval = sensor.UpdateIntervalSeconds,
                         IgnoreAvailability = sensor.IgnoreAvailability


### PR DESCRIPTION
This PR:
- fixes exception being thrown when entity is removed from configuration before being activated first
- fixes "Friendly name" not working correctly with 2023.8 MQTT changes
- adds proper handling of "Friendly name" for Satellite Service entities
- fixes installer paths to be correct after PR renaming solution's projects
- adds proper configuration migration path from both 2023Beta as well as LAB02 versions
- fixes 2023.8 name migration compatibility task skipping Satellite Service entities
- fixes MultiValue sensors causing Home Assistant unique id issues for internal sensors (possible breaking change in sensor history not being compatible)