### PR TITLE
Fix: missing audio commands due to improper configuration

### DIFF
--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/HASS.Agent.Satellite.Service.csproj
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/HASS.Agent.Satellite.Service.csproj
@@ -8,7 +8,7 @@
     <UserSecretsId>dotnet-HASSAgentSatelliteService-6E4FA50A-3AC9-4E66-8671-9FAB92372154</UserSecretsId>
     <PlatformTarget>x64</PlatformTarget>
     <Platforms>x64;x86</Platforms>
-    <Version>2.0.2-beta</Version>
+    <Version>2.0.2-beta1</Version>
     <Company>HASS.Agent Team</Company>
     <Product>HASS.Agent Satellite Service</Product>
     <AssemblyName>HASS.Agent.Satellite.Service</AssemblyName>

--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/HASS.Agent.Satellite.Service.csproj
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/HASS.Agent.Satellite.Service.csproj
@@ -8,7 +8,7 @@
     <UserSecretsId>dotnet-HASSAgentSatelliteService-6E4FA50A-3AC9-4E66-8671-9FAB92372154</UserSecretsId>
     <PlatformTarget>x64</PlatformTarget>
     <Platforms>x64;x86</Platforms>
-    <Version>2.0.1</Version>
+    <Version>2.0.2-beta</Version>
     <Company>HASS.Agent Team</Company>
     <Product>HASS.Agent Satellite Service</Product>
     <AssemblyName>HASS.Agent.Satellite.Service</AssemblyName>
@@ -17,9 +17,9 @@
     <PackageProjectUrl>https://github.com/hass-agent/HASS.Agent</PackageProjectUrl>
     <RepositoryUrl>https://github.com/hass-agent/HASS.Agent</RepositoryUrl>
     <PackageIcon>hass.png</PackageIcon>
-    <AssemblyVersion>2.0.1</AssemblyVersion>
+    <AssemblyVersion>2.0.2</AssemblyVersion>
     <ApplicationIcon>hass.ico</ApplicationIcon>
-    <FileVersion>2.0.1</FileVersion>
+    <FileVersion>2.0.2</FileVersion>
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
 	<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>

--- a/src/HASS.Agent/HASS.Agent.Shared/Enums/CommandType.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Enums/CommandType.cs
@@ -101,6 +101,10 @@ namespace HASS.Agent.Shared.Enums
         [EnumMember(Value = "SetApplicationVolumeCommand")]
         SetApplicationVolumeCommand,
 
+        [LocalizedDescription("CommandType_SetAudioOutputCommand", typeof(Languages))]
+        [EnumMember(Value = "SetAudioOutputCommand")]
+        SetAudioOutputCommand,
+
         [LocalizedDescription("CommandType_ShutdownCommand", typeof(Languages))]
         [EnumMember(Value = "ShutdownCommand")]
         ShutdownCommand,

--- a/src/HASS.Agent/HASS.Agent.Shared/HASS.Agent.Shared.csproj
+++ b/src/HASS.Agent/HASS.Agent.Shared/HASS.Agent.Shared.csproj
@@ -10,9 +10,9 @@
     <Description>Shared functions and models for the HASS.Agent platform.</Description>
     <PackageProjectUrl>https://github.com/hass-agent/HASS.Agent</PackageProjectUrl>
     <RepositoryUrl>https://github.com/hass-agent/HASS.Agent</RepositoryUrl>
-    <AssemblyVersion>2.0.1</AssemblyVersion>
-    <FileVersion>2.0.1</FileVersion>
-    <Version>2.0.1</Version>
+    <AssemblyVersion>2.0.2</AssemblyVersion>
+    <FileVersion>2.0.2</FileVersion>
+    <Version>2.0.2-beta</Version>
     <PackageIcon>logo_128.png</PackageIcon>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <ApplicationIcon>hassagent.ico</ApplicationIcon>

--- a/src/HASS.Agent/HASS.Agent.Shared/HASS.Agent.Shared.csproj
+++ b/src/HASS.Agent/HASS.Agent.Shared/HASS.Agent.Shared.csproj
@@ -12,7 +12,7 @@
     <RepositoryUrl>https://github.com/hass-agent/HASS.Agent</RepositoryUrl>
     <AssemblyVersion>2.0.2</AssemblyVersion>
     <FileVersion>2.0.2</FileVersion>
