### PR TITLE
Fix: Powershell command argument binding

### DIFF
--- a/src/HASS.Agent/HASS.Agent.Shared/Managers/PowershellManager.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Managers/PowershellManager.cs
@@ -38,19 +38,9 @@ namespace HASS.Agent.Shared.Managers
         {
             if (isScript)
             {
-                var splitParameters = _parameterRegex.Matches(parameters);
-
-                var processedParameters = "";
-                foreach (Match param in splitParameters.Cast<Match>())
-                {
-                    processedParameters += " ";
-                    var safeParam = (param.Value.StartsWith("\"") && param.Value.EndsWith("\"")) ? param.Value.Replace("\"", "") : param.Value;
-                    processedParameters += safeParam;
-                }
-
                 return string.IsNullOrWhiteSpace(parameters)
                     ? $"-File \"{command}\""
-                    : $"-File \"{command}\"{splitParameters}";
+                    : $"-File \"{command}\" {parameters}";
             }
             else
             {

--- a/src/HASS.Agent/HASS.Agent.Shared/Managers/PowershellManager.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Managers/PowershellManager.cs
@@ -9,320 +9,316 @@ using CliWrap;
 using Newtonsoft.Json;
 using Serilog;
 
-namespace HASS.Agent.Shared.Managers
+namespace HASS.Agent.Shared.Managers;
+
+/// <summary>
+/// Performs Powershell-related actions
+/// </summary>
+public static class PowershellManager
 {
     /// <summary>
-    /// Performs Powershell-related actions
+    /// Execute a Powershell command without waiting for or checking results
     /// </summary>
-    public static class PowershellManager
+    /// <param name="command"></param>
+    /// <returns></returns>
+    public static bool ExecuteCommandHeadless(string command) => ExecuteHeadless(command, string.Empty, false);
+
+    /// <summary>
+    /// Executes a Powershell script without waiting for or checking results
+    /// </summary>
+    /// <param name="script"></param>
+    /// <param name="parameters"></param>
+    /// <returns></returns>
+    public static bool ExecuteScriptHeadless(string script, string parameters) => ExecuteHeadless(script, parameters, true);
+
+    private static string GetProcessArguments(string command, string parameters, bool isScript)
     {
-        private const string _parameterPattern = @"[^\s""']+|""([^""]*)""|'([^']*)'";
-        private static readonly Regex _parameterRegex = new Regex(_parameterPattern);
-
-        /// <summary>
-        /// Execute a Powershell command without waiting for or checking results
-        /// </summary>
-        /// <param name="command"></param>
-        /// <returns></returns>
-        public static bool ExecuteCommandHeadless(string command) => ExecuteHeadless(command, string.Empty, false);
-
-        /// <summary>
-        /// Executes a Powershell script without waiting for or checking results
-        /// </summary>
-        /// <param name="script"></param>
-        /// <param name="parameters"></param>
-        /// <returns></returns>
-        public static bool ExecuteScriptHeadless(string script, string parameters) => ExecuteHeadless(script, parameters, true);
-
-        private static string GetProcessArguments(string command, string parameters, bool isScript)
+        if (isScript)
         {
+            return string.IsNullOrWhiteSpace(parameters)
+                ? $"-File \"{command}\""
+                : $"-File \"{command}\" {parameters}";
+        }
+        else
+        {
+            return $@"& {{{command}}}"; //NOTE: place to fix any potential future issues with "command part of the command"
+        }
+    }
+
+    private static bool ExecuteHeadless(string command, string parameters, bool isScript)
+    {
+        var descriptor = isScript ? "script" : "command";
+
+        try
+        {
+            var workingDir = string.Empty;
             if (isScript)
             {
-                return string.IsNullOrWhiteSpace(parameters)
-                    ? $"-File \"{command}\""
-                    : $"-File \"{command}\" {parameters}";
+                // try to get the script's startup path
+                var scriptDir = Path.GetDirectoryName(command);
+                workingDir = !string.IsNullOrEmpty(scriptDir) ? scriptDir : string.Empty;
+            }
+
+            var psExec = GetPsExecutable();
+            if (string.IsNullOrEmpty(psExec))
+                return false;
+
+            var processInfo = new ProcessStartInfo
+            {
+                WindowStyle = ProcessWindowStyle.Hidden,
+                CreateNoWindow = true,
+                FileName = psExec,
+                WorkingDirectory = workingDir,
+                Arguments = GetProcessArguments(command, parameters, isScript)
+            };
+
+            using var process = new Process();
+            process.StartInfo = processInfo;
+            var start = process.Start();
+
+            if (!start)
+            {
+                Log.Error("[POWERSHELL] Unable to start processing {descriptor}: {command}", descriptor, command);
+
+                return false;
+            }
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.Fatal(ex, "[POWERSHELL] Fatal error when executing {descriptor}: {command}", descriptor, command);
+
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Execute a Powershell command, logs the output if it fails
+    /// </summary>
+    /// <param name="command"></param>
+    /// <param name="timeout"></param>
+    /// <returns></returns>
+    public static bool ExecuteCommand(string command, TimeSpan timeout) => Execute(command, string.Empty, false, timeout);
+
+    /// <summary>
+    /// Executes a Powershell script, logs the output if it fails
+    /// </summary>
+    /// <param name="script"></param>
+    /// <param name="timeout"></param>
+    /// <returns></returns>
+    public static bool ExecuteScript(string script, string parameters, TimeSpan timeout) => Execute(script, parameters, true, timeout);
+
+    private static bool Execute(string command, string parameters, bool isScript, TimeSpan timeout)
+    {
+        var descriptor = isScript ? "script" : "command";
+
+        try
+        {
+            var workingDir = string.Empty;
+            if (isScript)
+            {
+                // try to get the script's startup path
+                var scriptDir = Path.GetDirectoryName(command);
+                workingDir = !string.IsNullOrEmpty(scriptDir) ? scriptDir : string.Empty;
+            }
+
+            var psExec = GetPsExecutable();
+            if (string.IsNullOrEmpty(psExec)) return false;
+
+            var processInfo = new ProcessStartInfo
+            {
+                FileName = psExec,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                WorkingDirectory = workingDir,
+                Arguments = GetProcessArguments(command, parameters, isScript)
+            };
+
+            using var process = new Process();
+            process.StartInfo = processInfo;
+            var start = process.Start();
+
+            if (!start)
+            {
+                Log.Error("[POWERSHELL] Unable to start processing {descriptor}: {script}", descriptor, command);
+
+                return false;
+            }
+
+            process.WaitForExit(Convert.ToInt32(timeout.TotalMilliseconds));
+
+            if (process.ExitCode == 0)
+                return true;
+
+            // non-zero exitcode, process as failed
+            Log.Error("[POWERSHELL] The {descriptor} returned non-zero exitcode: {code}", descriptor, process.ExitCode);
+
+            var errors = process.StandardError.ReadToEnd().Trim();
+            if (!string.IsNullOrEmpty(errors))
+            {
+                Log.Error("[POWERSHELL] Error output:\r\n{output}", errors);
             }
             else
             {
-                return $@"& {{{command}}}"; //NOTE: place to fix any potential future issues with "command part of the command"
-            }
-        }
-
-        private static bool ExecuteHeadless(string command, string parameters, bool isScript)
-        {
-            var descriptor = isScript ? "script" : "command";
-
-            try
-            {
-                var workingDir = string.Empty;
-                if (isScript)
-                {
-                    // try to get the script's startup path
-                    var scriptDir = Path.GetDirectoryName(command);
-                    workingDir = !string.IsNullOrEmpty(scriptDir) ? scriptDir : string.Empty;
-                }
-
-                var psExec = GetPsExecutable();
-                if (string.IsNullOrEmpty(psExec))
-                    return false;
-
-                var processInfo = new ProcessStartInfo
-                {
-                    WindowStyle = ProcessWindowStyle.Hidden,
-                    CreateNoWindow = true,
-                    FileName = psExec,
-                    WorkingDirectory = workingDir,
-                    Arguments = GetProcessArguments(command, parameters, isScript)
-                };
-
-                using var process = new Process();
-                process.StartInfo = processInfo;
-                var start = process.Start();
-
-                if (!start)
-                {
-                    Log.Error("[POWERSHELL] Unable to start processing {descriptor}: {command}", descriptor, command);
-
-                    return false;
-                }
-
-                return true;
-            }
-            catch (Exception ex)
-            {
-                Log.Fatal(ex, "[POWERSHELL] Fatal error when executing {descriptor}: {command}", descriptor, command);
-
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Execute a Powershell command, logs the output if it fails
-        /// </summary>
-        /// <param name="command"></param>
-        /// <param name="timeout"></param>
-        /// <returns></returns>
-        public static bool ExecuteCommand(string command, TimeSpan timeout) => Execute(command, string.Empty, false, timeout);
-
-        /// <summary>
-        /// Executes a Powershell script, logs the output if it fails
-        /// </summary>
-        /// <param name="script"></param>
-        /// <param name="timeout"></param>
-        /// <returns></returns>
-        public static bool ExecuteScript(string script, string parameters, TimeSpan timeout) => Execute(script, parameters, true, timeout);
-
-        private static bool Execute(string command, string parameters, bool isScript, TimeSpan timeout)
-        {
-            var descriptor = isScript ? "script" : "command";
-
-            try
-            {
-                var workingDir = string.Empty;
-                if (isScript)
-                {
-                    // try to get the script's startup path
-                    var scriptDir = Path.GetDirectoryName(command);
-                    workingDir = !string.IsNullOrEmpty(scriptDir) ? scriptDir : string.Empty;
-                }
-
-                var psExec = GetPsExecutable();
-                if (string.IsNullOrEmpty(psExec)) return false;
-
-                var processInfo = new ProcessStartInfo
-                {
-                    FileName = psExec,
-                    RedirectStandardError = true,
-                    RedirectStandardOutput = true,
-                    UseShellExecute = false,
-                    WorkingDirectory = workingDir,
-                    Arguments = GetProcessArguments(command, parameters, isScript)
-                };
-
-                using var process = new Process();
-                process.StartInfo = processInfo;
-                var start = process.Start();
-
-                if (!start)
-                {
-                    Log.Error("[POWERSHELL] Unable to start processing {descriptor}: {script}", descriptor, command);
-
-                    return false;
-                }
-
-                process.WaitForExit(Convert.ToInt32(timeout.TotalMilliseconds));
-
-                if (process.ExitCode == 0)
-                    return true;
-
-                // non-zero exitcode, process as failed
-                Log.Error("[POWERSHELL] The {descriptor} returned non-zero exitcode: {code}", descriptor, process.ExitCode);
-
-                var errors = process.StandardError.ReadToEnd().Trim();
-                if (!string.IsNullOrEmpty(errors))
-                {
-                    Log.Error("[POWERSHELL] Error output:\r\n{output}", errors);
-                }
+                var console = process.StandardOutput.ReadToEnd().Trim();
+                if (!string.IsNullOrEmpty(console))
+                    Log.Error("[POWERSHELL] No error output, console output:\r\n{output}", errors);
                 else
-                {
-                    var console = process.StandardOutput.ReadToEnd().Trim();
-                    if (!string.IsNullOrEmpty(console))
-                        Log.Error("[POWERSHELL] No error output, console output:\r\n{output}", errors);
-                    else
-                        Log.Error("[POWERSHELL] No error and no console output");
-                }
-
-                return false;
+                    Log.Error("[POWERSHELL] No error and no console output");
             }
-            catch (Exception ex)
-            {
-                Log.Fatal(ex, "[POWERSHELL] Fatal error when executing {descriptor}: {command}", descriptor, command);
 
-                return false;
-            }
+            return false;
+        }
+        catch (Exception ex)
+        {
+            Log.Fatal(ex, "[POWERSHELL] Fatal error when executing {descriptor}: {command}", descriptor, command);
+
+            return false;
+        }
+    }
+
+    private static Encoding TryParseCodePage(int codePage)
+    {
+        Encoding encoding = null;
+        try
+        {
+            encoding = Encoding.GetEncoding(codePage);
+        }
+        catch
+        {
+            // best effort
         }
 
-        private static Encoding TryParseCodePage(int codePage)
-        {
-            Encoding encoding = null;
-            try
-            {
-                encoding = Encoding.GetEncoding(codePage);
-            }
-            catch
-            {
-                // best effort
-            }
+        return encoding;
+    }
 
+    private static Encoding GetEncoding()
+    {
+        var encoding = TryParseCodePage(CultureInfo.InstalledUICulture.TextInfo.OEMCodePage);
+        if (encoding != null)
             return encoding;
-        }
 
-        private static Encoding GetEncoding()
+        encoding = TryParseCodePage(CultureInfo.CurrentCulture.TextInfo.OEMCodePage);
+        if (encoding != null)
+            return encoding;
+
+        encoding = TryParseCodePage(CultureInfo.CurrentUICulture.TextInfo.OEMCodePage);
+        if (encoding != null)
+            return encoding;
+
+        encoding = TryParseCodePage(CultureInfo.InvariantCulture.TextInfo.OEMCodePage);
+        if (encoding != null)
+            return encoding;
+
+        Log.Warning("[POWERSHELL] Cannot parse system text culture to encoding, returning UTF-8 as a fallback, please report this as a GitHub issue");
+
+        Log.Debug("[POWERSHELL] currentInstalledUICulture  {c}", JsonConvert.SerializeObject(CultureInfo.InstalledUICulture.TextInfo));
+        Log.Debug("[POWERSHELL] currentCulture  {c}", JsonConvert.SerializeObject(CultureInfo.CurrentCulture.TextInfo));
+        Log.Debug("[POWERSHELL] currentUICulture  {c}", JsonConvert.SerializeObject(CultureInfo.CurrentUICulture.TextInfo));
+        Log.Debug("[POWERSHELL] invariantCulture  {c}", JsonConvert.SerializeObject(CultureInfo.InvariantCulture.TextInfo));
+
+        return Encoding.UTF8;
+    }
+
+    /// <summary>
+    /// Executes the command or script, and returns the standard and error output
+    /// </summary>
+    /// <param name="command"></param>
+    /// <param name="timeout"></param>
+    /// <param name="output"></param>
+    /// <param name="errors"></param>
+    /// <returns></returns>
+    internal static bool ExecuteWithOutput(string command, TimeSpan timeout, out string output, out string errors)
+    {
+        output = string.Empty;
+        errors = string.Empty;
+
+        try
         {
-            var encoding = TryParseCodePage(CultureInfo.InstalledUICulture.TextInfo.OEMCodePage);
-            if (encoding != null)
-                return encoding;
+            var isScript = command.ToLower().EndsWith(".ps1");
 
-            encoding = TryParseCodePage(CultureInfo.CurrentCulture.TextInfo.OEMCodePage);
-            if (encoding != null)
-                return encoding;
-
-            encoding = TryParseCodePage(CultureInfo.CurrentUICulture.TextInfo.OEMCodePage);
-            if (encoding != null)
-                return encoding;
-
-            encoding = TryParseCodePage(CultureInfo.InvariantCulture.TextInfo.OEMCodePage);
-            if (encoding != null)
-                return encoding;
-
-            Log.Warning("[POWERSHELL] Cannot parse system text culture to encoding, returning UTF-8 as a fallback, please report this as a GitHub issue");
-
-            Log.Debug("[POWERSHELL] currentInstalledUICulture  {c}", JsonConvert.SerializeObject(CultureInfo.InstalledUICulture.TextInfo));
-            Log.Debug("[POWERSHELL] currentCulture  {c}", JsonConvert.SerializeObject(CultureInfo.CurrentCulture.TextInfo));
-            Log.Debug("[POWERSHELL] currentUICulture  {c}", JsonConvert.SerializeObject(CultureInfo.CurrentUICulture.TextInfo));
-            Log.Debug("[POWERSHELL] invariantCulture  {c}", JsonConvert.SerializeObject(CultureInfo.InvariantCulture.TextInfo));
-
-            return Encoding.UTF8;
-        }
-
-        /// <summary>
-        /// Executes the command or script, and returns the standard and error output
-        /// </summary>
-        /// <param name="command"></param>
-        /// <param name="timeout"></param>
-        /// <param name="output"></param>
-        /// <param name="errors"></param>
-        /// <returns></returns>
-        internal static bool ExecuteWithOutput(string command, TimeSpan timeout, out string output, out string errors)
-        {
-            output = string.Empty;
-            errors = string.Empty;
-
-            try
+            var workingDir = string.Empty;
+            if (isScript)
             {
-                var isScript = command.ToLower().EndsWith(".ps1");
-
-                var workingDir = string.Empty;
-                if (isScript)
-                {
-                    // try to get the script's startup path
-                    var scriptDir = Path.GetDirectoryName(command);
-                    workingDir = !string.IsNullOrEmpty(scriptDir) ? scriptDir : string.Empty;
-                }
-
-                var psExec = GetPsExecutable();
-                if (string.IsNullOrEmpty(psExec))
-                    return false;
-
-                var encoding = GetEncoding();
-
-                var processInfo = new ProcessStartInfo
-                {
-                    FileName = psExec,
-                    RedirectStandardError = true,
-                    RedirectStandardOutput = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true,
-                    WorkingDirectory = workingDir,
-                    StandardOutputEncoding = encoding,
-                    StandardErrorEncoding = encoding,
-                    // set the right type of arguments
-                    Arguments = isScript
-                        ? $@"& '{command}'"
-                        : $@"& {{{command}}}"
-                };
-
-                using var process = new Process();
-                process.StartInfo = processInfo;
-
-                var start = process.Start();
-                if (!start)
-                {
-                    Log.Error("[POWERSHELL] Unable to begin executing the {type}: {cmd}", isScript ? "script" : "command", command);
-
-                    return false;
-                }
-
-                var completed = process.WaitForExit(Convert.ToInt32(timeout.TotalMilliseconds));
-                if (!completed)
-                    Log.Error("[POWERSHELL] Timeout executing the {type}: {cmd}", isScript ? "script" : "command", command);
-
-                output = process.StandardOutput.ReadToEnd().Trim();
-                errors = process.StandardError.ReadToEnd().Trim();
-
-                process.StandardOutput.Dispose();
-                process.StandardError.Dispose();
-
-                process.Kill();
-
-                return completed;
+                // try to get the script's startup path
+                var scriptDir = Path.GetDirectoryName(command);
+                workingDir = !string.IsNullOrEmpty(scriptDir) ? scriptDir : string.Empty;
             }
-            catch (Exception ex)
+
+            var psExec = GetPsExecutable();
+            if (string.IsNullOrEmpty(psExec))
+                return false;
+
+            var encoding = GetEncoding();
+
+            var processInfo = new ProcessStartInfo
             {
-                Log.Fatal(ex, ex.Message);
+                FileName = psExec,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                WorkingDirectory = workingDir,
+                StandardOutputEncoding = encoding,
+                StandardErrorEncoding = encoding,
+                // set the right type of arguments
+                Arguments = isScript
+                    ? $@"& '{command}'"
+                    : $@"& {{{command}}}"
+            };
+
+            using var process = new Process();
+            process.StartInfo = processInfo;
+
+            var start = process.Start();
+            if (!start)
+            {
+                Log.Error("[POWERSHELL] Unable to begin executing the {type}: {cmd}", isScript ? "script" : "command", command);
 
                 return false;
             }
-        }
 
-        /// <summary>
-        /// Attempt to locate powershell.exe
-        /// </summary>
-        /// <returns></returns>
-        public static string GetPsExecutable()
+            var completed = process.WaitForExit(Convert.ToInt32(timeout.TotalMilliseconds));
+            if (!completed)
+                Log.Error("[POWERSHELL] Timeout executing the {type}: {cmd}", isScript ? "script" : "command", command);
+
+            output = process.StandardOutput.ReadToEnd().Trim();
+            errors = process.StandardError.ReadToEnd().Trim();
+
+            process.StandardOutput.Dispose();
+            process.StandardError.Dispose();
+
+            process.Kill();
+
+            return completed;
+        }
+        catch (Exception ex)
         {
-            // try regular location
-            var psExec = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "WindowsPowerShell\\v1.0\\powershell.exe");
-            if (File.Exists(psExec))
-                return psExec;
+            Log.Fatal(ex, ex.Message);
 
-            // try specific
-            psExec = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.SystemX86), "WindowsPowerShell\\v1.0\\powershell.exe");
-            if (File.Exists(psExec))
-                return psExec;
-
-            Log.Error("[POWERSHELL] PS executable not found, make sure you have powershell installed on your system");
-            return string.Empty;
+            return false;
         }
+    }
+
+    /// <summary>
+    /// Attempt to locate powershell.exe
+    /// </summary>
+    /// <returns></returns>
+    public static string GetPsExecutable()
+    {
+        // try regular location
+        var psExec = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "WindowsPowerShell\\v1.0\\powershell.exe");
+        if (File.Exists(psExec))
+            return psExec;
+
+        // try specific
+        psExec = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.SystemX86), "WindowsPowerShell\\v1.0\\powershell.exe");
+        if (File.Exists(psExec))
+            return psExec;
+
+        Log.Error("[POWERSHELL] PS executable not found, make sure you have powershell installed on your system");
+        return string.Empty;
     }
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/Managers/PowershellManager.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Managers/PowershellManager.cs
@@ -2,322 +2,337 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using CliWrap;
 using Newtonsoft.Json;
 using Serilog;
 
 namespace HASS.Agent.Shared.Managers
 {
-	/// <summary>
-	/// Performs Powershell-related actions
-	/// </summary>
-	public static class PowershellManager
-	{
-		/// <summary>
-		/// Execute a Powershell command without waiting for or checking results
-		/// </summary>
-		/// <param name="command"></param>
-		/// <returns></returns>
-		public static bool ExecuteCommandHeadless(string command) => ExecuteHeadless(command, string.Empty, false);
+    /// <summary>
+    /// Performs Powershell-related actions
+    /// </summary>
+    public static class PowershellManager
+    {
+        private const string _parameterPattern = @"[^\s""']+|""([^""]*)""|'([^']*)'";
+        private static readonly Regex _parameterRegex = new Regex(_parameterPattern);
 
-		/// <summary>
-		/// Executes a Powershell script without waiting for or checking results
-		/// </summary>
-		/// <param name="script"></param>
-		/// <param name="parameters"></param>
-		/// <returns></returns>
-		public static bool ExecuteScriptHeadless(string script, string parameters) => ExecuteHeadless(script, parameters, true);
+        /// <summary>
+        /// Execute a Powershell command without waiting for or checking results
+        /// </summary>
+        /// <param name="command"></param>
+        /// <returns></returns>
+        public static bool ExecuteCommandHeadless(string command) => ExecuteHeadless(command, string.Empty, false);
 
-		private static string GetProcessArguments(string command, string parameters, bool isScript)
-		{
-			if (isScript)
-			{
-				return string.IsNullOrWhiteSpace(parameters)
-					? $"-File \"{command}\""
-					: $"-File \"{command}\" \"{parameters}\"";
-			}
-			else
-			{
-				return $@"& {{{command}}}"; //NOTE: place to fix any potential future issues with "command part of the command"
-			}
-		}
+        /// <summary>
+        /// Executes a Powershell script without waiting for or checking results
+        /// </summary>
+        /// <param name="script"></param>
+        /// <param name="parameters"></param>
+        /// <returns></returns>
+        public static bool ExecuteScriptHeadless(string script, string parameters) => ExecuteHeadless(script, parameters, true);
 
-		private static bool ExecuteHeadless(string command, string parameters, bool isScript)
-		{
-			var descriptor = isScript ? "script" : "command";
+        private static string GetProcessArguments(string command, string parameters, bool isScript)
+        {
+            if (isScript)
+            {
+                var splitParameters = _parameterRegex.Matches(parameters);
 
-			try
-			{
-				var workingDir = string.Empty;
-				if (isScript)
-				{
-					// try to get the script's startup path
-					var scriptDir = Path.GetDirectoryName(command);
-					workingDir = !string.IsNullOrEmpty(scriptDir) ? scriptDir : string.Empty;
-				}
+                var processedParameters = "";
+                foreach (Match param in splitParameters.Cast<Match>())
+                {
+                    processedParameters += " ";
+                    var safeParam = (param.Value.StartsWith("\"") && param.Value.EndsWith("\"")) ? param.Value.Replace("\"", "") : param.Value;
+                    processedParameters += safeParam;
+                }
 
-				var psExec = GetPsExecutable();
-				if (string.IsNullOrEmpty(psExec))
-					return false;
+                return string.IsNullOrWhiteSpace(parameters)
+                    ? $"-File \"{command}\""
+                    : $"-File \"{command}\"{splitParameters}";
+            }
+            else
+            {
+                return $@"& {{{command}}}"; //NOTE: place to fix any potential future issues with "command part of the command"
+            }
+        }
 
-				var processInfo = new ProcessStartInfo
-				{
-					WindowStyle = ProcessWindowStyle.Hidden,
-					CreateNoWindow = true,
-					FileName = psExec,
-					WorkingDirectory = workingDir,
-					Arguments = GetProcessArguments(command, parameters, isScript)
-				};
+        private static bool ExecuteHeadless(string command, string parameters, bool isScript)
+        {
+            var descriptor = isScript ? "script" : "command";
 
-				using var process = new Process();
-				process.StartInfo = processInfo;
-				var start = process.Start();
+            try
+            {
+                var workingDir = string.Empty;
+                if (isScript)
+                {
+                    // try to get the script's startup path
+                    var scriptDir = Path.GetDirectoryName(command);
+                    workingDir = !string.IsNullOrEmpty(scriptDir) ? scriptDir : string.Empty;
+                }
 
-				if (!start)
-				{
-					Log.Error("[POWERSHELL] Unable to start processing {descriptor}: {command}", descriptor, command);
+                var psExec = GetPsExecutable();
+                if (string.IsNullOrEmpty(psExec))
+                    return false;
 
-					return false;
-				}
+                var processInfo = new ProcessStartInfo
+                {
+                    WindowStyle = ProcessWindowStyle.Hidden,
+                    CreateNoWindow = true,
+                    FileName = psExec,
+                    WorkingDirectory = workingDir,
+                    Arguments = GetProcessArguments(command, parameters, isScript)
+                };
 
-				return true;
-			}
-			catch (Exception ex)
-			{
-				Log.Fatal(ex, "[POWERSHELL] Fatal error when executing {descriptor}: {command}", descriptor, command);
+                using var process = new Process();
+                process.StartInfo = processInfo;
+                var start = process.Start();
 
-				return false;
-			}
-		}
+                if (!start)
+                {
+                    Log.Error("[POWERSHELL] Unable to start processing {descriptor}: {command}", descriptor, command);
 
-		/// <summary>
-		/// Execute a Powershell command, logs the output if it fails
-		/// </summary>
-		/// <param name="command"></param>
-		/// <param name="timeout"></param>
-		/// <returns></returns>
-		public static bool ExecuteCommand(string command, TimeSpan timeout) => Execute(command, string.Empty, false, timeout);
+                    return false;
+                }
 
-		/// <summary>
-		/// Executes a Powershell script, logs the output if it fails
-		/// </summary>
-		/// <param name="script"></param>
-		/// <param name="timeout"></param>
-		/// <returns></returns>
-		public static bool ExecuteScript(string script, string parameters, TimeSpan timeout) => Execute(script, parameters, true, timeout);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Log.Fatal(ex, "[POWERSHELL] Fatal error when executing {descriptor}: {command}", descriptor, command);
 
-		private static bool Execute(string command, string parameters, bool isScript, TimeSpan timeout)
-		{
-			var descriptor = isScript ? "script" : "command";
+                return false;
+            }
+        }
 
-			try
-			{
-				var workingDir = string.Empty;
-				if (isScript)
-				{
-					// try to get the script's startup path
-					var scriptDir = Path.GetDirectoryName(command);
-					workingDir = !string.IsNullOrEmpty(scriptDir) ? scriptDir : string.Empty;
-				}
+        /// <summary>
+        /// Execute a Powershell command, logs the output if it fails
+        /// </summary>
+        /// <param name="command"></param>
+        /// <param name="timeout"></param>
+        /// <returns></returns>
+        public static bool ExecuteCommand(string command, TimeSpan timeout) => Execute(command, string.Empty, false, timeout);
 
-				var psExec = GetPsExecutable();
-				if (string.IsNullOrEmpty(psExec)) return false;
+        /// <summary>
+        /// Executes a Powershell script, logs the output if it fails
+        /// </summary>
+        /// <param name="script"></param>
+        /// <param name="timeout"></param>
+        /// <returns></returns>
+        public static bool ExecuteScript(string script, string parameters, TimeSpan timeout) => Execute(script, parameters, true, timeout);
 
-				var processInfo = new ProcessStartInfo
-				{
-					FileName = psExec,
-					RedirectStandardError = true,
-					RedirectStandardOutput = true,
-					UseShellExecute = false,
-					WorkingDirectory = workingDir,
-					Arguments = GetProcessArguments(command, parameters, isScript)
-				};
+        private static bool Execute(string command, string parameters, bool isScript, TimeSpan timeout)
+        {
+            var descriptor = isScript ? "script" : "command";
 
-				using var process = new Process();
-				process.StartInfo = processInfo;
-				var start = process.Start();
+            try
+            {
+                var workingDir = string.Empty;
+                if (isScript)
+                {
+                    // try to get the script's startup path
+                    var scriptDir = Path.GetDirectoryName(command);
+                    workingDir = !string.IsNullOrEmpty(scriptDir) ? scriptDir : string.Empty;
+                }
 
-				if (!start)
-				{
-					Log.Error("[POWERSHELL] Unable to start processing {descriptor}: {script}", descriptor, command);
+                var psExec = GetPsExecutable();
+                if (string.IsNullOrEmpty(psExec)) return false;
 
-					return false;
-				}
+                var processInfo = new ProcessStartInfo
+                {
+                    FileName = psExec,
+                    RedirectStandardError = true,
+                    RedirectStandardOutput = true,
+                    UseShellExecute = false,
+                    WorkingDirectory = workingDir,
+                    Arguments = GetProcessArguments(command, parameters, isScript)
+                };
 
-				process.WaitForExit(Convert.ToInt32(timeout.TotalMilliseconds));
+                using var process = new Process();
+                process.StartInfo = processInfo;
+                var start = process.Start();
 
-				if (process.ExitCode == 0)
-					return true;
+                if (!start)
+                {
+                    Log.Error("[POWERSHELL] Unable to start processing {descriptor}: {script}", descriptor, command);
 
-				// non-zero exitcode, process as failed
-				Log.Error("[POWERSHELL] The {descriptor} returned non-zero exitcode: {code}", descriptor, process.ExitCode);
+                    return false;
+                }
 
-				var errors = process.StandardError.ReadToEnd().Trim();
-				if (!string.IsNullOrEmpty(errors))
-				{
-					Log.Error("[POWERSHELL] Error output:\r\n{output}", errors);
-				}
-				else
-				{
-					var console = process.StandardOutput.ReadToEnd().Trim();
-					if (!string.IsNullOrEmpty(console))
-						Log.Error("[POWERSHELL] No error output, console output:\r\n{output}", errors);
-					else
-						Log.Error("[POWERSHELL] No error and no console output");
-				}
+                process.WaitForExit(Convert.ToInt32(timeout.TotalMilliseconds));
 
-				return false;
-			}
-			catch (Exception ex)
-			{
-				Log.Fatal(ex, "[POWERSHELL] Fatal error when executing {descriptor}: {command}", descriptor, command);
+                if (process.ExitCode == 0)
+                    return true;
 
-				return false;
-			}
-		}
+                // non-zero exitcode, process as failed
+                Log.Error("[POWERSHELL] The {descriptor} returned non-zero exitcode: {code}", descriptor, process.ExitCode);
 
-		private static Encoding TryParseCodePage(int codePage)
-		{
-			Encoding encoding = null;
-			try
-			{
-				encoding = Encoding.GetEncoding(codePage);
-			}
-			catch
-			{
-				// best effort
-			}
+                var errors = process.StandardError.ReadToEnd().Trim();
+                if (!string.IsNullOrEmpty(errors))
+                {
+                    Log.Error("[POWERSHELL] Error output:\r\n{output}", errors);
+                }
+                else
+                {
+                    var console = process.StandardOutput.ReadToEnd().Trim();
+                    if (!string.IsNullOrEmpty(console))
+                        Log.Error("[POWERSHELL] No error output, console output:\r\n{output}", errors);
+                    else
+                        Log.Error("[POWERSHELL] No error and no console output");
+                }
 
-			return encoding;
-		}
+                return false;
+            }
+            catch (Exception ex)
+            {
+                Log.Fatal(ex, "[POWERSHELL] Fatal error when executing {descriptor}: {command}", descriptor, command);
 
-		private static Encoding GetEncoding()
-		{
-			var encoding = TryParseCodePage(CultureInfo.InstalledUICulture.TextInfo.OEMCodePage);
-			if (encoding != null)
-				return encoding;
+                return false;
+            }
+        }
 
-			encoding = TryParseCodePage(CultureInfo.CurrentCulture.TextInfo.OEMCodePage);
-			if (encoding != null)
-				return encoding;
+        private static Encoding TryParseCodePage(int codePage)
+        {
+            Encoding encoding = null;
+            try
+            {
+                encoding = Encoding.GetEncoding(codePage);
+            }
+            catch
+            {
+                // best effort
+            }
 
-			encoding = TryParseCodePage(CultureInfo.CurrentUICulture.TextInfo.OEMCodePage);
-			if (encoding != null)
-				return encoding;
+            return encoding;
+        }
 
-			encoding = TryParseCodePage(CultureInfo.InvariantCulture.TextInfo.OEMCodePage);
-			if (encoding != null)
-				return encoding;
+        private static Encoding GetEncoding()
+        {
+            var encoding = TryParseCodePage(CultureInfo.InstalledUICulture.TextInfo.OEMCodePage);
+            if (encoding != null)
+                return encoding;
 
-			Log.Warning("[POWERSHELL] Cannot parse system text culture to encoding, returning UTF-8 as a fallback, please report this as a GitHub issue");
+            encoding = TryParseCodePage(CultureInfo.CurrentCulture.TextInfo.OEMCodePage);
+            if (encoding != null)
+                return encoding;
 
-			Log.Debug("[POWERSHELL] currentInstalledUICulture  {c}", JsonConvert.SerializeObject(CultureInfo.InstalledUICulture.TextInfo));
-			Log.Debug("[POWERSHELL] currentCulture  {c}", JsonConvert.SerializeObject(CultureInfo.CurrentCulture.TextInfo));
-			Log.Debug("[POWERSHELL] currentUICulture  {c}", JsonConvert.SerializeObject(CultureInfo.CurrentUICulture.TextInfo));
-			Log.Debug("[POWERSHELL] invariantCulture  {c}", JsonConvert.SerializeObject(CultureInfo.InvariantCulture.TextInfo));
+            encoding = TryParseCodePage(CultureInfo.CurrentUICulture.TextInfo.OEMCodePage);
+            if (encoding != null)
+                return encoding;
 
-			return Encoding.UTF8;
-		}
+            encoding = TryParseCodePage(CultureInfo.InvariantCulture.TextInfo.OEMCodePage);
+            if (encoding != null)
+                return encoding;
 
-		/// <summary>
-		/// Executes the command or script, and returns the standard and error output
-		/// </summary>
-		/// <param name="command"></param>
-		/// <param name="timeout"></param>
-		/// <param name="output"></param>
-		/// <param name="errors"></param>
-		/// <returns></returns>
-		internal static bool ExecuteWithOutput(string command, TimeSpan timeout, out string output, out string errors)
-		{
-			output = string.Empty;
-			errors = string.Empty;
+            Log.Warning("[POWERSHELL] Cannot parse system text culture to encoding, returning UTF-8 as a fallback, please report this as a GitHub issue");
 
-			try
-			{
-				var isScript = command.ToLower().EndsWith(".ps1");
+            Log.Debug("[POWERSHELL] currentInstalledUICulture  {c}", JsonConvert.SerializeObject(CultureInfo.InstalledUICulture.TextInfo));
+            Log.Debug("[POWERSHELL] currentCulture  {c}", JsonConvert.SerializeObject(CultureInfo.CurrentCulture.TextInfo));
+            Log.Debug("[POWERSHELL] currentUICulture  {c}", JsonConvert.SerializeObject(CultureInfo.CurrentUICulture.TextInfo));
+            Log.Debug("[POWERSHELL] invariantCulture  {c}", JsonConvert.SerializeObject(CultureInfo.InvariantCulture.TextInfo));
 
-				var workingDir = string.Empty;
-				if (isScript)
-				{
-					// try to get the script's startup path
-					var scriptDir = Path.GetDirectoryName(command);
-					workingDir = !string.IsNullOrEmpty(scriptDir) ? scriptDir : string.Empty;
-				}
+            return Encoding.UTF8;
+        }
 
-				var psExec = GetPsExecutable();
-				if (string.IsNullOrEmpty(psExec))
-					return false;
+        /// <summary>
+        /// Executes the command or script, and returns the standard and error output
+        /// </summary>
+        /// <param name="command"></param>
+        /// <param name="timeout"></param>
+        /// <param name="output"></param>
+        /// <param name="errors"></param>
+        /// <returns></returns>
+        internal static bool ExecuteWithOutput(string command, TimeSpan timeout, out string output, out string errors)
+        {
+            output = string.Empty;
+            errors = string.Empty;
 
-				var encoding = GetEncoding();
+            try
+            {
+                var isScript = command.ToLower().EndsWith(".ps1");
 
-				var processInfo = new ProcessStartInfo
-				{
-					FileName = psExec,
-					RedirectStandardError = true,
-					RedirectStandardOutput = true,
-					UseShellExecute = false,
-					CreateNoWindow = true,
-					WorkingDirectory = workingDir,
-					StandardOutputEncoding = encoding,
-					StandardErrorEncoding = encoding,
-					// set the right type of arguments
-					Arguments = isScript
-						? $@"& '{command}'"
-						: $@"& {{{command}}}"
-				};
+                var workingDir = string.Empty;
+                if (isScript)
+                {
+                    // try to get the script's startup path
+                    var scriptDir = Path.GetDirectoryName(command);
+                    workingDir = !string.IsNullOrEmpty(scriptDir) ? scriptDir : string.Empty;
+                }
 
-				using var process = new Process();
-				process.StartInfo = processInfo;
+                var psExec = GetPsExecutable();
+                if (string.IsNullOrEmpty(psExec))
+                    return false;
 
-				var start = process.Start();
-				if (!start)
-				{
-					Log.Error("[POWERSHELL] Unable to begin executing the {type}: {cmd}", isScript ? "script" : "command", command);
+                var encoding = GetEncoding();
 
-					return false;
-				}
+                var processInfo = new ProcessStartInfo
+                {
+                    FileName = psExec,
+                    RedirectStandardError = true,
+                    RedirectStandardOutput = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    WorkingDirectory = workingDir,
+                    StandardOutputEncoding = encoding,
+                    StandardErrorEncoding = encoding,
+                    // set the right type of arguments
+                    Arguments = isScript
+                        ? $@"& '{command}'"
+                        : $@"& {{{command}}}"
+                };
 
-				var completed = process.WaitForExit(Convert.ToInt32(timeout.TotalMilliseconds));
-				if (!completed)
-					Log.Error("[POWERSHELL] Timeout executing the {type}: {cmd}", isScript ? "script" : "command", command);
+                using var process = new Process();
+                process.StartInfo = processInfo;
 
-				output = process.StandardOutput.ReadToEnd().Trim();
-				errors = process.StandardError.ReadToEnd().Trim();
+                var start = process.Start();
+                if (!start)
+                {
+                    Log.Error("[POWERSHELL] Unable to begin executing the {type}: {cmd}", isScript ? "script" : "command", command);
 
-				process.StandardOutput.Dispose();
-				process.StandardError.Dispose();
+                    return false;
+                }
 
-				process.Kill();
+                var completed = process.WaitForExit(Convert.ToInt32(timeout.TotalMilliseconds));
+                if (!completed)
+                    Log.Error("[POWERSHELL] Timeout executing the {type}: {cmd}", isScript ? "script" : "command", command);
 
-				return completed;
-			}
-			catch (Exception ex)
-			{
-				Log.Fatal(ex, ex.Message);
+                output = process.StandardOutput.ReadToEnd().Trim();
+                errors = process.StandardError.ReadToEnd().Trim();
 
-				return false;
-			}
-		}
+                process.StandardOutput.Dispose();
+                process.StandardError.Dispose();
 
-		/// <summary>
-		/// Attempt to locate powershell.exe
-		/// </summary>
-		/// <returns></returns>
-		public static string GetPsExecutable()
-		{
-			// try regular location
-			var psExec = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "WindowsPowerShell\\v1.0\\powershell.exe");
-			if (File.Exists(psExec))
-				return psExec;
+                process.Kill();
 
-			// try specific
-			psExec = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.SystemX86), "WindowsPowerShell\\v1.0\\powershell.exe");
-			if (File.Exists(psExec))
-				return psExec;
+                return completed;
+            }
+            catch (Exception ex)
+            {
+                Log.Fatal(ex, ex.Message);
 
-			Log.Error("[POWERSHELL] PS executable not found, make sure you have powershell installed on your system");
-			return string.Empty;
-		}
-	}
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Attempt to locate powershell.exe
+        /// </summary>
+        /// <returns></returns>
+        public static string GetPsExecutable()
+        {
+            // try regular location
+            var psExec = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "WindowsPowerShell\\v1.0\\powershell.exe");
+            if (File.Exists(psExec))
+                return psExec;
+
+            // try specific
+            psExec = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.SystemX86), "WindowsPowerShell\\v1.0\\powershell.exe");
+            if (File.Exists(psExec))
+                return psExec;
+
+            Log.Error("[POWERSHELL] PS executable not found, make sure you have powershell installed on your system");
+            return string.Empty;
+        }
+    }
 }


