### PR TITLE
Feature: screenshot camera sensor

### DIFF
--- a/src/HASS.Agent/HASS.Agent.Shared/Enums/SensorType.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Enums/SensorType.cs
@@ -165,6 +165,10 @@ namespace HASS.Agent.Shared.Enums
 
         [LocalizedDescription("SensorType_InternalDeviceSensor", typeof(Languages))]
         [EnumMember(Value = "InternalDeviceSensor")]
-        InternalDeviceSensor
+        InternalDeviceSensor,
+
+        [LocalizedDescription("SensorType_ScreenshotSensor", typeof(Languages))]
+        [EnumMember(Value = "ScreenshotSensor")]
+        ScreenshotSensor
     }
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/HASS.Agent.Shared.csproj
+++ b/src/HASS.Agent/HASS.Agent.Shared/HASS.Agent.Shared.csproj
@@ -42,6 +42,7 @@
     <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="8.0.0" />
     <PackageReference Include="System.DirectoryServices.AccountManagement" Version="8.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.1" />
     <PackageReference Include="System.Management" Version="8.0.0" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="8.0.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/ScreenshotSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/ScreenshotSensor.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.DirectoryServices.ActiveDirectory;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using HASS.Agent.Shared.Models.HomeAssistant;
+using Serilog;
+using System.Windows.Forms;
+using System.Xml.Linq;
+using System.Runtime.InteropServices;
+using System.Drawing.Imaging;
+using System.Text.RegularExpressions;
+
+namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue;
+public class ScreenshotSensor : AbstractSingleValueSensor
+{
+    private const string DefaultName = "screenshot";
+
+    public int ScreenIndex;
+
+    public ScreenshotSensor(string screenIndex = "0", int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 15, id)
+    {
+        ScreenIndex = int.TryParse(screenIndex, out var parsedScreenIndex) ? parsedScreenIndex : 0;
+        Domain = "camera";
+    }
+
+    public override DiscoveryConfigModel GetAutoDiscoveryConfig()
+    {
+        if (Variables.MqttManager == null) return null;
+
+        var deviceConfig = Variables.MqttManager.GetDeviceConfigModel();
+        if (deviceConfig == null) return null;
+
+        return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new CameraSensorDiscoveryConfigModel()
+        {
+            EntityName = EntityName,
+            Name = Name,
+            Unique_id = Id,
+            Device = deviceConfig,
+            Image_encoding = "b64",
+            State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",
+            Topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",
+            Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/sensor/{deviceConfig.Name}/availability"
+        });
+    }
+
+    public override string GetState()
+    {
+        var screenCount = Screen.AllScreens.Length;
+        if (ScreenIndex >= screenCount || ScreenIndex < 0)
+        {
+            Log.Warning("[SCREENSHOT] Error capturing screen {index} - returning image for screen 0", ScreenIndex);
+            ScreenIndex = 0;
+        }
+
+        var screenImage = CaptureScreen(ScreenIndex);
+        return Convert.ToBase64String(screenImage);
+    }
+
+    private byte[] CaptureScreen(int screenIndex)
+    {
+        try
+        {
+            return CapturePngFile(Screen.AllScreens[screenIndex]);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "[SCREENSHOT] Internal Error capturing screen {index}, {ex}", ex.Message);
+            return Array.Empty<byte>();
+        }
+    }
+
+    private byte[] CapturePngFile(Screen screen)
+    {
+        var captureRectangle = screen.Bounds;
+        var captureBitmap = new Bitmap(captureRectangle.Width, captureRectangle.Height, PixelFormat.Format32bppArgb);
+        var captureGraphics = Graphics.FromImage(captureBitmap);
+        captureGraphics.CopyFromScreen(captureRectangle.Left, captureRectangle.Top, 0, 0, captureRectangle.Size);
+
+        using var ms = new MemoryStream();
+        captureBitmap.Save(ms, ImageFormat.Png);
+
+        return ms.ToArray();
+    }
+
+    public override string GetAttributes() => string.Empty;
+}

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/ScreenshotSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/ScreenshotSensor.cs
@@ -29,10 +29,12 @@ public class ScreenshotSensor : AbstractSingleValueSensor
 
     public override DiscoveryConfigModel GetAutoDiscoveryConfig()
     {
-        if (Variables.MqttManager == null) return null;
+        if (Variables.MqttManager == null)
+            return null;
 
         var deviceConfig = Variables.MqttManager.GetDeviceConfigModel();
-        if (deviceConfig == null) return null;
+        if (deviceConfig == null)
+            return null;
 
         return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new CameraSensorDiscoveryConfigModel()
         {
@@ -41,6 +43,7 @@ public class ScreenshotSensor : AbstractSingleValueSensor
             Unique_id = Id,
             Device = deviceConfig,
             Image_encoding = "b64",
+            Icon = "mdi:camera",
             State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",
             Topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",
             Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/sensor/{deviceConfig.Name}/availability"
@@ -52,7 +55,7 @@ public class ScreenshotSensor : AbstractSingleValueSensor
         var screenCount = Screen.AllScreens.Length;
         if (ScreenIndex >= screenCount || ScreenIndex < 0)
         {
-            Log.Warning("[SCREENSHOT] Error capturing screen {index} - returning image for screen 0", ScreenIndex);
+            Log.Warning("[SCREENSHOT] Wrong index '{index}' - returning image for screen 0", ScreenIndex);
             ScreenIndex = 0;
         }
 
@@ -68,7 +71,7 @@ public class ScreenshotSensor : AbstractSingleValueSensor
         }
         catch (Exception ex)
         {
-            Log.Warning(ex, "[SCREENSHOT] Internal Error capturing screen {index}, {ex}", ex.Message);
+            Log.Error(ex, "[SCREENSHOT] Internal Error capturing screen {index}, {ex}", ex.Message);
             return Array.Empty<byte>();
         }
     }

