### PR TITLE
Fix: PowerShell sensor character limit note

### DIFF
--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.Designer.cs
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.Designer.cs
@@ -6094,6 +6094,7 @@ namespace HASS.Agent.Resources.Localization {
         
         /// <summary>
         ///   Looks up a localized string similar to Returns the result of the provided Powershell command or script.
+        ///Note: please keep in mind that Home Assistant accepts payload up to 255 characters.
         ///
         ///Converts the outcome to text..
         /// </summary>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.de.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.de.resx
@@ -3260,6 +3260,7 @@ Gedimmt, PowerOff, PowerOn und Unbekannt.</value>
   </data>
   <data name="SensorsManager_PowershellSensorDescription" xml:space="preserve">
     <value>Gibt das Ergebnis des bereitgestellten Powershell-Befehls oder -Skripts zurück.
+Hinweis: Bitte beachten Sie, dass Home Assistant Nutzdaten von bis zu 255 Zeichen akzeptiert.
 
 Konvertiert das Ergebnis in Text.</value>
   </data>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.en.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.en.resx
@@ -3138,6 +3138,7 @@ Dimmed, PowerOff, PowerOn and Unkown.</value>
   </data>
   <data name="SensorsManager_PowershellSensorDescription" xml:space="preserve">
 	  <value>Returns the result of the provided Powershell command or script.
+Note: please keep in mind that Home Assistant accepts payload up to 255 characters.
 
 Converts the outcome to text.</value>
   </data>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.es.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.es.resx
@@ -3137,6 +3137,7 @@ Atenuado, Apagado, Encendido y Desconocido.</value>
   </data>
   <data name="SensorsManager_PowershellSensorDescription" xml:space="preserve">
     <value>Devuelve el resultado del comando o script de Powershell proporcionado.
+Nota: tenga en cuenta que Home Assistant acepta una carga útil de hasta 255 caracteres.
 
 Convierte el resultado en texto.</value>
   </data>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.fr.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.fr.resx
@@ -3169,9 +3169,10 @@ Selon votre version de Windows, cela peut être trouvé dans le nouveau panneau 
 Dimmed, PowerOff, PowerOn and Unkown.</value>
   </data>
   <data name="SensorsManager_PowershellSensorDescription" xml:space="preserve">
-    <value>Returns the result of the provided Powershell command or script.
+    <value>Renvoie le résultat de la commande ou du script Powershell fourni.
+Remarque : veuillez garder à l'esprit que Home Assistant accepte des charges utiles allant jusqu'à 255 caractères.
 
-Converts the outcome to text.</value>
+Convertit le résultat en texte.</value>
   </data>
   <data name="SensorsManager_PrintersSensorsDescription" xml:space="preserve">
     <value>Fournit des informations sur toutes les imprimantes installées et leurs files d'attente.</value>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.nl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.nl.resx
@@ -3158,9 +3158,10 @@ Afhankelijk van je Windows versie, kan dit gevonden worden in het nieuwe configu
 Gedimmed, Uitgeschakeld, Ingeschakeld en Onbekend</value>
   </data>
   <data name="SensorsManager_PowershellSensorDescription" xml:space="preserve">
-    <value>Geeft het resultaat van het opgegeven Powershell commando of script.
+    <value>Retourneert het resultaat van de opgegeven Powershell-opdracht of -script.
+Opmerking: houd er rekening mee dat Home Assistant een payload van maximaal 255 tekens accepteert.
 
-Converteert de uitkomst naar text.</value>
+Converteert de uitkomst naar tekst.</value>
   </data>
   <data name="SensorsManager_PrintersSensorsDescription" xml:space="preserve">
     <value>Geeft informatie over alle geïnstalleerde printers en hun wachtrijen.</value>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pl.resx
@@ -3246,9 +3246,10 @@ W zalezności od Twojej wersji Windows'a opcje te możesz znaleźć w Ustawienia
 Przyciemnienie, Wyłączenie, Włączenie, Nieznany</value>
   </data>
   <data name="SensorsManager_PowershellSensorDescription" xml:space="preserve">
-    <value>Zwraca wynik poprzedniej komendy Powershell lub skryptu.
+    <value>Zwraca wynik podanego polecenia lub skryptu programu PowerShell.
+Uwaga: pamiętaj, że Home Assistant akceptuje ładunek o długości do 255 znaków.
 
-Konwertuje wynik do tekstu.</value>
+Konwertuje wynik na tekst.</value>
   </data>
   <data name="SensorsManager_PrintersSensorsDescription" xml:space="preserve">
     <value>Zwraca informacje na temat wszystkich zainstalowanych drukarek i ich kolejek.</value>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pt-br.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pt-br.resx
@@ -2276,6 +2276,7 @@ Você pode explorar os contadores através da ferramenta 'perfmon.exe' do Window
   </data>
   <data name="SensorsManager_PowershellSensorDescription" xml:space="preserve">
     <value>Retorna o resultado do comando ou script do Powershell fornecido.
+Observação: lembre-se de que o Home Assistant aceita carga útil de até 255 caracteres.
 
 Converte o resultado em texto.</value>
   </data>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.resx
@@ -2925,6 +2925,7 @@ Dimmed, PowerOff, PowerOn and Unkown.</value>
   </data>
   <data name="SensorsManager_PowershellSensorDescription" xml:space="preserve">
     <value>Returns the result of the provided Powershell command or script.
+Note: please keep in mind that Home Assistant accepts payload up to 255 characters.
 
 Converts the outcome to text.</value>
   </data>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.ru.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.ru.resx
@@ -3204,7 +3204,8 @@ Home Assistant.
 Затемненный, Выключенный, Включенный и Неизвестный.</value>
   </data>
   <data name="SensorsManager_PowershellSensorDescription" xml:space="preserve">
-    <value>Возвращает результат предоставленной команды Powershell или сценария.
+    <value>Возвращает результат предоставленной команды или сценария Powershell.
+Примечание. Имейте в виду, что Home Assistant принимает полезную нагрузку длиной до 255 символов.
 
 Преобразует результат в текст.</value>
   </data>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.sl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.sl.resx
@@ -2353,9 +2353,10 @@ Primer: _Skupaj
 Številke lahko raziščete z orodjem Windows 'perfmon.exe'.</value>
   </data>
   <data name="SensorsManager_PowershellSensorDescription" xml:space="preserve">
-    <value>Vrne rezultat Powershell ukaza ali skripta.
+    <value>Vrne rezultat podanega ukaza ali skripta Powershell.
+Opomba: ne pozabite, da Home Assistant sprejme vsebino do 255 znakov.
 
-Pretvori rezultat v tekst.</value>
+Pretvori rezultat v besedilo.</value>
   </data>
   <data name="SensorsManager_PrintersSensorsDescription" xml:space="preserve">
     <value>Vrne informacijo o nameščenih tiskalnikih in čakalni vrsti za njih.</value>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.tr.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.tr.resx
@@ -2768,7 +2768,10 @@ Daha fazla tuşa ve/veya CTRL gibi değiştiricilere ihtiyacınız varsa, Multip
     <value>Son monitör güç durumu değişikliğini sağlar: Soluk, Güç Kapalı, Güç Açık ve Bilinmiyor.</value>
   </data>
   <data name="SensorsManager_PowershellSensorDescription" xml:space="preserve">
-    <value>Sağlanan Powershell komutunun veya komut dosyasının sonucunu döndürür. Sonucu metne dönüştürür.</value>
+    <value>Sağlanan Powershell komutunun veya betiğinin sonucunu döndürür.
+Not: Home Assistant'ın 255 karaktere kadar yükü kabul ettiğini lütfen unutmayın.
+
+Sonucu metne dönüştürür.</value>
   </data>
   <data name="SensorsManager_PrintersSensorsDescription" xml:space="preserve">
     <value>Yüklü tüm yazıcılar ve sıraları hakkında bilgi sağlar.</value>


### PR DESCRIPTION
This PR adds additional note reminding users about maximum payload length that Home Assistant supports.
```
Returns the result of the provided Powershell command or script.
Note: please keep in mind that Home Assistant accepts payload up to 255 characters.

Converts the outcome to text.
```