### PR TITLE
Fix: constant MQTT discovery payload publish

### DIFF
--- a/src/HASS.Agent/HASS.Agent/Commands/CommandsManager.cs
+++ b/src/HASS.Agent/HASS.Agent/Commands/CommandsManager.cs
@@ -107,6 +107,7 @@ namespace HASS.Agent.Commands
 
                     firstRun = false;
 
+                    // publish availability & autodiscovery every 30 sec
                     if ((DateTime.Now - _lastAutoDiscoPublish).TotalSeconds > 30)
                     {
                         await Variables.MqttManager.AnnounceAvailabilityAsync();

--- a/src/HASS.Agent/HASS.Agent/Commands/CommandsManager.cs
+++ b/src/HASS.Agent/HASS.Agent/Commands/CommandsManager.cs
@@ -17,6 +17,8 @@ namespace HASS.Agent.Commands
         private static bool _active = true;
         private static bool _pause;
 
+        private static bool _discoveryPublished = false;
+
         private static DateTime _lastAutoDiscoPublish = DateTime.MinValue;
 
         /// <summary>
@@ -66,6 +68,8 @@ namespace HASS.Agent.Commands
                 await command.UnPublishAutoDiscoveryConfigAsync();
                 await Variables.MqttManager.UnsubscribeAsync(command);
             }
+
+            _discoveryPublished = false;
         }
 
         /// <summary>
@@ -107,14 +111,19 @@ namespace HASS.Agent.Commands
                     {
                         await Variables.MqttManager.AnnounceAvailabilityAsync();
 
-                        foreach (var command in Variables.Commands
-                            .TakeWhile(_ => !_pause)
-                            .TakeWhile(_ => _active))
+                        if (!_discoveryPublished)
                         {
-                            if (_pause || Variables.MqttManager.GetStatus() != MqttStatus.Connected)
-                                continue;
+                            foreach (var command in Variables.Commands
+                                .TakeWhile(_ => !_pause)
+                                .TakeWhile(_ => _active))
+                            {
+                                if (_pause || Variables.MqttManager.GetStatus() != MqttStatus.Connected)
+                                    continue;
 
-                            await command.PublishAutoDiscoveryConfigAsync();
+                                await command.PublishAutoDiscoveryConfigAsync();
+                            }
+
+                            _discoveryPublished = true;
                         }
 
                         if (!subscribed)

--- a/src/HASS.Agent/HASS.Agent/Sensors/SensorsManager.cs
+++ b/src/HASS.Agent/HASS.Agent/Sensors/SensorsManager.cs
@@ -98,36 +98,34 @@ namespace HASS.Agent.Sensors
                     // optionally flag as the first real run
                     if (!firstRunDone) firstRunDone = true;
 
-                    if (!_discoveryPublished)
-                    {
-                        if (SingleValueSensorsPresent())
-                        {
-                            foreach (var sensor in Variables.SingleValueSensors.TakeWhile(_ => !_pause).TakeWhile(_ => _active))
-                            {
-                                if (_pause || Variables.MqttManager.GetStatus() != MqttStatus.Connected) continue;
-                                await sensor.PublishAutoDiscoveryConfigAsync();
-                            }
-                        }
-
-                        if (MultiValueSensorsPresent())
-                        {
-                            foreach (var sensor in Variables.MultiValueSensors.TakeWhile(_ => !_pause).TakeWhile(_ => _active))
-                            {
-                                if (_pause || Variables.MqttManager.GetStatus() != MqttStatus.Connected) continue;
-                                await sensor.PublishAutoDiscoveryConfigAsync();
-                            }
-                        }
-
-                        _discoveryPublished = true;
-                    }
-
-                    // publish availability every 30 sec
+                    // publish availability & autodiscovery every 30 sec
                     if ((DateTime.Now - _lastAutoDiscoPublish).TotalSeconds > 30)
                     {
-                        // let hass know we're still here
                         await Variables.MqttManager.AnnounceAvailabilityAsync();
 
-                        // log moment
+                        if (!_discoveryPublished)
+                        {
+                            if (SingleValueSensorsPresent())
+                            {
+                                foreach (var sensor in Variables.SingleValueSensors.TakeWhile(_ => !_pause).TakeWhile(_ => _active))
+                                {
+                                    if (_pause || Variables.MqttManager.GetStatus() != MqttStatus.Connected) continue;
+                                    await sensor.PublishAutoDiscoveryConfigAsync();
+                                }
+                            }
+
+                            if (MultiValueSensorsPresent())
+                            {
+                                foreach (var sensor in Variables.MultiValueSensors.TakeWhile(_ => !_pause).TakeWhile(_ => _active))
+                                {
+                                    if (_pause || Variables.MqttManager.GetStatus() != MqttStatus.Connected) continue;
+                                    await sensor.PublishAutoDiscoveryConfigAsync();
+                                }
+                            }
+
+                            _discoveryPublished = true;
+                        }
+
                         _lastAutoDiscoPublish = DateTime.Now;
                     }
 


### PR DESCRIPTION
This PR changes the MQTT behaviour to limit the times where MQTT discovery payload for entities is sent to the broker.
Huge thanks for @Anto79-ops for reporting this on Discord :)

After the changes the discovery messages are sent:
- after HASS.Agent starts
- after configuration change