### PR TITLE
Fix: microphone process sensor description

### DIFF
--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.Designer.cs
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.Designer.cs
@@ -6034,7 +6034,7 @@ namespace HASS.Agent.Resources.Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Provides the name of the process that&apos;s currently using the microphone.
+        ///   Looks up a localized string similar to Provides the number of the processes that currently use the microphone - additionally provides name of the processes in the sensor&apos;s attributes.
         ///
         ///Note: if used in the satellite service, it won&apos;t detect userspace applications..
         /// </summary>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.de.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.de.resx
@@ -3253,11 +3253,6 @@ Stelle sicher, dass die Ortungsdienste von Windows aktiviert sind!
 
 Je nach Windows-Version finden Sie diese in der neuen Systemsteuerung -&gt; „Datenschutz und Sicherheit“ -&gt; „Standort“.</value>
   </data>
-  <data name="SensorsManager_MicrophoneProcessSensorDescription" xml:space="preserve">
-    <value>Stellt den Namen des Prozesses bereit, der das Mikrofon derzeit verwendet.
-
-Hinweis: Bei Verwendung im Satellitenservice werden keine Userspace-Anwendungen erkannt.</value>
-  </data>
   <data name="SensorsManager_MonitorPowerStateSensorDescription" xml:space="preserve">
     <value>Zeigt die letzte Änderung des Monitor-Energiezustands:
 
@@ -3493,5 +3488,10 @@ Als Payload benötigen Sie den Namen des Audiogeräts.</value>
   </data>
   <data name="ConfigTrayIcon_CbUseModernIcon" xml:space="preserve">
     <value>Verwenden Sie ein modernes Taskleistensymbol</value>
+  </data>
+  <data name="SensorsManager_MicrophoneProcessSensorDescription" xml:space="preserve">
+    <value>Gibt die Anzahl der Prozesse an, die derzeit das Mikrofon verwenden. Zusätzlich werden die Namen der Prozesse in den Attributen des Sensors angegeben.
+
+Hinweis: Bei Verwendung im Satellitendienst werden keine Userspace-Anwendungen erkannt.</value>
   </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.en.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.en.resx
@@ -3131,11 +3131,6 @@ Make sure Windows' location services are enabled!
 
 Depending on your Windows version, this can be found in the new control panel -&gt; 'privacy and security' -&gt; 'location'.</value>
   </data>
-  <data name="SensorsManager_MicrophoneProcessSensorDescription" xml:space="preserve">
-	  <value>Provides the name of the process that's currently using the microphone.
-
-Note: if used in the satellite service, it won't detect userspace applications.</value>
-  </data>
   <data name="SensorsManager_MonitorPowerStateSensorDescription" xml:space="preserve">
 	  <value>Provides the last monitor power state change:
 
@@ -3370,5 +3365,10 @@ Requires audio device name as a payload.</value>
   </data>
   <data name="ConfigTrayIcon_CbUseModernIcon" xml:space="preserve">
     <value>Use modern tray icon</value>
+  </data>
+  <data name="SensorsManager_MicrophoneProcessSensorDescription" xml:space="preserve">
+    <value>Provides the number of the processes that currently use the microphone - additionally provides name of the processes in the sensor's attributes.
+
+Note: if used in the satellite service, it won't detect userspace applications.</value>
   </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.es.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.es.resx
@@ -3130,11 +3130,6 @@ Asegúrese de que los servicios de localización de Windows están activados.
 
 Dependiendo de su versión de Windows, esto se puede encontrar en el nuevo panel de control -&gt; 'privacidad y seguridad' -&gt; 'ubicación'.</value>
   </data>
-  <data name="SensorsManager_MicrophoneProcessSensorDescription" xml:space="preserve">
-    <value>Proporciona el nombre del proceso que está usando actualmente el micrófono.
-
-Nota: si se usa en el servicio de satélite, no detectará las aplicaciones del espacio de usuario.</value>
-  </data>
   <data name="SensorsManager_MonitorPowerStateSensorDescription" xml:space="preserve">
     <value>Proporciona el último cambio de estado de energía del monitor:
 