-    <Version>2.0.2-beta</Version>
+    <Version>2.0.2-beta1</Version>
     <PackageIcon>logo_128.png</PackageIcon>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <ApplicationIcon>hassagent.ico</ApplicationIcon>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.Designer.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.Designer.cs
@@ -1285,6 +1285,15 @@ namespace HASS.Agent.Shared.Resources.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to SetAudioOutputCommand.
+        /// </summary>
+        internal static string CommandType_SetAudioOutputCommand {
+            get {
+                return ResourceManager.GetString("CommandType_SetAudioOutputCommand", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to SetVolume.
         /// </summary>
         internal static string CommandType_SetVolumeCommand {

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.de.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.de.resx
@@ -3352,4 +3352,10 @@ Willst Du den Runtime Installer herunterladen?</value>
   <data name="SensorType_ActiveDesktopSensor" xml:space="preserve">
     <value>AktiverDesktop</value>
   </data>
+  <data name="CommandType_SetApplicationVolumeCommand" xml:space="preserve">
+    <value>Legen Sie die Anwendungslautstärke fest</value>
+  </data>
+  <data name="CommandType_SetAudioOutputCommand" xml:space="preserve">
+    <value>Legen Sie den Audioausgabebefehl fest</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.en.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.en.resx
@@ -3231,4 +3231,10 @@ Do you want to download the runtime installer?</value>
   <data name="SensorType_ActiveDesktopSensor" xml:space="preserve">
     <value>ActiveDesktop</value>
   </data>
+  <data name="CommandType_SetApplicationVolumeCommand" xml:space="preserve">
+    <value>SetApplicationVolume</value>
+  </data>
+  <data name="CommandType_SetAudioOutputCommand" xml:space="preserve">
+    <value>SetAudioOutputCommand</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.es.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.es.resx
@@ -3228,4 +3228,10 @@ Oculta, Maximizada, Minimizada, Normal y Desconocida.</value>
   <data name="SensorType_ActiveDesktopSensor" xml:space="preserve">
     <value>EscritorioActivo</value>
   </data>
+  <data name="CommandType_SetApplicationVolumeCommand" xml:space="preserve">
+    <value>Establecer volumen de aplicación</value>
+  </data>
+  <data name="CommandType_SetAudioOutputCommand" xml:space="preserve">
+    <value>Establecer comando de salida de audio</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.fr.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.fr.resx
@@ -3261,4 +3261,10 @@ Do you want to download the runtime installer?</value>
   <data name="SensorType_ActiveDesktopSensor" xml:space="preserve">
     <value>ActiveDesktop</value>
   </data>
+  <data name="CommandType_SetApplicationVolumeCommand" xml:space="preserve">
+    <value>Définir le volume d'application</value>
+  </data>
+  <data name="CommandType_SetAudioOutputCommand" xml:space="preserve">
+    <value>Définir la commande de sortie audio</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.nl.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.nl.resx
@@ -3250,4 +3250,10 @@ Wil je de runtime installatie downloaden?</value>
   <data name="SensorType_ActiveDesktopSensor" xml:space="preserve">
     <value>ActiveDesktop</value>
   </data>
+  <data name="CommandType_SetApplicationVolumeCommand" xml:space="preserve">
+    <value>Stel het toepassingsvolume in</value>
+  </data>
+  <data name="CommandType_SetAudioOutputCommand" xml:space="preserve">
+    <value>Stel het audio-uitvoercommando in</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.pl.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.pl.resx
@@ -3338,4 +3338,10 @@ Czy chcesz pobrać plik instalacyjny?</value>
   <data name="SensorType_ActiveDesktopSensor" xml:space="preserve">
     <value>AktywnyPulpit</value>
   </data>
+  <data name="CommandType_SetApplicationVolumeCommand" xml:space="preserve">
+    <value>Ustaw głośność aplikacji</value>
+  </data>
+  <data name="CommandType_SetAudioOutputCommand" xml:space="preserve">
+    <value>Ustaw wyjście audio</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.pt-br.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.pt-br.resx
@@ -3275,4 +3275,10 @@ Deseja baixar o Microsoft WebView2 runtime?</value>
   <data name="SensorType_ActiveDesktopSensor" xml:space="preserve">
     <value>ActiveDesktop</value>
   </data>
+  <data name="CommandType_SetApplicationVolumeCommand" xml:space="preserve">
+    <value>Definir Volume de Aplicativo</value>
+  </data>
+  <data name="CommandType_SetAudioOutputCommand" xml:space="preserve">
+    <value>Definir comando de saída de áudio</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.resx
@@ -3214,4 +3214,7 @@ Do you want to download the runtime installer?</value>
   <data name="CommandType_SwitchDesktopCommand" xml:space="preserve">
     <value>SwitchDesktop</value>
   </data>
+  <data name="CommandType_SetAudioOutputCommand" xml:space="preserve">
+    <value>SetAudioOutputCommand</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.ru.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.ru.resx
@@ -3296,4 +3296,10 @@ Home Assistant.
   <data name="SensorType_ActiveDesktopSensor" xml:space="preserve">
     <value>Активдесктоп</value>
   </data>
+  <data name="CommandType_SetApplicationVolumeCommand" xml:space="preserve">
+    <value>Установить громкость приложения</value>
+  </data>
+  <data name="CommandType_SetAudioOutputCommand" xml:space="preserve">
+    <value>Установить команду вывода звука</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.sl.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.sl.resx
@@ -3377,4 +3377,10 @@ Ali želite prenesti runtime installer?</value>
   <data name="SensorType_ActiveDesktopSensor" xml:space="preserve">
     <value>ActiveDesktop</value>
   </data>
+  <data name="CommandType_SetApplicationVolumeCommand" xml:space="preserve">
+    <value>Nastavite glasnost aplikacije</value>
+  </data>
+  <data name="CommandType_SetAudioOutputCommand" xml:space="preserve">
+    <value>Nastavite ukaz za avdio izhod</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.tr.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.tr.resx
@@ -2835,4 +2835,10 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
   <data name="SensorType_ActiveDesktopSensor" xml:space="preserve">
     <value>AktifMasaüstü</value>
   </data>
+  <data name="CommandType_SetApplicationVolumeCommand" xml:space="preserve">
+    <value>Uygulama Sesini Ayarla</value>
+  </data>
+  <data name="CommandType_SetAudioOutputCommand" xml:space="preserve">
+    <value>Ses Çıkışı Komutunu Ayarla</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Commands/CommandsManager.cs
+++ b/src/HASS.Agent/HASS.Agent/Commands/CommandsManager.cs
@@ -455,13 +455,29 @@ namespace HASS.Agent.Commands
                 Languages.CommandsManager_SwitchDesktopCommandDescription,
                 true, false, true);
 
-            // =================================
-
             CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
+
+            // =================================
 
             commandInfoCard = new CommandInfoCard(CommandType.SetVolumeCommand,
                 Languages.CommandsManager_SetVolumeCommandDescription,
                 true, true, true);
+
+            CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
+
+            // =================================
+
+            commandInfoCard = new CommandInfoCard(CommandType.SetApplicationVolumeCommand,
+                Languages.CommandsManager_SetApplicationVolumeCommandDescription,
+                true, false, true);
+
+            CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
+
+            // =================================
+
+            commandInfoCard = new CommandInfoCard(CommandType.SetAudioOutputCommand,
+                Languages.CommandsManager_SetAudioOutputCommandDescription,
+                true, false, true);
 
             CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
 

--- a/src/HASS.Agent/HASS.Agent/Forms/Commands/CommandsMod.cs
+++ b/src/HASS.Agent/HASS.Agent/Forms/Commands/CommandsMod.cs
@@ -815,10 +815,10 @@ namespace HASS.Agent.Forms.Commands
 			{
 				SetEmptyGui();
 
-				LblSetting.Text = "volume (between 0 and 100)";
-				LblSetting.Visible = true;
+				LblSetting.Text = Languages.CommandsMod_LblSetting_VolumeRange;
+                LblSetting.Visible = true;
 
-				TbSetting.Text = string.Empty;
+                TbSetting.Text = string.Empty;
 				TbSetting.Visible = true;
 			}));
 		}