### PR DESCRIPTION
This PR fixes how action arguments are passed on to the PowershellCommand.
Previously whole action string was passed as a one argument, this prevented parameter binding - after the changes the action string itself defines how the parameter/s will be handled.

Thanks to @Shupershuff for reporting :)

Test script configured with PowershellCommand:
```
param ([string]$test1,[string]$test2,[string]$test3)
$WorkingDirectory = ((Get-ChildItem -Path $PSScriptRoot)[0].fullname).substring(0,((Get-ChildItem -Path $PSScriptRoot)[0].fullname).lastindexof('\')) #Set #Current Directory path.
$wshell = New-Object -ComObject Wscript.Shell
$wshell.Popup("runs " + $PsBoundParameters.Values + "  :::::  " + $args,1,"Done",0x1)
$PsBoundParameters.Values >> $WorkingDirectory\sumlogs.txt

$DateTime = "[{0:dd/MM/yy} {0:HH:mm:ss}]" -f (Get-Date)
$LogMessage = "$DateTime TEST1 $test1 TEST2 $TEST2 TEST3 $TEST3 And value was $($PsBoundParameters.Values)"
Write-Output "Bananas"
Add-content "$WorkingDirectory\test.txt" -value $LogMessage -ErrorAction Stop
```

Service call on HA side:
```
service: mqtt.publish
data:
  topic: homeassistant/button/AMADEO-PC/powershell/action
  payload: -test1 "a string with spaces" maybearg2 -test3 arg3 additionalarg1
```

Result:
![rey4LO](https://github.com/hass-agent/HASS.Agent/assets/68441479/58e004e7-63a7-4c8c-b207-c0309ff7087e)
```
[15.02.24 20:19:24] TEST1 a string with spaces TEST2 maybearg2 TEST3 arg3 And value was a string with spaces arg3 maybearg2
```