@@ -3369,5 +3364,10 @@ Necesita el nombre del dispositivo de audio como carga útil.</value>
   </data>
   <data name="ConfigTrayIcon_CbUseModernIcon" xml:space="preserve">
     <value>Utilice el icono de bandeja moderno</value>
+  </data>
+  <data name="SensorsManager_MicrophoneProcessSensorDescription" xml:space="preserve">
+    <value>Proporciona el número de procesos que utilizan actualmente el micrófono; además, proporciona el nombre de los procesos en los atributos del sensor.
+
+Nota: si se usa en el servicio satelital, no detectará aplicaciones del espacio de usuario.</value>
   </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.fr.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.fr.resx
@@ -3163,11 +3163,6 @@ Assurez-vous que les services de localisation de Windows sont activés !
 
 Selon votre version de Windows, cela peut être trouvé dans le nouveau panneau de configuration -&gt; 'confidentialité et sécurité' -&gt; 'emplacement'.</value>
   </data>
-  <data name="SensorsManager_MicrophoneProcessSensorDescription" xml:space="preserve">
-    <value>Provides the name of the process that's currently using the microphone.
-
-Note: if used in the satellite service, it won't detect userspace applications.</value>
-  </data>
   <data name="SensorsManager_MonitorPowerStateSensorDescription" xml:space="preserve">
     <value>Provides the last monitor power state change:
 
@@ -3402,5 +3397,10 @@ Vous avez besoin du nom du périphérique audio comme charge utile.</value>
   </data>
   <data name="ConfigTrayIcon_CbUseModernIcon" xml:space="preserve">
     <value>Utiliser l'icône de la barre d'état moderne</value>
+  </data>
+  <data name="SensorsManager_MicrophoneProcessSensorDescription" xml:space="preserve">
+    <value>Fournit le nombre de processus qui utilisent actuellement le microphone - fournit en outre le nom des processus dans les attributs du capteur.
+
+Remarque : s'il est utilisé dans le service satellite, il ne détectera pas les applications de l'espace utilisateur.</value>
   </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.nl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.nl.resx
@@ -3152,11 +3152,6 @@ Verzeker dat Windows' localisatieservices ingeschakeld zijn!
 
 Afhankelijk van je Windows versie, kan dit gevonden worden in het nieuwe configuratiescherm -&gt; 'privacy en beveiliging' -&gt; 'locatie'.</value>
   </data>
-  <data name="SensorsManager_MicrophoneProcessSensorDescription" xml:space="preserve">
-    <value>Geeft de naam van het proces dat momenteel de microfoon gebruikt.
-
-Notitie: als hij in de satellietservice gebruikt wordt, zal hij geen gebruikerapplicaties detecteren.</value>
-  </data>
   <data name="SensorsManager_MonitorPowerStateSensorDescription" xml:space="preserve">
     <value>Geeft de laatste beeldscherm energiemodus status verandering:
 
@@ -3390,5 +3385,10 @@ U hebt de naam van het audioapparaat nodig als payload.</value>
   </data>
   <data name="ConfigTrayIcon_CbUseModernIcon" xml:space="preserve">
     <value>Gebruik het moderne ladepictogram</value>
+  </data>
+  <data name="SensorsManager_MicrophoneProcessSensorDescription" xml:space="preserve">
+    <value>Geeft het aantal processen weer die momenteel de microfoon gebruiken - geeft bovendien de naam van de processen in de attributen van de sensor.
+
+Opmerking: indien gebruikt in de satellietdienst, zal het geen gebruikersruimtetoepassingen detecteren.</value>
   </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pl.resx
@@ -3240,11 +3240,6 @@ Upewnij się że lokalizacja jest włączona w systemie Windows!
 
 W zalezności od Twojej wersji Windows'a opcje te możesz znaleźć w Ustawienia -&gt; Prywatność i Zabezpieczenia -&gt; Lokalizacja</value>
   </data>