@@ -832,7 +832,7 @@ namespace HASS.Agent.Forms.Commands
             {
                 SetEmptyGui();
 
-                LblSetting.Text = "JSON Command Payload";
+                LblSetting.Text = Languages.CommandsMod_LblSetting_JsonPayload;
                 LblSetting.Visible = true;
 
                 TbSetting.Text = string.Empty;
@@ -849,7 +849,7 @@ namespace HASS.Agent.Forms.Commands
             {
                 SetEmptyGui();
 
-                LblSetting.Text = "Audio Device Name";
+                LblSetting.Text = Languages.CommandsMod_LblSetting_AudioDeviceName;
                 LblSetting.Visible = true;
 
                 TbSetting.Text = string.Empty;

--- a/src/HASS.Agent/HASS.Agent/Forms/Commands/CommandsMod.cs
+++ b/src/HASS.Agent/HASS.Agent/Forms/Commands/CommandsMod.cs
@@ -205,6 +205,7 @@ namespace HASS.Agent.Forms.Commands
 
                 case CommandType.SetVolumeCommand:
                 case CommandType.SetApplicationVolumeCommand:
+                case CommandType.SetAudioOutputCommand:
                     TbSetting.Text = Command.Command;
                     break;
             }
@@ -455,6 +456,21 @@ namespace HASS.Agent.Forms.Commands
                     }
                     break;
 
