### PR TITLE
Fix: product version including github hash

### DIFF
--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/HASS.Agent.Satellite.Service.csproj
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/HASS.Agent.Satellite.Service.csproj
@@ -21,6 +21,7 @@
     <ApplicationIcon>hass.ico</ApplicationIcon>
     <FileVersion>2.0.0</FileVersion>
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
+	<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/HASS.Agent.Satellite.Service.csproj
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/HASS.Agent.Satellite.Service.csproj
@@ -8,7 +8,7 @@
     <UserSecretsId>dotnet-HASSAgentSatelliteService-6E4FA50A-3AC9-4E66-8671-9FAB92372154</UserSecretsId>
     <PlatformTarget>x64</PlatformTarget>
     <Platforms>x64;x86</Platforms>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
     <Company>HASS.Agent Team</Company>
     <Product>HASS.Agent Satellite Service</Product>
     <AssemblyName>HASS.Agent.Satellite.Service</AssemblyName>
@@ -17,9 +17,9 @@
     <PackageProjectUrl>https://github.com/hass-agent/HASS.Agent</PackageProjectUrl>
     <RepositoryUrl>https://github.com/hass-agent/HASS.Agent</RepositoryUrl>
     <PackageIcon>hass.png</PackageIcon>
-    <AssemblyVersion>2.0.0</AssemblyVersion>
+    <AssemblyVersion>2.0.1</AssemblyVersion>
     <ApplicationIcon>hass.ico</ApplicationIcon>
-    <FileVersion>2.0.0</FileVersion>
+    <FileVersion>2.0.1</FileVersion>
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
 	<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>

--- a/src/HASS.Agent/HASS.Agent.Shared/HASS.Agent.Shared.csproj
+++ b/src/HASS.Agent/HASS.Agent.Shared/HASS.Agent.Shared.csproj
@@ -10,9 +10,9 @@
     <Description>Shared functions and models for the HASS.Agent platform.</Description>
     <PackageProjectUrl>https://github.com/hass-agent/HASS.Agent</PackageProjectUrl>
     <RepositoryUrl>https://github.com/hass-agent/HASS.Agent</RepositoryUrl>
-    <AssemblyVersion></AssemblyVersion>
-    <FileVersion></FileVersion>
-    <Version>2.0.0</Version>
+    <AssemblyVersion>2.0.1</AssemblyVersion>
+    <FileVersion>2.0.1</FileVersion>
+    <Version>2.0.1</Version>
     <PackageIcon>logo_128.png</PackageIcon>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <ApplicationIcon>hassagent.ico</ApplicationIcon>

--- a/src/HASS.Agent/HASS.Agent.Shared/HASS.Agent.Shared.csproj
+++ b/src/HASS.Agent/HASS.Agent.Shared/HASS.Agent.Shared.csproj
@@ -22,6 +22,7 @@
     <Nullable>disable</Nullable>
     <DebugType>full</DebugType>
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
+	<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HASS.Agent/HASS.Agent/HASS.Agent.csproj
+++ b/src/HASS.Agent/HASS.Agent/HASS.Agent.csproj
@@ -12,7 +12,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <Platforms>x64;x86</Platforms>
     <DebugType>full</DebugType>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
     <Company>HASS.Agent Team</Company>
     <Authors>HASS.Agent Team</Authors>
     <Description>Windows-based client for Home Assistant. Provides notifications, quick actions, commands, sensors and more. </Description>
@@ -22,8 +22,8 @@
     <RepositoryUrl>https://github.com/hass-agent/HASS.Agent</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <AssemblyVersion>2022.15.0</AssemblyVersion>
-    <FileVersion>2022.15.0</FileVersion>
+    <AssemblyVersion>2.0.1</AssemblyVersion>
+    <FileVersion>2.0.1</FileVersion>
     <RootNamespace>HASS.Agent</RootNamespace>
     <WindowsPackageType>None</WindowsPackageType>
     <RuntimeIdentifiers>win10-x64;win10-x86</RuntimeIdentifiers>

--- a/src/HASS.Agent/HASS.Agent/HASS.Agent.csproj
+++ b/src/HASS.Agent/HASS.Agent/HASS.Agent.csproj
@@ -31,6 +31,7 @@
 	<WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
 	<EnableCoreMrtTooling Condition=" '$(BuildingInsideVisualStudio)' != 'true' ">false</EnableCoreMrtTooling>
 	<ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+	<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR adds project property that makes the build system skip github commit hash as a postfix.