--- a/src/HASS.Agent/HASS.Agent.Shared/Models/HomeAssistant/DiscoveryConfigModel.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Models/HomeAssistant/DiscoveryConfigModel.cs
@@ -144,6 +144,13 @@ namespace HASS.Agent.Shared.Models.HomeAssistant
     }
 
     [SuppressMessage("ReSharper", "InconsistentNaming")]
+    public class CameraSensorDiscoveryConfigModel : SensorDiscoveryConfigModel
+    {
+        public string Topic { get; set; }
+        public string Image_encoding { get; set; }
+    }
+
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
     public class CommandDiscoveryConfigModel : DiscoveryConfigModel
     {
         /// <summary>

--- a/src/HASS.Agent/HASS.Agent.Shared/Models/HomeAssistant/DiscoveryConfigModel.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Models/HomeAssistant/DiscoveryConfigModel.cs
@@ -146,7 +146,14 @@ namespace HASS.Agent.Shared.Models.HomeAssistant
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     public class CameraSensorDiscoveryConfigModel : SensorDiscoveryConfigModel
     {
+        /// <summary>
+        /// Messages published to this topic need to contain full contents of an image
+        /// </summary>
         public string Topic { get; set; }
+
+        /// <summary>
+        /// (Optional) The encoding of the image payloads received.
+        /// </summary>
         public string Image_encoding { get; set; }
     }
 

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.Designer.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.Designer.cs
@@ -6736,6 +6736,15 @@ namespace HASS.Agent.Shared.Resources.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Screenshot.
+        /// </summary>
+        internal static string SensorType_ScreenshotSensor {
+            get {
+                return ResourceManager.GetString("SensorType_ScreenshotSensor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ServiceState.
         /// </summary>
         internal static string SensorType_ServiceStateSensor {

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.de.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.de.resx
@@ -3358,4 +3358,7 @@ Willst Du den Runtime Installer herunterladen?</value>
   <data name="CommandType_SetAudioOutputCommand" xml:space="preserve">
     <value>Legen Sie den Audioausgabebefehl fest</value>
   </data>
+  <data name="SensorType_ScreenshotSensor" xml:space="preserve">
+    <value>Bildschirmfoto</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.en.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.en.resx
@@ -3237,4 +3237,7 @@ Do you want to download the runtime installer?</value>
   <data name="CommandType_SetAudioOutputCommand" xml:space="preserve">
     <value>SetAudioOutputCommand</value>
   </data>
+  <data name="SensorType_ScreenshotSensor" xml:space="preserve">
+    <value>Screenshot</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.es.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.es.resx
@@ -3234,4 +3234,7 @@ Oculta, Maximizada, Minimizada, Normal y Desconocida.</value>
   <data name="CommandType_SetAudioOutputCommand" xml:space="preserve">
     <value>Establecer comando de salida de audio</value>
   </data>
+  <data name="SensorType_ScreenshotSensor" xml:space="preserve">
+    <value>Captura de pantalla</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.fr.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.fr.resx
@@ -3267,4 +3267,7 @@ Do you want to download the runtime installer?</value>
   <data name="CommandType_SetAudioOutputCommand" xml:space="preserve">
     <value>Définir la commande de sortie audio</value>
   </data>
+  <data name="SensorType_ScreenshotSensor" xml:space="preserve">
+    <value>Capture d'écran</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.nl.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.nl.resx
@@ -3256,4 +3256,7 @@ Wil je de runtime installatie downloaden?</value>
   <data name="CommandType_SetAudioOutputCommand" xml:space="preserve">
     <value>Stel het audio-uitvoercommando in</value>
   </data>
+  <data name="SensorType_ScreenshotSensor" xml:space="preserve">
+    <value>Schermafbeelding</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.pl.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.pl.resx
@@ -3344,4 +3344,7 @@ Czy chcesz pobrać plik instalacyjny?</value>
   <data name="CommandType_SetAudioOutputCommand" xml:space="preserve">
     <value>Ustaw wyjście audio</value>
   </data>
+  <data name="SensorType_ScreenshotSensor" xml:space="preserve">
+    <value>Zrzut ekranu</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.pt-br.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.pt-br.resx
@@ -3281,4 +3281,7 @@ Deseja baixar o Microsoft WebView2 runtime?</value>
   <data name="CommandType_SetAudioOutputCommand" xml:space="preserve">
     <value>Definir comando de saída de áudio</value>
   </data>
+  <data name="SensorType_ScreenshotSensor" xml:space="preserve">
+    <value>Captura de tela</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.resx
@@ -3217,4 +3217,7 @@ Do you want to download the runtime installer?</value>
   <data name="CommandType_SetAudioOutputCommand" xml:space="preserve">
     <value>SetAudioOutputCommand</value>
   </data>
+  <data name="SensorType_ScreenshotSensor" xml:space="preserve">
+    <value>Screenshot</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.ru.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.ru.resx
@@ -3302,4 +3302,7 @@ Home Assistant.
   <data name="CommandType_SetAudioOutputCommand" xml:space="preserve">
     <value>Установить команду вывода звука</value>
   </data>
+  <data name="SensorType_ScreenshotSensor" xml:space="preserve">
+    <value>Скриншот</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.sl.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.sl.resx
@@ -3383,4 +3383,7 @@ Ali želite prenesti runtime installer?</value>
   <data name="CommandType_SetAudioOutputCommand" xml:space="preserve">
     <value>Nastavite ukaz za avdio izhod</value>
   </data>
+  <data name="SensorType_ScreenshotSensor" xml:space="preserve">
+    <value>Posnetek zaslona</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.tr.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.tr.resx
@@ -2841,4 +2841,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
   <data name="CommandType_SetAudioOutputCommand" xml:space="preserve">
     <value>Ses Çıkışı Komutunu Ayarla</value>
   </data>
+  <data name="SensorType_ScreenshotSensor" xml:space="preserve">
+    <value>Ekran görüntüsü</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Forms/Sensors/SensorsMod.cs
+++ b/src/HASS.Agent/HASS.Agent/Forms/Sensors/SensorsMod.cs
@@ -228,7 +228,11 @@ namespace HASS.Agent.Forms.Sensors
 					CbApplyRounding.Checked = Sensor.ApplyRounding;
 					NumRound.Text = Sensor.Round?.ToString() ?? LastActiveSensor.DefaultTimeWindow.ToString(); ;
 					break;
-			}
+
+                case SensorType.ScreenshotSensor:
+                    TbSetting1.Text = Sensor.Query;
+                    break;
+            }
 		}
 
 		/// <summary>
@@ -326,6 +330,10 @@ namespace HASS.Agent.Forms.Sensors
 				case SensorType.LastActiveSensor:
 					SetLastActiveGui();
 					break;
+
+                case SensorType.ScreenshotSensor:
+                    SetScreenshotGui();
+                    break;
 
 				default:
 					SetEmptyGui();
@@ -528,10 +536,24 @@ namespace HASS.Agent.Forms.Sensors
 			}));
 		}
 