+                case CommandType.SetAudioOutputCommand:
+                    var audioDeviceName = TbSetting.Text.Trim();
+                    if (string.IsNullOrEmpty(audioDeviceName))
+                    {
+                        var q = MessageBoxAdv.Show(this, Languages.CommandsMod_BtnStore_MessageBox8, Variables.MessageBoxTitle, MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+                        if (q != DialogResult.Yes)
+                        {
+                            ActiveControl = BtnConfigureCommand;
+                            return;
+                        }
+                    }
+                    Command.Command = audioDeviceName;
+                    break;
+
+
                 case CommandType.WebViewCommand:
                     var webview = TbSetting.Text.Trim();
                     if (string.IsNullOrEmpty(webview))
@@ -612,6 +628,10 @@ namespace HASS.Agent.Forms.Commands
 				case CommandType.SetApplicationVolumeCommand:
 					SetApplicationVolumeUi();
 					break;
+
+                case CommandType.SetAudioOutputCommand:
+                    SetAudioOutputUi();
+                    break;
 
 				case CommandType.RadioCommand:
 					CbConfigDropdown.DataSource = new BindingSource(_radioDevices, null);
@@ -813,6 +833,23 @@ namespace HASS.Agent.Forms.Commands
                 SetEmptyGui();
 
                 LblSetting.Text = "JSON Command Payload";
+                LblSetting.Visible = true;
+
+                TbSetting.Text = string.Empty;
+                TbSetting.Visible = true;
+            }));
+        }
+
+        /// <summary>
+        /// Change the UI to a 'setaudiooutput' type
+        /// </summary>
+        private void SetAudioOutputUi()
+        {
+            Invoke(new MethodInvoker(delegate
+            {
+                SetEmptyGui();
+
+                LblSetting.Text = "Audio Device Name";
                 LblSetting.Visible = true;
 
                 TbSetting.Text = string.Empty;

--- a/src/HASS.Agent/HASS.Agent/HASS.Agent.csproj
+++ b/src/HASS.Agent/HASS.Agent/HASS.Agent.csproj
@@ -12,7 +12,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <Platforms>x64;x86</Platforms>
     <DebugType>full</DebugType>
-    <Version>2.0.2-beta</Version>
+    <Version>2.0.2-beta1</Version>
     <Company>HASS.Agent Team</Company>
     <Authors>HASS.Agent Team</Authors>
     <Description>Windows-based client for Home Assistant. Provides notifications, quick actions, commands, sensors and more. </Description>

--- a/src/HASS.Agent/HASS.Agent/HASS.Agent.csproj
+++ b/src/HASS.Agent/HASS.Agent/HASS.Agent.csproj
@@ -12,7 +12,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <Platforms>x64;x86</Platforms>
     <DebugType>full</DebugType>
-    <Version>2.0.1</Version>
+    <Version>2.0.2-beta</Version>
     <Company>HASS.Agent Team</Company>
     <Authors>HASS.Agent Team</Authors>
     <Description>Windows-based client for Home Assistant. Provides notifications, quick actions, commands, sensors and more. </Description>
@@ -22,8 +22,8 @@
     <RepositoryUrl>https://github.com/hass-agent/HASS.Agent</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <AssemblyVersion>2.0.1</AssemblyVersion>
-    <FileVersion>2.0.1</FileVersion>
+    <AssemblyVersion>2.0.2</AssemblyVersion>
+    <FileVersion>2.0.2</FileVersion>
     <RootNamespace>HASS.Agent</RootNamespace>
     <WindowsPackageType>None</WindowsPackageType>
     <RuntimeIdentifiers>win10-x64;win10-x86</RuntimeIdentifiers>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.Designer.cs
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.Designer.cs
@@ -609,6 +609,16 @@ namespace HASS.Agent.Resources.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Sets the default audio output for the system.
+        ///Requires audio device name as a payload..
+        /// </summary>
+        internal static string CommandsManager_SetAudioOutputCommandDescription {
+            get {
+                return ResourceManager.GetString("CommandsManager_SetAudioOutputCommandDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Sets the volume of the current default audiodevice to the specified level..
         /// </summary>
         internal static string CommandsManager_SetVolumeCommandDescription {

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.Designer.cs
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.Designer.cs
@@ -1049,6 +1049,15 @@ namespace HASS.Agent.Resources.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Audio Device Name.
+        /// </summary>
+        internal static string CommandsMod_LblSetting_AudioDeviceName {
+            get {
+                return ResourceManager.GetString("CommandsMod_LblSetting_AudioDeviceName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Command.
         /// </summary>
         internal static string CommandsMod_LblSetting_Command {
@@ -1063,6 +1072,15 @@ namespace HASS.Agent.Resources.Localization {
         internal static string CommandsMod_LblSetting_CommandScript {
             get {
                 return ResourceManager.GetString("CommandsMod_LblSetting_CommandScript", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to JSON Command Payload.
+        /// </summary>
+        internal static string CommandsMod_LblSetting_JsonPayload {
+            get {
+                return ResourceManager.GetString("CommandsMod_LblSetting_JsonPayload", resourceCulture);
             }
         }
         
@@ -1099,6 +1117,15 @@ namespace HASS.Agent.Resources.Localization {
         internal static string CommandsMod_LblSetting_Url {
             get {
                 return ResourceManager.GetString("CommandsMod_LblSetting_Url", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Volume (between 0 and 100).
+        /// </summary>
+        internal static string CommandsMod_LblSetting_VolumeRange {
+            get {
+                return ResourceManager.GetString("CommandsMod_LblSetting_VolumeRange", resourceCulture);
             }
         }
         

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.de.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.de.resx
@@ -3468,4 +3468,13 @@ aus der Originalversion</value>
     <value>Legt die Standard-Audioausgabe für das System fest.
 Erfordert den Namen des Audiogeräts als Nutzlast.</value>
   </data>
+  <data name="CommandsMod_LblSetting_AudioDeviceName" xml:space="preserve">
+    <value>Name des Audiogeräts</value>
+  </data>
+  <data name="CommandsMod_LblSetting_JsonPayload" xml:space="preserve">
+    <value>JSON-Befehlsnutzlast</value>
+  </data>
+  <data name="CommandsMod_LblSetting_VolumeRange" xml:space="preserve">
+    <value>Lautstärke (zwischen 0 und 100)</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.de.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.de.resx
@@ -3464,4 +3464,8 @@ aus der Originalversion</value>
   <data name="Compat_NameTask_Error_ServiceStart" xml:space="preserve">
     <value>Fehler beim Starten des Satellitendienstes!</value>
   </data>
+  <data name="CommandsManager_SetAudioOutputCommandDescription" xml:space="preserve">
+    <value>Legt die Standard-Audioausgabe für das System fest.
+Erfordert den Namen des Audiogeräts als Nutzlast.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.en.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.en.resx
@@ -3345,4 +3345,13 @@ from the original version</value>
     <value>Sets the default audio output for the system.
 Requires audio device name as a payload.</value>
   </data>
+  <data name="CommandsMod_LblSetting_AudioDeviceName" xml:space="preserve">
+    <value>Audio Device Name</value>
+  </data>
+  <data name="CommandsMod_LblSetting_JsonPayload" xml:space="preserve">
+    <value>JSON Command Payload</value>
+  </data>
+  <data name="CommandsMod_LblSetting_VolumeRange" xml:space="preserve">
+    <value>Volume (between 0 and 100)</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.en.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.en.resx
@@ -3341,4 +3341,8 @@ from the original version</value>
   <data name="Compat_NameTask_Error_ServiceCommunication" xml:space="preserve">
     <value>Error communicating with the satellite service!</value>
   </data>
+  <data name="CommandsManager_SetAudioOutputCommandDescription" xml:space="preserve">
+    <value>Sets the default audio output for the system.
+Requires audio device name as a payload.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.es.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.es.resx
@@ -3344,4 +3344,13 @@ HASS.Agent de la versión original</value>
     <value>Establece la salida de audio predeterminada para el sistema.
 Requiere el nombre del dispositivo de audio como carga útil.</value>
   </data>
+  <data name="CommandsMod_LblSetting_VolumeRange" xml:space="preserve">
+    <value>Volumen (entre 0 y 100)</value>
+  </data>
+  <data name="CommandsMod_LblSetting_JsonPayload" xml:space="preserve">
+    <value>Carga útil del comando JSON</value>
+  </data>
+  <data name="CommandsMod_LblSetting_AudioDeviceName" xml:space="preserve">
+    <value>Nombre del dispositivo de audio</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.es.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.es.resx
@@ -3340,4 +3340,8 @@ HASS.Agent de la versión original</value>
   <data name="Compat_NameTask_Error_ServiceStart" xml:space="preserve">
     <value>¡Error al iniciar el servicio satelital!</value>
   </data>
+  <data name="CommandsManager_SetAudioOutputCommandDescription" xml:space="preserve">
+    <value>Establece la salida de audio predeterminada para el sistema.
+Requiere el nombre del dispositivo de audio como carga útil.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.fr.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.fr.resx
@@ -3373,4 +3373,8 @@ HASS.Agent de la version originale</value>
   <data name="Compat_NameTask_Error_ServiceStart" xml:space="preserve">
     <value>Erreur lors du démarrage du service satellite !</value>
   </data>
+  <data name="CommandsManager_SetAudioOutputCommandDescription" xml:space="preserve">
+    <value>Définit la sortie audio par défaut du système.
+Nécessite le nom du périphérique audio comme charge utile.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.fr.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.fr.resx
@@ -3377,4 +3377,13 @@ HASS.Agent de la version originale</value>
     <value>Définit la sortie audio par défaut du système.
 Nécessite le nom du périphérique audio comme charge utile.</value>
   </data>
+  <data name="CommandsMod_LblSetting_VolumeRange" xml:space="preserve">
+    <value>Volume (entre 0 et 100)</value>
+  </data>
+  <data name="CommandsMod_LblSetting_JsonPayload" xml:space="preserve">
+    <value>Charge utile de la commande JSON</value>
+  </data>
+  <data name="CommandsMod_LblSetting_AudioDeviceName" xml:space="preserve">
+    <value>Nom du périphérique audio</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.nl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.nl.resx
@@ -3361,4 +3361,8 @@ van de originele versie</value>
   <data name="Compat_NameTask_Error_ServiceStart" xml:space="preserve">
     <value>Fout bij starten satellietservice!</value>
   </data>
+  <data name="CommandsManager_SetAudioOutputCommandDescription" xml:space="preserve">
+    <value>Stelt de standaard audio-uitvoer voor het systeem in.
+Vereist de naam van het audioapparaat als payload.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.nl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.nl.resx
@@ -3365,4 +3365,13 @@ van de originele versie</value>
     <value>Stelt de standaard audio-uitvoer voor het systeem in.
 Vereist de naam van het audioapparaat als payload.</value>
   </data>
+  <data name="CommandsMod_LblSetting_AudioDeviceName" xml:space="preserve">
+    <value>Naam audioapparaat</value>
+  </data>
+  <data name="CommandsMod_LblSetting_JsonPayload" xml:space="preserve">
+    <value>JSON-opdrachtpayload</value>
+  </data>
+  <data name="CommandsMod_LblSetting_VolumeRange" xml:space="preserve">
+    <value>Volume (tussen 0 en 100)</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pl.resx
@@ -3093,7 +3093,7 @@ Uwaga: wyłączyłeś czyszczenie nazw, więc upewnij się, że nazwa Twojego ur
     <value>Stara się wybudzić wszystkie monitory poprzez symulowanie wciśnięcia przycisku "do góry".</value>
   </data>
   <data name="CommandsManager_SetVolumeCommandDescription" xml:space="preserve">
-    <value>Ustawia poziom głośności domyślnego urządzenia na podaną wartość. </value>
+    <value>Ustawia poziom głośności domyślnego urządzenia na podaną wartość.</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox10" xml:space="preserve">
     <value>Wprowadź wartość pomiędzy 0-100 jako nowy poziom głośności!</value>
@@ -3449,5 +3449,9 @@ z oryginalnej wersji</value>
   </data>
   <data name="Compat_NameTask_Error_ServiceStart" xml:space="preserve">
     <value>Błąd podczas uruchamiania usługi satelity!</value>
+  </data>
+  <data name="CommandsManager_SetAudioOutputCommandDescription" xml:space="preserve">
+    <value>Ustawia domyślne wyjście audio dla systemu.
+Wymaga nazwy urządzenia audio jako ładunku.</value>
   </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pl.resx
@@ -3454,4 +3454,13 @@ z oryginalnej wersji</value>
     <value>Ustawia domyślne wyjście audio dla systemu.
 Wymaga nazwy urządzenia audio jako ładunku.</value>
   </data>
+  <data name="CommandsMod_LblSetting_VolumeRange" xml:space="preserve">
+    <value>Głośność (od 0 do 100)</value>
+  </data>
+  <data name="CommandsMod_LblSetting_JsonPayload" xml:space="preserve">
+    <value>Ładunek polecenia JSON</value>
+  </data>
+  <data name="CommandsMod_LblSetting_AudioDeviceName" xml:space="preserve">
+    <value>Nazwa urządzenia audio</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pt-br.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pt-br.resx
@@ -3386,4 +3386,8 @@ HASS.Agent da versão original</value>
   <data name="Compat_NameTask_Error_ServiceStart" xml:space="preserve">
     <value>Erro ao iniciar o serviço de satélite!</value>
   </data>
+  <data name="CommandsManager_SetAudioOutputCommandDescription" xml:space="preserve">
+    <value>Define a saída de áudio padrão para o sistema.
+Requer o nome do dispositivo de áudio como carga útil.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pt-br.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pt-br.resx
@@ -3390,4 +3390,13 @@ HASS.Agent da versão original</value>
     <value>Define a saída de áudio padrão para o sistema.
 Requer o nome do dispositivo de áudio como carga útil.</value>
   </data>
+  <data name="CommandsMod_LblSetting_AudioDeviceName" xml:space="preserve">
+    <value>Nome do dispositivo de áudio</value>
+  </data>
+  <data name="CommandsMod_LblSetting_JsonPayload" xml:space="preserve">
+    <value>Carga útil do comando JSON</value>
+  </data>
+  <data name="CommandsMod_LblSetting_VolumeRange" xml:space="preserve">
+    <value>Volume (entre 0 e 100)</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.resx
@@ -3353,4 +3353,8 @@ from the original version</value>
   <data name="Compat_NameTask_Error_ServiceCommunication" xml:space="preserve">
     <value>Error communicating with the satellite service!</value>
   </data>
+  <data name="CommandsManager_SetAudioOutputCommandDescription" xml:space="preserve">
+    <value>Sets the default audio output for the system.
+Requires audio device name as a payload.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.resx
@@ -3357,4 +3357,13 @@ from the original version</value>
     <value>Sets the default audio output for the system.
 Requires audio device name as a payload.</value>
   </data>
+  <data name="CommandsMod_LblSetting_AudioDeviceName" xml:space="preserve">
+    <value>Audio Device Name</value>
+  </data>
+  <data name="CommandsMod_LblSetting_JsonPayload" xml:space="preserve">
+    <value>JSON Command Payload</value>
+  </data>
+  <data name="CommandsMod_LblSetting_VolumeRange" xml:space="preserve">
+    <value>Volume (between 0 and 100)</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.ru.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.ru.resx
@@ -3409,4 +3409,8 @@ Home Assistant.
   <data name="Compat_NameTask_Error_ServiceStart" xml:space="preserve">
     <value>Ошибка при запуске спутниковой службы!</value>
   </data>
+  <data name="CommandsManager_SetAudioOutputCommandDescription" xml:space="preserve">
+    <value>Устанавливает аудиовыход по умолчанию для системы.
+В качестве полезной нагрузки требуется имя аудиоустройства.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.ru.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.ru.resx
@@ -3413,4 +3413,13 @@ Home Assistant.
     <value>Устанавливает аудиовыход по умолчанию для системы.
 В качестве полезной нагрузки требуется имя аудиоустройства.</value>
   </data>
+  <data name="CommandsMod_LblSetting_VolumeRange" xml:space="preserve">
+    <value>Громкость (от 0 до 100)</value>
+  </data>
+  <data name="CommandsMod_LblSetting_JsonPayload" xml:space="preserve">
+    <value>Полезная нагрузка команды JSON</value>
+  </data>
+  <data name="CommandsMod_LblSetting_AudioDeviceName" xml:space="preserve">
+    <value>Имя аудиоустройства</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.sl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.sl.resx
@@ -3489,4 +3489,8 @@ iz izvirne različice</value>
   <data name="Compat_NameTask_Error_ServiceStart" xml:space="preserve">
     <value>Napaka pri zagonu satelitske storitve!</value>
   </data>
+  <data name="CommandsManager_SetAudioOutputCommandDescription" xml:space="preserve">
+    <value>Nastavi privzeti zvočni izhod za sistem.
+Zahteva ime zvočne naprave kot tovor.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.sl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.sl.resx
@@ -3493,4 +3493,13 @@ iz izvirne različice</value>
     <value>Nastavi privzeti zvočni izhod za sistem.
 Zahteva ime zvočne naprave kot tovor.</value>
   </data>
+  <data name="CommandsMod_LblSetting_AudioDeviceName" xml:space="preserve">
+    <value>Ime zvočne naprave</value>
+  </data>
+  <data name="CommandsMod_LblSetting_JsonPayload" xml:space="preserve">
+    <value>Tovor ukazov JSON</value>
+  </data>
+  <data name="CommandsMod_LblSetting_VolumeRange" xml:space="preserve">
+    <value>Glasnost (med 0 in 100)</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.tr.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.tr.resx
@@ -2952,4 +2952,8 @@ taşınması orijinal versiyondan</value>
   <data name="Compat_NameTask_Error_ServiceStart" xml:space="preserve">
     <value>Uydu hizmeti başlatılırken hata oluştu!</value>
   </data>
+  <data name="CommandsManager_SetAudioOutputCommandDescription" xml:space="preserve">
+    <value>Sistem için varsayılan ses çıkışını ayarlar.
+Yük olarak ses cihazı adını gerektirir.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.tr.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.tr.resx
@@ -2956,4 +2956,13 @@ taşınması orijinal versiyondan</value>
     <value>Sistem için varsayılan ses çıkışını ayarlar.
 Yük olarak ses cihazı adını gerektirir.</value>
   </data>
+  <data name="CommandsMod_LblSetting_AudioDeviceName" xml:space="preserve">
+    <value>Ses Cihazı Adı</value>
+  </data>
+  <data name="CommandsMod_LblSetting_JsonPayload" xml:space="preserve">
+    <value>JSON Komut Yükü</value>
+  </data>
+  <data name="CommandsMod_LblSetting_VolumeRange" xml:space="preserve">
+    <value>Hacim (0 ile 100 arasında)</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Settings/StoredCommands.cs
+++ b/src/HASS.Agent/HASS.Agent/Settings/StoredCommands.cs
@@ -175,6 +175,9 @@ namespace HASS.Agent.Settings
                 case CommandType.SetApplicationVolumeCommand:
                     abstractCommand = new SetApplicationVolumeCommand(command.EntityName, command.Name, command.Command, command.EntityType, command.Id.ToString());
                     break;
+                case CommandType.SetAudioOutputCommand:
+                    abstractCommand = new SetAudioOutputCommand(command.EntityName, command.Name, command.Command, command.EntityType, command.Id.ToString());
+                    break;
                 default:
                     Log.Error("[SETTINGS_COMMANDS] [{name}] Unknown configured command type: {type}", command.EntityName, command.Type.ToString());
                     break;


### PR DESCRIPTION
This PR adds additional configuration without which the "SetAudioOutputCommand" and "SetApplicationVolume" commands were not available within UI.

In addition:
- it adds ability to configure the device audio name in UI for SetAudioOutputCommand
- it adds translations for audio sensors missing in previous versions