-  <data name="SensorsManager_MicrophoneProcessSensorDescription" xml:space="preserve">
-    <value>Zwraca nazwę procesu który obecnie używa mikrofonu. 
-
-Wskazówka: jeżeli korzystasz z usługi Satellite, nie będziesz miał informacji o aplikacji w przestrzeni użytkownika.</value>
-  </data>
   <data name="SensorsManager_MonitorPowerStateSensorDescription" xml:space="preserve">
     <value>Zwraca ostatnią zmianę stanu ekranu: 
 
@@ -3479,5 +3474,10 @@ Wymaga nazwy urządzenia audio jako ładunku.</value>
   </data>
   <data name="ConfigTrayIcon_CbUseModernIcon" xml:space="preserve">
     <value>Użyj nowoczesnej ikony w zasobniku</value>
+  </data>
+  <data name="SensorsManager_MicrophoneProcessSensorDescription" xml:space="preserve">
+    <value>Podaje liczbę procesów aktualnie korzystających z mikrofonu - dodatkowo podaje nazwę procesów w atrybutach czujnika.
+
+Uwaga: jeśli jest używany w usłudze satelitarnej, nie wykryje aplikacji przestrzeni użytkownika.</value>
   </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pt-br.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pt-br.resx
@@ -2250,11 +2250,6 @@ HassAgentStarted, Logoff, SystemShutdown, Resume, Suspend, ConsoleConnect, Conso
     <value>Fornece um valor bool com base em se o microfone está sendo usado no momento.</value>
     <comment>Fuzzy</comment>
   </data>
-  <data name="SensorsManager_MicrophoneProcessSensorDescription" xml:space="preserve">
-    <value>Fornece o nome do processo que está usando o microfone no momento.
-
-Observação: se usado no serviço satélite, ele não detectará aplicativos de espaço de usuário.</value>
-  </data>
   <data name="SensorsManager_MonitorPowerStateSensorDescription" xml:space="preserve">
     <value>Fornece a última alteração do estado de energia do monitor:
 
@@ -3415,5 +3410,10 @@ Você precisa do nome do dispositivo de áudio como carga útil.</value>
   </data>
   <data name="ConfigTrayIcon_CbUseModernIcon" xml:space="preserve">
     <value>Use o ícone moderno da bandeja</value>
+  </data>
+  <data name="SensorsManager_MicrophoneProcessSensorDescription" xml:space="preserve">
+    <value>Fornece o número de processos que utilizam atualmente o microfone - fornece adicionalmente o nome dos processos nos atributos do sensor.
+
+Nota: se usado no serviço de satélite, não detectará aplicações no espaço do usuário.</value>
   </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.resx
@@ -2951,7 +2951,7 @@ Hidden, Maximized, Minimized, Normal and Unknown.</value>
 Note: if used in the satellite service, it won't detect userspace applications.</value>
   </data>
   <data name="SensorsManager_MicrophoneProcessSensorDescription" xml:space="preserve">
-    <value>Provides the name of the process that's currently using the microphone.
+    <value>Provides the number of the processes that currently use the microphone - additionally provides name of the processes in the sensor's attributes.
 
 Note: if used in the satellite service, it won't detect userspace applications.</value>
   </data>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.ru.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.ru.resx
@@ -3198,11 +3198,6 @@ Home Assistant.
 
 В зависимости от вашей версии Windows, это можно найти в новой панели управления -&gt; 'конфиденциальность и безопасность' -&gt; 'местоположение'.</value>
   </data>
-  <data name="SensorsManager_MicrophoneProcessSensorDescription" xml:space="preserve">
-    <value>Указывает имя процесса, который в данный момент использует микрофон.
-
-Примечание: если он используется в спутниковой службе, он не будет обнаруживать приложения пользовательского пространства.</value>
-  </data>
   <data name="SensorsManager_MonitorPowerStateSensorDescription" xml:space="preserve">
     <value>Обеспечивает последнее изменение состояния питания монитора:
 
@@ -3438,5 +3433,10 @@ Home Assistant.
   </data>
   <data name="ConfigTrayIcon_CbUseModernIcon" xml:space="preserve">
     <value>Использовать современный значок в трее</value>
