### PR TITLE
Fix: null referece within migration task

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ on:
 
 jobs:
   build:
-    environment: TestEnv
+    environment: ReleaseBuildEnv
     strategy:
       matrix:
         #configuration: [Debug, Release]

--- a/README.md
+++ b/README.md
@@ -87,4 +87,4 @@ Documentation for the original project is available here: [https://hassagent.rea
 
 ----
 
-Thanks! If you need more info, please join on [Discord](https://discord.gg/nMvqzwrVBU).
+Thanks! If you need more info, please join on [Discord](https://discord.com/invite/JfZj98xqJr).

--- a/src/HASS.Agent.Installer/InstallerScript.iss
+++ b/src/HASS.Agent.Installer/InstallerScript.iss
@@ -69,7 +69,7 @@ Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
 Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
 
 [Run]
-Filename: "{app}\{#MyAppExeName}"; Parameters: "compat_migrate"; Description: "Try to migrate configuration"; Flags: postinstall skipifsilent runascurrentuser
+Filename: "{app}\{#MyAppExeName}"; Parameters: "compat_migrate"; Description: "Try to migrate configuration"; Flags: postinstall skipifsilent runascurrentuser unchecked
 Filename: "{sys}\sc.exe"; Parameters: "start {#ServiceName}"; Description: "Start Satellite Service"; Flags: postinstall runhidden runascurrentuser 
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: postinstall skipifsilent nowait
 

--- a/src/HASS.Agent/HASS.Agent/Compatibility/MigrateCompatibilityTask.cs
+++ b/src/HASS.Agent/HASS.Agent/Compatibility/MigrateCompatibilityTask.cs
@@ -106,11 +106,14 @@ namespace HASS.Agent.Compatibility
             //from HKEY_CURRENT_USER\SOFTWARE\LAB02Research\HASSAgent
             //to   HKEY_CURRENT_USER\SOFTWARE\HASSAgent\Client"
 
-            //from HKEY_LOCAL_MACHINE\SOFTWARE\LAB02Research\HASSAgent\SatelliteService"
-            //to   HKEY_LOCAL_MACHINE\SOFTWARE\HASSAgent\SatelliteService
-
             var source = Registry.CurrentUser.OpenSubKey(@"SOFTWARE\LAB02Research\HASSAgent");
             var destination = Registry.CurrentUser.OpenSubKey(@"SOFTWARE\HASSAgent\Client", true);
+            if(source == null)
+            {
+                Log.Information("[COMPATTASK] No source registry keys found");
+                return;
+            }
+
             CopyRegistryKey(source, destination);
         }
 


### PR DESCRIPTION
This PR
- fixes null reference exception if source (original HASS.Agent) registry keys do not exist
- makes the migration task deselected by default