### PR TITLE
Fix: update manager crash on malformed version

### DIFF
--- a/src/HASS.Agent.Installer/InstallerScript.iss
+++ b/src/HASS.Agent.Installer/InstallerScript.iss
@@ -9,7 +9,7 @@
 
 ; Standard installation constants
 #define MyAppName "HASS.Agent"
-#define MyAppVersion "2.0.0"
+#define MyAppVersion "2.0.1"
 #define MyAppPublisher "HASS.Agent Team"
 #define MyAppURL "https://hass-agent.io"
 #define MyAppExeName "HASS.Agent.exe"

--- a/src/HASS.Agent/HASS.Agent/Managers/UpdateManager.cs
+++ b/src/HASS.Agent/HASS.Agent/Managers/UpdateManager.cs
@@ -15,7 +15,7 @@ internal static class UpdateManager
 {
     private static readonly DateTimeOffset s_releaseCutoff = new(2023, 11, 30, 23, 59, 59, TimeSpan.Zero);
 
-    private static readonly Version CurrentVersion = Version.Parse(Variables.Version.Split('-').First());
+    //private static readonly Version CurrentVersion = Version.Parse(Variables.Version.Split('-').First());
 
     /// <summary>
     /// Initialize initial and periodic update checking

--- a/src/HASS.Agent/HASS.Agent/Managers/UpdateManager.cs
+++ b/src/HASS.Agent/HASS.Agent/Managers/UpdateManager.cs
@@ -15,8 +15,6 @@ internal static class UpdateManager
 {
     private static readonly DateTimeOffset s_releaseCutoff = new(2023, 11, 30, 23, 59, 59, TimeSpan.Zero);
 
-    //private static readonly Version CurrentVersion = Version.Parse(Variables.Version.Split('-').First());
-
     /// <summary>
     /// Initialize initial and periodic update checking
     /// </summary>


### PR DESCRIPTION
This PR contains quick fix for UpdateManager exception when product version is malformed.
