### PR TITLE
Fix: added additional check for mixed german keyboard layouts

### DIFF
--- a/src/HASS.Agent/HASS.Agent/Functions/HelperFunctions.cs
+++ b/src/HASS.Agent/HASS.Agent/Functions/HelperFunctions.cs
@@ -546,13 +546,24 @@ namespace HASS.Agent.Functions
             var inputLanguage = InputLanguage.CurrentInputLanguage.Handle;
 
             // check for known OK languages
-            if (KnownOkInputLanguage.ContainsKey(inputLanguage)) return false;
-
+            if (KnownOkInputLanguage.ContainsKey(inputLanguage))
+                return false;
+            
             // check for known NOT OK languages
-            if (KnownNotOkInputLanguage.ContainsKey(inputLanguage))
+            var germanLayoutDetected = false;
+            foreach(InputLanguage language in InputLanguage.InstalledInputLanguages)
+            {
+                if(language.Culture.TwoLetterISOLanguageName == "de")
+                {
+                    germanLayoutDetected = true;
+                    break;
+                }
+            }
+
+            if (KnownNotOkInputLanguage.ContainsKey(inputLanguage) || germanLayoutDetected)
             {
                 // get human-readable name
-                var langName = KnownNotOkInputLanguage[inputLanguage];
+                var langName = germanLayoutDetected ? "German" : KnownNotOkInputLanguage[inputLanguage];
 
                 message = string.Format(Languages.HelperFunctions_InputLanguageCheckDiffers_ErrorMsg1, langName);
                 return true;


### PR DESCRIPTION
This PR adds additional check for the german input language being installed on system.
Should remediate cases where mixed language systems (English UI with German keyboard layout) do not present the notification regarding HotKey collision - https://github.com/hass-agent/HASS.Agent/issues/62