### PR TITLE
Fix: active window title encoding

### DIFF
--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/ActiveWindowSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/ActiveWindowSensor.cs
@@ -53,7 +53,6 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
 
         private static string GetActiveWindowTitle()
         {
-            //const int nChars = 255;
             var windowHandle = GetForegroundWindow();
             var titleLength = GetWindowTextLength(windowHandle) + 1;
             var builder = new StringBuilder(titleLength);

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/ActiveWindowSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/ActiveWindowSensor.cs
@@ -16,10 +16,12 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
 
         public override DiscoveryConfigModel GetAutoDiscoveryConfig()
         {
-            if (Variables.MqttManager == null) return null;
+            if (Variables.MqttManager == null)
+                return null;
 
             var deviceConfig = Variables.MqttManager.GetDeviceConfigModel();
-            if (deviceConfig == null) return null;
+            if (deviceConfig == null)
+                return null;
 
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
             {
@@ -43,18 +45,21 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
         [DllImport("user32.dll")]
         private static extern IntPtr GetForegroundWindow();
 
+        [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+        private static extern int GetWindowTextLength(IntPtr hWnd);
+
         [DllImport("user32.dll", CharSet = CharSet.Auto)]
-        private static extern int GetWindowText(IntPtr hWnd, StringBuilder text, int count);
+        private static extern int GetWindowText(IntPtr hWnd, StringBuilder builder, int count);
 
         private static string GetActiveWindowTitle()
         {
-            const int nChars = 256;
-            var buff = new StringBuilder(nChars);
-            var handle = GetForegroundWindow();
+            //const int nChars = 255;
+            var windowHandle = GetForegroundWindow();
+            var titleLength = GetWindowTextLength(windowHandle) + 1;
+            var builder = new StringBuilder(titleLength);
+            var windowTitle = GetWindowText(windowHandle, builder, titleLength) > 0 ? builder.ToString() : string.Empty;
 
-            var windowTitle = GetWindowText(handle, buff, nChars) > 0 ? buff.ToString() : string.Empty;
-
-            return windowTitle;
+            return windowTitle.Length > 255 ? windowTitle[..255]: windowTitle; //Note(Amadeo): to make sure we don't exceed HA limitation of 255 payload length
         }
     }
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/ActiveWindowSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/ActiveWindowSensor.cs
@@ -43,7 +43,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
         [DllImport("user32.dll")]
         private static extern IntPtr GetForegroundWindow();
 
-        [DllImport("user32.dll")]
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
         private static extern int GetWindowText(IntPtr hWnd, StringBuilder text, int count);
 
         private static string GetActiveWindowTitle()
@@ -52,7 +52,9 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
             var buff = new StringBuilder(nChars);
             var handle = GetForegroundWindow();
 
-            return GetWindowText(handle, buff, nChars) > 0 ? buff.ToString() : string.Empty;
+            var windowTitle = GetWindowText(handle, buff, nChars) > 0 ? buff.ToString() : string.Empty;
+
+            return windowTitle;
         }
     }
 }


### PR DESCRIPTION
This PR fixes window title sensor encoding issue reported by Evostance.

Before:
![KGc30M](https://github.com/hass-agent/HASS.Agent/assets/68441479/9c3a1f82-9152-452b-89d3-3adfc4b5aa6f)

After:
![WTs0It](https://github.com/hass-agent/HASS.Agent/assets/68441479/bc1bc1e3-d750-4e5d-909a-bd0b8c9fe50d)

In addition, changes were made to ensure the window title length sent to HA will not exceed 255 characters - max HA payload/state length.