### PR TITLE
Fix: device rename MQTT messages cleanup

### DIFF
--- a/src/HASS.Agent/HASS.Agent/MQTT/MqttManager.cs
+++ b/src/HASS.Agent/HASS.Agent/MQTT/MqttManager.cs
@@ -562,11 +562,38 @@ namespace HASS.Agent.MQTT
                 {
                     if (string.IsNullOrEmpty(Variables.AppSettings.MqttDiscoveryPrefix))
                         Variables.AppSettings.MqttDiscoveryPrefix = "homeassistant";
-
                     var messageBuilder = new MqttApplicationMessageBuilder()
                         .WithTopic($"{Variables.AppSettings.MqttDiscoveryPrefix}/sensor/{Variables.DeviceConfig.Name}/availability")
                         .WithPayload(Array.Empty<byte>())
-                        .WithRetainFlag(Variables.AppSettings.MqttUseRetainFlag);
+                        .WithRetainFlag(false);
+
+                    await _mqttClient.InternalClient.PublishAsync(messageBuilder.Build());
+
+                    messageBuilder = new MqttApplicationMessageBuilder()
+                        .WithTopic($"hass.agent/devices/{Variables.DeviceConfig.Name}")
+                        .WithPayload(Array.Empty<byte>())
+                        .WithRetainFlag(false);
+
+                    await _mqttClient.InternalClient.PublishAsync(messageBuilder.Build());
+
+                    messageBuilder = new MqttApplicationMessageBuilder()
+                        .WithTopic($"hass.agent/media_player/{Variables.DeviceConfig.Name}")
+                        .WithPayload(Array.Empty<byte>())
+                        .WithRetainFlag(false);
+
+                    await _mqttClient.InternalClient.PublishAsync(messageBuilder.Build());
+
+                    messageBuilder = new MqttApplicationMessageBuilder()
+                        .WithTopic($"hass.agent/media_player/{Variables.DeviceConfig.Name}/thumbnail")
+                        .WithPayload(Array.Empty<byte>())
+                        .WithRetainFlag(false);
+
+                    await _mqttClient.InternalClient.PublishAsync(messageBuilder.Build());
+
+                    messageBuilder = new MqttApplicationMessageBuilder()
+                        .WithTopic($"hass.agent/media_player/{Variables.DeviceConfig.Name}/state")
+                        .WithPayload(Array.Empty<byte>())
+                        .WithRetainFlag(false);
 
                     await _mqttClient.InternalClient.PublishAsync(messageBuilder.Build());
                 }


### PR DESCRIPTION
This PR adds additional cleanup for device and media player MQTT discovery messages than can cause HASS.Agent not to be rediscovered after changing device name - https://github.com/hass-agent/HASS.Agent/issues/68

Current proper way to rename HASS.Agent device:
- rename device in HASS.Agent
- remove device from HA integration
- restart HA

After doing so, "new device name" should be discovered by HA.

Without this fix, discovery configuration message with previous name wouldn't be removed which could cause the "new device name" not to be discovered at all, even after removing old one.

Thanks for @Mystically11 for reporting this!