+  </data>
+  <data name="SensorsManager_MicrophoneProcessSensorDescription" xml:space="preserve">
+    <value>Предоставляет количество процессов, которые в данный момент используют микрофон. Дополнительно указывается имя процесса в атрибутах датчика.
+
+Примечание. При использовании в спутниковой службе он не обнаружит приложения пользовательского пространства.</value>
   </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.sl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.sl.resx
@@ -2328,11 +2328,6 @@ HassAgentStarted, Odjava, SystemShutdown, Resume, Suspend, ConsoleConnect, Conso
     <value>Zagotavlja bool vrednost glede na to, ali se mikrofon trenutno uporablja.</value>
     <comment>Fuzzy</comment>
   </data>
-  <data name="SensorsManager_MicrophoneProcessSensorDescription" xml:space="preserve">
-    <value>Vrne ime procesa, ki trenutno uporablja mikrofon.
-
-Opomba: če se uporablja v satelitski storitvi</value>
-  </data>
   <data name="SensorsManager_MonitorPowerStateSensorDescription" xml:space="preserve">
     <value>Vrne zadnjo spremembo načina monitorja:
 
@@ -3518,5 +3513,10 @@ Ime zvočne naprave potrebujete kot obremenitev.</value>
   </data>
   <data name="ConfigTrayIcon_CbUseModernIcon" xml:space="preserve">
     <value>Uporabi sodobno ikono pladnja</value>
+  </data>
+  <data name="SensorsManager_MicrophoneProcessSensorDescription" xml:space="preserve">
+    <value>Zagotavlja število procesov, ki trenutno uporabljajo mikrofon - dodatno podaja ime procesov v atributih senzorja.
+
+Opomba: če se uporablja v satelitski storitvi, ne bo zaznal aplikacij uporabniškega prostora.</value>
   </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.tr.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.tr.resx
@@ -2764,9 +2764,6 @@ Daha fazla tuşa ve/veya CTRL gibi değiştiricilere ihtiyacınız varsa, Multip
   <data name="SensorsManager_GeoLocationSensorDescription" xml:space="preserve">
     <value>Geçerli enlem, boylam ve yüksekliğinizi virgülle ayrılmış bir değer olarak döndürür. Windows'un konum hizmetlerinin etkinleştirildiğinden emin olun! Windows sürümünüze bağlı olarak bu, yeni kontrol panelinde -&gt; 'gizlilik ve güvenlik' -&gt; 'konum'da bulunabilir.</value>
   </data>
-  <data name="SensorsManager_MicrophoneProcessSensorDescription" xml:space="preserve">
-    <value>Şu anda mikrofonu kullanan işlemin adını sağlar. Not: uydu hizmetinde kullanılırsa, kullanıcı alanı uygulamalarını algılamaz.</value>
-  </data>
   <data name="SensorsManager_MonitorPowerStateSensorDescription" xml:space="preserve">
     <value>Son monitör güç durumu değişikliğini sağlar: Soluk, Güç Kapalı, Güç Açık ve Bilinmiyor.</value>
   </data>
@@ -2981,5 +2978,10 @@ Yük olarak ses cihazı adına ihtiyacınız vardır.</value>
   </data>
   <data name="ConfigTrayIcon_CbUseModernIcon" xml:space="preserve">
     <value>Modern tepsi simgesini kullan</value>
+  </data>
+  <data name="SensorsManager_MicrophoneProcessSensorDescription" xml:space="preserve">
+    <value>Halihazırda mikrofonu kullanan işlemlerin sayısını sağlar; ayrıca sensörün özniteliklerinde süreçlerin adını da sağlar.
+
+Not: Uydu hizmetinde kullanılırsa kullanıcı alanı uygulamalarını algılamaz.</value>
   </data>
 </root>


### PR DESCRIPTION
This PR changes the microphone process sensor description to better reflect its functionality (https://github.com/hass-agent/HASS.Agent/issues/49):
```
Provides the number of the processes that currently use the microphone - additionally provides name of the processes in the sensor's attributes.

Note: if used in the satellite service, it won't detect userspace applications.
```