-		/// <summary>
-		/// Change the UI to a general type
-		/// </summary>
-		private void SetEmptyGui()
+        private void SetScreenshotGui()
+        {
+            Invoke(new MethodInvoker(delegate
+            {
+                SetEmptyGui();
+
+                LblSetting1.Text = Languages.SensorsMod_LblSetting1_ScreenNumber;
+                LblSetting1.Visible = true;
+                TbSetting1.Visible = true;
+
+                BtnTest.Visible = false;
+            }));
+        }
+
+        /// <summary>
+        /// Change the UI to a general type
+        /// </summary>
+        private void SetEmptyGui()
 		{
 			Invoke(new MethodInvoker(delegate
 			{
@@ -798,6 +820,17 @@ namespace HASS.Agent.Forms.Sensors
                         ActiveControl = TbSetting1;
                         return;
                     }
+                    break;
+
+                case SensorType.ScreenshotSensor:
+                    var screenIndex = TbSetting1.Text.Trim();
+                    if (string.IsNullOrEmpty(screenIndex))
+                    {
+                        MessageBoxAdv.Show(this, Languages.SensorsMod_BtnStore_MessageBox10, Variables.MessageBoxTitle, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        ActiveControl = TbSetting1;
+                        return;
+                    }
+                    Sensor.Query = screenIndex;
                     break;
             }
 

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.Designer.cs
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.Designer.cs
@@ -6096,7 +6096,8 @@ namespace HASS.Agent.Resources.Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Provides a screenshot sensor in form of a camera entity..
+        ///   Looks up a localized string similar to Provides a screenshot sensor in form of a camera entity.
+        ///Screen number depends on system configuration - starts at 0..
         /// </summary>
         internal static string SensorsManager_ScreenshotSensorDescription {
             get {

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.Designer.cs
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.Designer.cs
@@ -6096,6 +6096,15 @@ namespace HASS.Agent.Resources.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Provides a screenshot sensor in form of a camera entity..
+        /// </summary>
+        internal static string SensorsManager_ScreenshotSensorDescription {
+            get {
+                return ResourceManager.GetString("SensorsManager_ScreenshotSensorDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Returns the state of the provided service: NotFound, Stopped, StartPending, StopPending, Running, ContinuePending, PausePending or Paused.
         ///
         ///Make sure to provide the &apos;Service name&apos;, not the &apos;Display name&apos;..
@@ -6517,6 +6526,15 @@ namespace HASS.Agent.Resources.Localization {
         internal static string SensorsMod_LblSetting1_Process {
             get {
                 return ResourceManager.GetString("SensorsMod_LblSetting1_Process", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Screen number.
+        /// </summary>
+        internal static string SensorsMod_LblSetting1_ScreenNumber {
+            get {
+                return ResourceManager.GetString("SensorsMod_LblSetting1_ScreenNumber", resourceCulture);
             }
         }
         

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.de.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.de.resx
@@ -3477,4 +3477,11 @@ Erfordert den Namen des Audiogeräts als Nutzlast.</value>
   <data name="CommandsMod_LblSetting_VolumeRange" xml:space="preserve">
     <value>Lautstärke (zwischen 0 und 100)</value>
   </data>
+  <data name="SensorsManager_ScreenshotSensorDescription" xml:space="preserve">
+    <value>Sie stellen einen Screenshot-Sensor in Form einer Kameraeinheit bereit.
+Die Bildschirmnummer hängt von der Systemkonfiguration ab – beginnt bei 0.</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_ScreenNumber" xml:space="preserve">
+    <value>Bildschirmnummer</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.en.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.en.resx
@@ -3358,6 +3358,7 @@ Requires audio device name as a payload.</value>
     <value>Screen number</value>
   </data>
   <data name="SensorsManager_ScreenshotSensorDescription" xml:space="preserve">
-    <value>Provides a screenshot sensor in form of a camera entity.</value>
+    <value>Provides a screenshot sensor in form of a camera entity.
+Screen number depends on system configuration - starts at 0.</value>
   </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.en.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.en.resx
@@ -3354,4 +3354,10 @@ Requires audio device name as a payload.</value>
   <data name="CommandsMod_LblSetting_VolumeRange" xml:space="preserve">
     <value>Volume (between 0 and 100)</value>
   </data>
+  <data name="SensorsMod_LblSetting1_ScreenNumber" xml:space="preserve">
+    <value>Screen number</value>
+  </data>
+  <data name="SensorsManager_ScreenshotSensorDescription" xml:space="preserve">
+    <value>Provides a screenshot sensor in form of a camera entity.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.es.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.es.resx
@@ -3353,4 +3353,11 @@ Requiere el nombre del dispositivo de audio como carga útil.</value>
   <data name="CommandsMod_LblSetting_AudioDeviceName" xml:space="preserve">
     <value>Nombre del dispositivo de audio</value>
   </data>
+  <data name="SensorsManager_ScreenshotSensorDescription" xml:space="preserve">
+    <value>Proporciona un sensor de captura de pantalla en forma de entidad de cámara.
+El número de pantalla depende de la configuración del sistema: comienza en 0.</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_ScreenNumber" xml:space="preserve">
+    <value>Número de pantalla</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.fr.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.fr.resx
@@ -3386,4 +3386,11 @@ Nécessite le nom du périphérique audio comme charge utile.</value>
   <data name="CommandsMod_LblSetting_AudioDeviceName" xml:space="preserve">
     <value>Nom du périphérique audio</value>
   </data>
+  <data name="SensorsManager_ScreenshotSensorDescription" xml:space="preserve">
+    <value>Vous fournissez un capteur de capture d’écran sous la forme d’une entité caméra.
+Le numéro d'écran dépend de la configuration du système - commence à 0.</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_ScreenNumber" xml:space="preserve">
+    <value>Numéro d'écran</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.nl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.nl.resx
@@ -3374,4 +3374,11 @@ Vereist de naam van het audioapparaat als payload.</value>
   <data name="CommandsMod_LblSetting_VolumeRange" xml:space="preserve">
     <value>Volume (tussen 0 en 100)</value>
   </data>
+  <data name="SensorsManager_ScreenshotSensorDescription" xml:space="preserve">
+    <value>U levert een screenshot-sensor in de vorm van een camera-entiteit.
+Schermnummer is afhankelijk van de systeemconfiguratie - begint bij 0.</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_ScreenNumber" xml:space="preserve">
+    <value>Schermnummer</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pl.resx
@@ -3463,4 +3463,11 @@ Wymaga nazwy urządzenia audio jako ładunku.</value>
   <data name="CommandsMod_LblSetting_AudioDeviceName" xml:space="preserve">
     <value>Nazwa urządzenia audio</value>
   </data>
+  <data name="SensorsManager_ScreenshotSensorDescription" xml:space="preserve">
+    <value>Czujnik zrzutu ekranu w postaci kamery.
+Numer ekranu zależy od konfiguracji systemu – zaczyna się od 0.</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_ScreenNumber" xml:space="preserve">
+    <value>Numer ekranu</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pt-br.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pt-br.resx
@@ -3399,4 +3399,11 @@ Requer o nome do dispositivo de áudio como carga útil.</value>
   <data name="CommandsMod_LblSetting_VolumeRange" xml:space="preserve">
     <value>Volume (entre 0 e 100)</value>
   </data>
+  <data name="SensorsManager_ScreenshotSensorDescription" xml:space="preserve">
+    <value>Você fornece um sensor de captura de tela na forma de uma entidade de câmera.
+O número da tela depende da configuração do sistema – começa em 0.</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_ScreenNumber" xml:space="preserve">
+    <value>Número da tela</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.resx
@@ -3366,4 +3366,10 @@ Requires audio device name as a payload.</value>
   <data name="CommandsMod_LblSetting_VolumeRange" xml:space="preserve">
     <value>Volume (between 0 and 100)</value>
   </data>
+  <data name="SensorsMod_LblSetting1_ScreenNumber" xml:space="preserve">
+    <value>Screen number</value>
+  </data>
+  <data name="SensorsManager_ScreenshotSensorDescription" xml:space="preserve">
+    <value>Provides a screenshot sensor in form of a camera entity.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.resx
@@ -3370,6 +3370,7 @@ Requires audio device name as a payload.</value>
     <value>Screen number</value>
   </data>
   <data name="SensorsManager_ScreenshotSensorDescription" xml:space="preserve">
-    <value>Provides a screenshot sensor in form of a camera entity.</value>
+    <value>Provides a screenshot sensor in form of a camera entity.
+Screen number depends on system configuration - starts at 0.</value>
   </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.ru.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.ru.resx
@@ -3422,4 +3422,11 @@ Home Assistant.
   <data name="CommandsMod_LblSetting_AudioDeviceName" xml:space="preserve">
     <value>Имя аудиоустройства</value>
   </data>
+  <data name="SensorsManager_ScreenshotSensorDescription" xml:space="preserve">
+    <value>Вы предоставляете датчик скриншота в виде объекта камеры.
+Номер экрана зависит от конфигурации системы — начинается с 0.</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_ScreenNumber" xml:space="preserve">
+    <value>Номер экрана</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.sl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.sl.resx
@@ -3502,4 +3502,11 @@ Zahteva ime zvočne naprave kot tovor.</value>
   <data name="CommandsMod_LblSetting_VolumeRange" xml:space="preserve">
     <value>Glasnost (med 0 in 100)</value>
   </data>
+  <data name="SensorsManager_ScreenshotSensorDescription" xml:space="preserve">
+    <value>Zagotovite senzor posnetka zaslona v obliki entitete kamere.
+Številka zaslona je odvisna od konfiguracije sistema - začne se pri 0.</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_ScreenNumber" xml:space="preserve">
+    <value>Številka zaslona</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.tr.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.tr.resx
@@ -2965,4 +2965,11 @@ Yük olarak ses cihazı adını gerektirir.</value>
   <data name="CommandsMod_LblSetting_VolumeRange" xml:space="preserve">
     <value>Hacim (0 ile 100 arasında)</value>
   </data>
+  <data name="SensorsManager_ScreenshotSensorDescription" xml:space="preserve">
+    <value>Bir kamera varlığı biçiminde bir ekran görüntüsü sensörü sağlarsınız.
+Ekran numarası sistem konfigürasyonuna bağlıdır - 0'dan başlar.</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_ScreenNumber" xml:space="preserve">
+    <value>Ekran numarası</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Sensors/SensorsManager.cs
+++ b/src/HASS.Agent/HASS.Agent/Sensors/SensorsManager.cs
@@ -661,6 +661,14 @@ namespace HASS.Agent.Sensors
             SensorInfoCards.Add(sensorInfoCard.SensorType, sensorInfoCard);
 
             // =================================
+
+            sensorInfoCard = new SensorInfoCard(SensorType.ScreenshotSensor,
+            Languages.SensorsManager_ScreenshotSensorDescription,
+            10, false, true, true);
+
+            SensorInfoCards.Add(sensorInfoCard.SensorType, sensorInfoCard);
+
+            // =================================
         }
     }
 }

--- a/src/HASS.Agent/HASS.Agent/Sensors/SensorsManager.cs
+++ b/src/HASS.Agent/HASS.Agent/Sensors/SensorsManager.cs
@@ -664,7 +664,7 @@ namespace HASS.Agent.Sensors
 
             sensorInfoCard = new SensorInfoCard(SensorType.ScreenshotSensor,
             Languages.SensorsManager_ScreenshotSensorDescription,
-            10, false, true, true);
+            10, false, true, false);
 
             SensorInfoCards.Add(sensorInfoCard.SensorType, sensorInfoCard);
 

--- a/src/HASS.Agent/HASS.Agent/Settings/StoredSensors.cs
+++ b/src/HASS.Agent/HASS.Agent/Settings/StoredSensors.cs
@@ -3,6 +3,7 @@ using HASS.Agent.Enums;
 using HASS.Agent.Extensions;
 using HASS.Agent.HomeAssistant.Sensors.GeneralSensors.MultiValue;
 using HASS.Agent.HomeAssistant.Sensors.GeneralSensors.SingleValue;
+using HASS.Agent.Managers.DeviceSensors;
 using HASS.Agent.Resources.Localization;
 using HASS.Agent.Shared.Enums;
 using HASS.Agent.Shared.Extensions;
@@ -196,7 +197,10 @@ namespace HASS.Agent.Settings
                     abstractSensor = new BluetoothLeDevicesSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 case SensorType.InternalDeviceSensor:
-                    abstractSensor = new InternalDeviceSensor(sensor.Query, sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
+                    abstractSensor = new HomeAssistant.Sensors.GeneralSensors.SingleValue.InternalDeviceSensor(sensor.Query, sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
+                    break;
+                case SensorType.ScreenshotSensor:
+                    abstractSensor = new ScreenshotSensor(sensor.Query, sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString());
                     break;
                 default:
                     Log.Error("[SETTINGS_SENSORS] [{name}] Unknown configured single-value sensor type: {type}", sensor.EntityName, sensor.Type.ToString());
@@ -389,7 +393,7 @@ namespace HASS.Agent.Settings
                     };
                 }
 
-                case InternalDeviceSensor internalDeviceSensor:
+                case HomeAssistant.Sensors.GeneralSensors.SingleValue.InternalDeviceSensor internalDeviceSensor:
                     {
                         _ = Enum.TryParse<SensorType>(internalDeviceSensor.GetType().Name, out var type);
                         return new ConfiguredSensor
@@ -401,6 +405,21 @@ namespace HASS.Agent.Settings
                             UpdateInterval = internalDeviceSensor.UpdateIntervalSeconds,
 							IgnoreAvailability = internalDeviceSensor.IgnoreAvailability,
 							Query = internalDeviceSensor.SensorType.ToString()
+                        };
+                    }
+
+                case ScreenshotSensor screenshotSensor:
+                    {
+                        _ = Enum.TryParse<SensorType>(screenshotSensor.GetType().Name, out var type);
+                        return new ConfiguredSensor
+                        {
+                            Id = Guid.Parse(screenshotSensor.Id),
+                            EntityName = screenshotSensor.EntityName,
+                            Name = screenshotSensor.Name,
+                            Type = type,
+                            UpdateInterval = screenshotSensor.UpdateIntervalSeconds,
+                            IgnoreAvailability = screenshotSensor.IgnoreAvailability,
+                            Query = screenshotSensor.ScreenIndex.ToString()
                         };
                     }
 


### PR DESCRIPTION
This PR adds screenshot sensor (camera entity) which was originally proposed and implemented by @denisabt in the PR to original HASS.Agent repository https://github.com/LAB02-Research/HASS.Agent.Staging/pull/8
This sensor is supported only for client part of HASS.Agent.

Due to internal m$ shenanigans I couldn't 100% reliably reproduce the screen numbering present in the system settings. It can change due to primary screen configuration and other factors.

Small adjustments have been made to make the footprint and required changes as small as possible.

![obraz](https://github.com/hass-agent/HASS.Agent/assets/68441479/b36a190f-23f0-4a42-910d-c001306c2fed)
![rUgfZJ](https://github.com/hass-agent/HASS.Agent/assets/68441479/da80847c-6ec9-4427-98b8-cc3bdb124f08)

