### PR TITLE
Fix: sensor being updated constantly when value doesn't change

### DIFF
--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/PowershellSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/PowershellSensor.cs
@@ -5,59 +5,63 @@ using HASS.Agent.Shared.Managers;
 using HASS.Agent.Shared.Models.HomeAssistant;
 using Serilog;
 
-namespace HASS.Agent.Shared.HomeAssistant.Sensors
+namespace HASS.Agent.Shared.HomeAssistant.Sensors;
+
+/// <summary>
+/// Sensor containing the result of the provided Powershell command or script
+/// </summary>
+public class PowershellSensor : AbstractSingleValueSensor
 {
-    /// <summary>
-    /// Sensor containing the result of the provided Powershell command or script
-    /// </summary>
-    public class PowershellSensor : AbstractSingleValueSensor
+    private const string DefaultName = "powershellsensor";
+
+    public string Command { get; private set; }
+    public bool ApplyRounding { get; private set; }
+    public int? Round { get; private set; }
+
+    public PowershellSensor(string command, bool applyRounding = false, int? round = null, int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 10, id)
     {
-        private const string DefaultName = "powershellsensor";
-
-        public string Command { get; private set; }
-        public bool ApplyRounding { get; private set; }
-        public int? Round { get; private set; }
-
-        public PowershellSensor(string command, bool applyRounding = false, int? round = null, int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 10, id)
-        {
-            Command = command;
-            ApplyRounding = applyRounding;
-            Round = round;
-        }
-
-        public override DiscoveryConfigModel GetAutoDiscoveryConfig()
-        {
-            if (Variables.MqttManager == null) return null;
-
-            var deviceConfig = Variables.MqttManager.GetDeviceConfigModel();
-            if (deviceConfig == null) return null;
-
-            return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
-            {
-                EntityName = EntityName,
-                Name = Name,
-                Unique_id = Id,
-                Device = deviceConfig,
-                State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{EntityName}/state",
-                Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/availability"
-            });
-        }
-        
-        public override string GetState()
-        {
-            var executed = PowershellManager.ExecuteWithOutput(Command, TimeSpan.FromMinutes(5), out var output, out var errors);
-            if (!executed) return "error_during_execution";
-
-            if (string.IsNullOrWhiteSpace(output) && string.IsNullOrWhiteSpace(errors)) return string.Empty;
-            if (string.IsNullOrWhiteSpace(output)) return errors.Trim();
-
-            // optionally apply rounding
-            if (ApplyRounding && Round != null && double.TryParse(output, out var dblValue)) { output = Math.Round(dblValue, (int)Round).ToString(CultureInfo.CurrentCulture); }
-
-            // done
-            return string.IsNullOrWhiteSpace(errors) ? output : $"{output} | {errors}";
-        }
-
-        public override string GetAttributes() => string.Empty;
+        Command = command;
+        ApplyRounding = applyRounding;
+        Round = round;
     }
+
+    public override DiscoveryConfigModel GetAutoDiscoveryConfig()
+    {
+        if (Variables.MqttManager == null)
+            return null;
+
+        var deviceConfig = Variables.MqttManager.GetDeviceConfigModel();
+        if (deviceConfig == null)
+            return null;
+
+        return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
+        {
+            EntityName = EntityName,
+            Name = Name,
+            Unique_id = Id,
+            Device = deviceConfig,
+            State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{EntityName}/state",
+            Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/availability"
+        });
+    }
+
+    public override string GetState()
+    {
+        var executed = PowershellManager.ExecuteWithOutput(Command, TimeSpan.FromMinutes(5), out var output, out var errors);
+        if (!executed)
+            return "error_during_execution";
+
+        if (string.IsNullOrWhiteSpace(output) && string.IsNullOrWhiteSpace(errors))
+            return string.Empty;
+        if (string.IsNullOrWhiteSpace(output))
+            return errors.Trim();
+
+        // optionally apply rounding
+        if (ApplyRounding && Round != null && double.TryParse(output, out var dblValue)) { output = Math.Round(dblValue, (int)Round).ToString(CultureInfo.CurrentCulture); }
+
+        // done
+        return string.IsNullOrWhiteSpace(errors) ? output : $"{output} | {errors}";
+    }
+
+    public override string GetAttributes() => string.Empty;
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/Models/HomeAssistant/AbstractSingleValueSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Models/HomeAssistant/AbstractSingleValueSensor.cs
@@ -3,134 +3,136 @@ using System.Threading.Tasks;
 using MQTTnet;
 using Serilog;
 
