### PR TITLE
Fix: close all subwindows when main one is closed

### DIFF
--- a/src/HASS.Agent/HASS.Agent/Forms/Main.cs
+++ b/src/HASS.Agent/HASS.Agent/Forms/Main.cs
@@ -344,7 +344,19 @@ namespace HASS.Agent.Forms
             if (_isClosing)
                 return;
 
-            Invoke(new MethodInvoker(Hide));
+            Invoke(() =>
+            {
+                HelperFunctions.GetForm("QuickActions")?.Close();
+                HelperFunctions.GetForm("Configuration")?.Close();
+                HelperFunctions.GetForm("QuickActionsConfig")?.Close();
+                HelperFunctions.GetForm("SensorsConfig")?.Close();
+                HelperFunctions.GetForm("ServiceConfig")?.Close();
+                HelperFunctions.GetForm("CommandsConfig")?.Close();
+                HelperFunctions.GetForm("Help")?.Close();
+                HelperFunctions.GetForm("Donate")?.Close();
+
+                new MethodInvoker(Hide).Invoke();
+            });
 
             if (!Variables.ShuttingDown)
             {


### PR DESCRIPTION
This simple PR fixes the issue where configuration subwindows would stay open (in some cases in broken state) after the main windows was closed by the user.
Thanks to @KohGeek for reporting :)