-namespace HASS.Agent.Shared.Models.HomeAssistant
+namespace HASS.Agent.Shared.Models.HomeAssistant;
+
+/// <summary>
+/// Abstract singlevalue-sensor from which all singlevalue-sensors are derived
+/// </summary>
+public abstract class AbstractSingleValueSensor : AbstractDiscoverable
 {
-    /// <summary>
-    /// Abstract singlevalue-sensor from which all singlevalue-sensors are derived
-    /// </summary>
-    public abstract class AbstractSingleValueSensor : AbstractDiscoverable
+    public int UpdateIntervalSeconds { get; protected set; }
+    public DateTime? LastUpdated { get; protected set; }
+
+    public string PreviousPublishedState { get; protected set; } = string.Empty;
+    public string PreviousPublishedAttributes { get; protected set; } = string.Empty;
+
+    protected AbstractSingleValueSensor(string entityName, string name, int updateIntervalSeconds = 10, string id = default, bool useAttributes = false)
     {
-        public int UpdateIntervalSeconds { get; protected set; }
-        public DateTime? LastUpdated { get; protected set; }
+        Id = id == null || id == Guid.Empty.ToString() ? Guid.NewGuid().ToString() : id;
+        EntityName = entityName;
+        Name = name;
+        UpdateIntervalSeconds = updateIntervalSeconds;
+        Domain = "sensor";
+        UseAttributes = useAttributes;
+    }
 
-        public string PreviousPublishedState { get; protected set; } = string.Empty;
-        public string PreviousPublishedAttributes { get; protected set; } = string.Empty;
+    protected SensorDiscoveryConfigModel AutoDiscoveryConfigModel;
+    protected SensorDiscoveryConfigModel SetAutoDiscoveryConfigModel(SensorDiscoveryConfigModel config)
+    {
+        AutoDiscoveryConfigModel = config;
+        return config;
+    }
 
-        protected AbstractSingleValueSensor(string entityName, string name, int updateIntervalSeconds = 10, string id = default, bool useAttributes = false)
+    public override void ClearAutoDiscoveryConfig() => AutoDiscoveryConfigModel = null;
+
+    // nullable in preparation for possible future "nullable enablement"
+    public abstract string? GetState();
+
+    // nullable in preparation for possible future "nullable enablement"
+    public abstract string? GetAttributes();
+
+    public void ResetChecks()
+    {
+        LastUpdated = DateTime.MinValue;
+
+        PreviousPublishedState = string.Empty;
+        PreviousPublishedAttributes = string.Empty;
+    }
+
+    public async Task PublishStateAsync(bool respectChecks = true)
+    {
+        try
         {
-            Id = id == null || id == Guid.Empty.ToString() ? Guid.NewGuid().ToString() : id;
-            EntityName = entityName;
-            Name = name;
-            UpdateIntervalSeconds = updateIntervalSeconds;
-            Domain = "sensor";
-            UseAttributes = useAttributes;
-        }
+            if (Variables.MqttManager == null) return;
 
-        protected SensorDiscoveryConfigModel AutoDiscoveryConfigModel;
-        protected SensorDiscoveryConfigModel SetAutoDiscoveryConfigModel(SensorDiscoveryConfigModel config)
-        {
-            AutoDiscoveryConfigModel = config;
-            return config;
-        }
-
-        public override void ClearAutoDiscoveryConfig() => AutoDiscoveryConfigModel = null;
-
-        // nullable in preparation for possible future "nullable enablement"
-        public abstract string? GetState();
-
-        // nullable in preparation for possible future "nullable enablement"
-        public abstract string? GetAttributes();
-
-        public void ResetChecks()
-        {
-            LastUpdated = DateTime.MinValue;
-
-            PreviousPublishedState = string.Empty;
-            PreviousPublishedAttributes = string.Empty;
-        }
-
-        public async Task PublishStateAsync(bool respectChecks = true)
-        {
-            try
+            // are we asked to check elapsed time?
+            if (respectChecks)
             {
-                if (Variables.MqttManager == null) return;
+                if (LastUpdated.HasValue && LastUpdated.Value.AddSeconds(UpdateIntervalSeconds) > DateTime.Now) return;
+            }
 
-                // are we asked to check elapsed time?
-                if (respectChecks)
-                {
-                    if (LastUpdated.HasValue && LastUpdated.Value.AddSeconds(UpdateIntervalSeconds) > DateTime.Now) return;
-                }
+            // get the current state/attributes
+            var state = GetState();
+            if (state == null)
+                return;
 
-                // get the current state/attributes
-                var state = GetState();
-                if (state == null)
+            var attributes = GetAttributes();
+
+            // are we asked to check state changes?
+            if (respectChecks)
+            {
+                if (PreviousPublishedState == state && PreviousPublishedAttributes == attributes) {
+                    LastUpdated = DateTime.Now;
                     return;
-
-                var attributes = GetAttributes();
-
-                // are we asked to check state changes?
-                if (respectChecks)
-                {
-                    if (PreviousPublishedState == state && PreviousPublishedAttributes == attributes) return;
                 }
+            }
 
-                // fetch the autodiscovery config
-                var autoDiscoConfig = (SensorDiscoveryConfigModel)GetAutoDiscoveryConfig();
-                if (autoDiscoConfig == null) return;
+            // fetch the autodiscovery config
+            var autoDiscoConfig = (SensorDiscoveryConfigModel)GetAutoDiscoveryConfig();
+            if (autoDiscoConfig == null) return;
 
-                // prepare the state message
-                var message = new MqttApplicationMessageBuilder()
-                    .WithTopic(autoDiscoConfig.State_topic)
-                    .WithPayload(state)
+            // prepare the state message
+            var message = new MqttApplicationMessageBuilder()
+                .WithTopic(autoDiscoConfig.State_topic)
+                .WithPayload(state)
+                .WithRetainFlag(Variables.MqttManager.UseRetainFlag())
+                .Build();
+
+            // send it
+            var published = await Variables.MqttManager.PublishAsync(message);
+            if (!published)
+                return; // failed, don't store the state
+
+            // optionally prepare and send attributes
+            if (UseAttributes && attributes != null)
+            {
+                message = new MqttApplicationMessageBuilder()
+                    .WithTopic(autoDiscoConfig.Json_attributes_topic)
+                    .WithPayload(attributes)
                     .WithRetainFlag(Variables.MqttManager.UseRetainFlag())
                     .Build();
 
-                // send it
-                var published = await Variables.MqttManager.PublishAsync(message);
+                published = await Variables.MqttManager.PublishAsync(message);
                 if (!published)
                     return; // failed, don't store the state
-
-                // optionally prepare and send attributes
-                if (UseAttributes && attributes != null)
-                {
-                    message = new MqttApplicationMessageBuilder()
-                        .WithTopic(autoDiscoConfig.Json_attributes_topic)
-                        .WithPayload(attributes)
-                        .WithRetainFlag(Variables.MqttManager.UseRetainFlag())
-                        .Build();
-
-                    published = await Variables.MqttManager.PublishAsync(message);
-                    if (!published)
-                        return; // failed, don't store the state
-                }
-
-                // only store the values if the checks are respected
-                // otherwise, we might stay in 'unknown' state until the value changes
-                if (!respectChecks)
-                    return;
-
-                PreviousPublishedState = state;
-                if (attributes != null)
-                    PreviousPublishedAttributes = attributes;
-
-                LastUpdated = DateTime.Now;
             }
-            catch (Exception ex)
-            {
-                Log.Fatal("[SENSOR] [{name}] Error publishing state: {err}", EntityName, ex.Message);
-            }
-        }
 
-        public async Task PublishAutoDiscoveryConfigAsync()
-        {
-            if (Variables.MqttManager == null) return;
-            await Variables.MqttManager.AnnounceAutoDiscoveryConfigAsync(this, Domain);
-        }
+            // only store the values if the checks are respected
+            // otherwise, we might stay in 'unknown' state until the value changes
+            if (!respectChecks)
+                return;
 
-        public async Task UnPublishAutoDiscoveryConfigAsync()
-        {
-            if (Variables.MqttManager == null) return;
-            await Variables.MqttManager.AnnounceAutoDiscoveryConfigAsync(this, Domain, true);
+            PreviousPublishedState = state;
+            if (attributes != null)
+                PreviousPublishedAttributes = attributes;
+
+            LastUpdated = DateTime.Now;
         }
+        catch (Exception ex)
+        {
+            Log.Fatal("[SENSOR] [{name}] Error publishing state: {err}", EntityName, ex.Message);
+        }
+    }
+
+    public async Task PublishAutoDiscoveryConfigAsync()
+    {
+        if (Variables.MqttManager == null) return;
+        await Variables.MqttManager.AnnounceAutoDiscoveryConfigAsync(this, Domain);
+    }
+
+    public async Task UnPublishAutoDiscoveryConfigAsync()
+    {
+        if (Variables.MqttManager == null) return;
+        await Variables.MqttManager.AnnounceAutoDiscoveryConfigAsync(this, Domain, true);
     }
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/Models/HomeAssistant/AbstractSingleValueSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Models/HomeAssistant/AbstractSingleValueSensor.cs
@@ -53,12 +53,14 @@ public abstract class AbstractSingleValueSensor : AbstractDiscoverable
     {
         try
         {
-            if (Variables.MqttManager == null) return;
+            if (Variables.MqttManager == null)
+                return;
 
             // are we asked to check elapsed time?
             if (respectChecks)
             {
-                if (LastUpdated.HasValue && LastUpdated.Value.AddSeconds(UpdateIntervalSeconds) > DateTime.Now) return;
+                if (LastUpdated.HasValue && LastUpdated.Value.AddSeconds(UpdateIntervalSeconds) > DateTime.Now)
+                    return;
             }
 
             // get the current state/attributes
@@ -71,7 +73,8 @@ public abstract class AbstractSingleValueSensor : AbstractDiscoverable
             // are we asked to check state changes?
             if (respectChecks)
             {
-                if (PreviousPublishedState == state && PreviousPublishedAttributes == attributes) {
+                if (PreviousPublishedState == state && PreviousPublishedAttributes == attributes)
+                {
                     LastUpdated = DateTime.Now;
                     return;
                 }
@@ -79,7 +82,8 @@ public abstract class AbstractSingleValueSensor : AbstractDiscoverable
 
             // fetch the autodiscovery config
             var autoDiscoConfig = (SensorDiscoveryConfigModel)GetAutoDiscoveryConfig();
-            if (autoDiscoConfig == null) return;
+            if (autoDiscoConfig == null)
+                return;
 
             // prepare the state message
             var message = new MqttApplicationMessageBuilder()
@@ -91,7 +95,7 @@ public abstract class AbstractSingleValueSensor : AbstractDiscoverable
             // send it
             var published = await Variables.MqttManager.PublishAsync(message);
             if (!published)
-                return; // failed, don't store the state
+                return;
 
             // optionally prepare and send attributes
             if (UseAttributes && attributes != null)
@@ -104,7 +108,7 @@ public abstract class AbstractSingleValueSensor : AbstractDiscoverable
 
                 published = await Variables.MqttManager.PublishAsync(message);
                 if (!published)
-                    return; // failed, don't store the state
+                    return;
             }
 
             // only store the values if the checks are respected
@@ -126,13 +130,17 @@ public abstract class AbstractSingleValueSensor : AbstractDiscoverable
 
     public async Task PublishAutoDiscoveryConfigAsync()
     {
-        if (Variables.MqttManager == null) return;
+        if (Variables.MqttManager == null)
+            return;
+
         await Variables.MqttManager.AnnounceAutoDiscoveryConfigAsync(this, Domain);
     }
 
     public async Task UnPublishAutoDiscoveryConfigAsync()
     {
-        if (Variables.MqttManager == null) return;
+        if (Variables.MqttManager == null)
+            return;
+
         await Variables.MqttManager.AnnounceAutoDiscoveryConfigAsync(this, Domain, true);
     }
 }


### PR DESCRIPTION
This PR fixes issue where the "LastUpdated" value is not updated if sensor value is same as previously.
Thanks to @Shupershuff for reporting the issue :)

Due to this issue sensor's "GetState" would be called every second or often. For most of the sensors it wasn't an issue but in some cases where custom code (for example PowerShell sensor) is used, this may result in the code/script being run "constantly" without respect for the "Update every" sensor configuration.

Before:
![obraz](https://github.com/hass-agent/HASS.Agent/assets/68441479/a0063ed4-d1be-48df-a6a0-093eeb23027a)

After:
![obraz](https://github.com/hass-agent/HASS.Agent/assets/68441479/074b91c1-dab3-4e1c-9d86-7effc5f96e3b)
