### PR TITLE
Fix: sensor state_class/device_class

### DIFF
--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/AudioSensors.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/AudioSensors.cs
@@ -76,7 +76,7 @@ public class AudioSensors : AbstractMultiValueSensor
         var masterVolume = Convert.ToInt32(Math.Round(audioDevice.AudioEndpointVolume?.MasterVolumeLevelScalar * 100 ?? 0, 0));
         var defaultDeviceVolumeEntityName = $"{parentSensorSafeName}_default_device_volume";
         var defaultDeviceVolumeId = $"{Id}_default_device_volume";
-        var defaultDeviceVolumeSensor = new DataTypeIntSensor(_updateInterval, defaultDeviceVolumeEntityName, $"Default Device Volume", defaultDeviceVolumeId, string.Empty, "mdi:speaker", string.Empty, EntityName);
+        var defaultDeviceVolumeSensor = new DataTypeIntSensor(_updateInterval, defaultDeviceVolumeEntityName, $"Default Device Volume", defaultDeviceVolumeId, string.Empty, "measurement", "mdi:speaker", string.Empty, EntityName);
         defaultDeviceVolumeSensor.SetState(masterVolume);
         AddUpdateSensor(defaultDeviceVolumeId, defaultDeviceVolumeSensor);
 
@@ -98,7 +98,7 @@ public class AudioSensors : AbstractMultiValueSensor
 
         var sessionsEntityName = $"{parentSensorSafeName}_sessions";
         var sessionsId = $"{Id}_sessions";
-        var sessionsSensor = new DataTypeIntSensor(_updateInterval, sessionsEntityName, $"Audio Sessions", sessionsId, string.Empty, "mdi:music-box-multiple-outline", string.Empty, EntityName, true);
+        var sessionsSensor = new DataTypeIntSensor(_updateInterval, sessionsEntityName, $"Audio Sessions", sessionsId, string.Empty, "measurement", "mdi:music-box-multiple-outline", string.Empty, EntityName, true);
         sessionsSensor.SetState(sessionInfos.Count);
         sessionsSensor.SetAttributes(
             JsonConvert.SerializeObject(new
@@ -111,7 +111,7 @@ public class AudioSensors : AbstractMultiValueSensor
         var audioOutputDevices = GetAudioOutputDevices();
         var audioOutputDevicesEntityName = $"{parentSensorSafeName}_output_devices";
         var audioOutputDevicesId = $"{Id}_output_devices";
-        var audioOutputDevicesSensor = new DataTypeIntSensor(_updateInterval, audioOutputDevicesEntityName, $"Audio Output Devices", audioOutputDevicesId, string.Empty, "mdi:music-box-multiple-outline", string.Empty, EntityName, true);
+        var audioOutputDevicesSensor = new DataTypeIntSensor(_updateInterval, audioOutputDevicesEntityName, $"Audio Output Devices", audioOutputDevicesId, string.Empty, "measurement", "mdi:music-box-multiple-outline", string.Empty, EntityName, true);
         audioOutputDevicesSensor.SetState(audioOutputDevices.Count);
         audioOutputDevicesSensor.SetAttributes(
             JsonConvert.SerializeObject(new
@@ -148,14 +148,14 @@ public class AudioSensors : AbstractMultiValueSensor
         var inputVolume = (int)GetDefaultInputDevicePeakVolume(inputDevice);
         var defaultInputDeviceVolumeEntityName = $"{parentSensorSafeName}_default_input_device_volume";
         var defaultInputDeviceVolumeId = $"{Id}_default_input_device_volume";
-        var defaultInputDeviceVolumeSensor = new DataTypeIntSensor(_updateInterval, defaultInputDeviceVolumeEntityName, $"Default Input Device Volume", defaultInputDeviceVolumeId, string.Empty, "mdi:microphone", string.Empty, EntityName);
+        var defaultInputDeviceVolumeSensor = new DataTypeIntSensor(_updateInterval, defaultInputDeviceVolumeEntityName, $"Default Input Device Volume", defaultInputDeviceVolumeId, string.Empty, "measurement", "mdi:microphone", string.Empty, EntityName);
         defaultInputDeviceVolumeSensor.SetState(inputVolume);
         AddUpdateSensor(defaultInputDeviceVolumeId, defaultInputDeviceVolumeSensor);
 
         var audioInputDevices = GetAudioInputDevices();
         var audioInputDevicesEntityName = $"{parentSensorSafeName}_input_devices";
         var audioInputDevicesId = $"{Id}_input_devices";
-        var audioInputDevicesSensor = new DataTypeIntSensor(_updateInterval, audioInputDevicesEntityName, $"Audio Input Devices", audioInputDevicesId, string.Empty, "mdi:microphone", string.Empty, EntityName, true);
+        var audioInputDevicesSensor = new DataTypeIntSensor(_updateInterval, audioInputDevicesEntityName, $"Audio Input Devices", audioInputDevicesId, string.Empty, "measurement", "mdi:microphone", string.Empty, EntityName, true);
         audioInputDevicesSensor.SetState(audioInputDevices.Count);
         audioInputDevicesSensor.SetAttributes(
             JsonConvert.SerializeObject(new

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/BatterySensors.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/BatterySensors.cs
@@ -52,14 +52,14 @@ public class BatterySensors : AbstractMultiValueSensor
 
         var fullChargeLifetimeEntityName = $"{parentSensorSafeName}_full_charge_lifetime";
         var fullChargeLifetimeId = $"{Id}_full_charge_lifetime";
-        var fullChargeLifetimeSensor = new DataTypeIntSensor(_updateInterval, fullChargeLifetimeEntityName, "Full Charge Lifetime", fullChargeLifetimeId, string.Empty, "mdi:battery-high", string.Empty, EntityName);
+        var fullChargeLifetimeSensor = new DataTypeIntSensor(_updateInterval, fullChargeLifetimeEntityName, "Full Charge Lifetime", fullChargeLifetimeId, string.Empty, "measurement", "mdi:battery-high", string.Empty, EntityName);
         fullChargeLifetimeSensor.SetState(fullChargeLifetimeMinutes);
         AddUpdateSensor(fullChargeLifetimeId, fullChargeLifetimeSensor);
 
         var chargeRemainingPercentage = Convert.ToInt32(powerStatus.BatteryLifePercent * 100);
         var chargeRemainingPercentageEntityName = $"{parentSensorSafeName}_charge_remaining_percentage";
         var chargeRemainingPercentageId = $"{Id}_charge_remaining_percentage";
-        var chargeRemainingPercentageSensor = new DataTypeIntSensor(_updateInterval, chargeRemainingPercentageEntityName, "Charge Remaining Percentage", chargeRemainingPercentageId, string.Empty, "mdi:battery-high", "%", EntityName);
+        var chargeRemainingPercentageSensor = new DataTypeIntSensor(_updateInterval, chargeRemainingPercentageEntityName, "Charge Remaining Percentage", chargeRemainingPercentageId, string.Empty, "measurement", "mdi:battery-high", "%", EntityName);
         chargeRemainingPercentageSensor.SetState(chargeRemainingPercentage);
         AddUpdateSensor(chargeRemainingPercentageId, chargeRemainingPercentageSensor);
 
@@ -69,7 +69,7 @@ public class BatterySensors : AbstractMultiValueSensor
 
         var chargeRemainingMinutesEntityName = $"{parentSensorSafeName}_charge_remaining";
         var chargeRemainingMinutesId = $"{Id}_charge_remaining";
-        var chargeRemainingMinutesSensor = new DataTypeIntSensor(_updateInterval, chargeRemainingMinutesEntityName, "Charge Remaining", chargeRemainingMinutesId, string.Empty, "mdi:battery-high", string.Empty, EntityName);
+        var chargeRemainingMinutesSensor = new DataTypeIntSensor(_updateInterval, chargeRemainingMinutesEntityName, "Charge Remaining", chargeRemainingMinutesId, string.Empty, "measurement", "mdi:battery-high", string.Empty, EntityName);
         chargeRemainingMinutesSensor.SetState(chargeRemainingMinutes);
         AddUpdateSensor(chargeRemainingMinutesId, chargeRemainingMinutesSensor);
 

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/DataTypes/DataTypeDoubleSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/DataTypes/DataTypeDoubleSensor.cs
@@ -10,17 +10,19 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.Data
     public class DataTypeDoubleSensor : AbstractSingleValueSensor
     {
         private readonly string _deviceClass;
+        private readonly string _stateClass;
         private readonly string _unitOfMeasurement;
         private readonly string _icon;
 
         private double _value = 0d;
         private string _attributes = string.Empty;
 
-        public DataTypeDoubleSensor(int? updateInterval, string entityName, string name, string id, string deviceClass, string icon, string unitOfMeasurement, string multiValueSensorName, bool useAttributes = false) : base(entityName, name, updateInterval ?? 30, id, useAttributes)
+        public DataTypeDoubleSensor(int? updateInterval, string entityName, string name, string id, string deviceClass, string stateClass, string icon, string unitOfMeasurement, string multiValueSensorName, bool useAttributes = false) : base(entityName, name, updateInterval ?? 30, id, useAttributes)
         {
             TopicName = multiValueSensorName;
 
             _deviceClass = deviceClass;
+            _stateClass = stateClass;
             _unitOfMeasurement = unitOfMeasurement;
             _icon = icon;
 
@@ -60,9 +62,14 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.Data
 
             if (UseAttributes) model.Json_attributes_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{TopicName}/{ObjectId}/attributes";
 
-            if (!string.IsNullOrWhiteSpace(_deviceClass)) model.Device_class = _deviceClass;
-            if (!string.IsNullOrWhiteSpace(_unitOfMeasurement)) model.Unit_of_measurement = _unitOfMeasurement;
-            if (!string.IsNullOrWhiteSpace(_icon)) model.Icon = _icon;
+            if (!string.IsNullOrWhiteSpace(_deviceClass))
+                model.Device_class = _deviceClass;
+            if (!string.IsNullOrWhiteSpace(_stateClass))
+                model.State_class = _stateClass;
+            if (!string.IsNullOrWhiteSpace(_unitOfMeasurement))
+                model.Unit_of_measurement = _unitOfMeasurement;
+            if (!string.IsNullOrWhiteSpace(_icon))
+                model.Icon = _icon;
 
             return SetAutoDiscoveryConfigModel(model);
         }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/DataTypes/DataTypeIntSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/DataTypes/DataTypeIntSensor.cs
@@ -9,17 +9,19 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.Data
     public class DataTypeIntSensor : AbstractSingleValueSensor
     {
         private readonly string _deviceClass;
+        private readonly string _stateClass;
         private readonly string _unitOfMeasurement;
         private readonly string _icon;
 
         private int _value = 0;
         private string _attributes = string.Empty;
 
-        public DataTypeIntSensor(int? updateInterval, string entityName, string name, string id, string deviceClass, string icon, string unitOfMeasurement, string multiValueSensorName, bool useAttributes = false) : base(entityName, name, updateInterval ?? 30, id, useAttributes)
+        public DataTypeIntSensor(int? updateInterval, string entityName, string name, string id, string deviceClass, string stateClass, string icon, string unitOfMeasurement, string multiValueSensorName, bool useAttributes = false) : base(entityName, name, updateInterval ?? 30, id, useAttributes)
         {
             TopicName = multiValueSensorName;
 
             _deviceClass = deviceClass;
+            _stateClass = stateClass;
             _unitOfMeasurement = unitOfMeasurement;
             _icon = icon;
 
@@ -59,9 +61,14 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.Data
 
             if (UseAttributes) model.Json_attributes_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{TopicName}/{ObjectId}/attributes";
 
-            if (!string.IsNullOrWhiteSpace(_deviceClass)) model.Device_class = _deviceClass;
-            if (!string.IsNullOrWhiteSpace(_unitOfMeasurement)) model.Unit_of_measurement = _unitOfMeasurement;
-            if (!string.IsNullOrWhiteSpace(_icon)) model.Icon = _icon;
+            if (!string.IsNullOrWhiteSpace(_deviceClass))
+                model.Device_class = _deviceClass;
+            if (!string.IsNullOrWhiteSpace(_stateClass))
+                model.State_class = _stateClass;
+            if (!string.IsNullOrWhiteSpace(_unitOfMeasurement))
+                model.Unit_of_measurement = _unitOfMeasurement;
+            if (!string.IsNullOrWhiteSpace(_icon))
+                model.Icon = _icon;
 
             return SetAutoDiscoveryConfigModel(model);
         }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/DisplaySensors.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/DisplaySensors.cs
@@ -48,7 +48,7 @@ public class DisplaySensors : AbstractMultiValueSensor
         var displayCount = displays.Length;
         var displayCountEntityName = $"{parentSensorSafeName}_display_count";
         var displayCountId = $"{Id}_display_count";
-        var displayCountSensor = new DataTypeIntSensor(_updateInterval, displayCountEntityName, "Display Count", displayCountId, string.Empty, "mdi:monitor", string.Empty, EntityName);
+        var displayCountSensor = new DataTypeIntSensor(_updateInterval, displayCountEntityName, "Display Count", displayCountId, string.Empty, "measurement", "mdi:monitor", string.Empty, EntityName);
         displayCountSensor.SetState(displayCount);
         AddUpdateSensor(displayCountId, displayCountSensor);
 

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/NetworkSensors.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/NetworkSensors.cs
@@ -139,7 +139,7 @@ public class NetworkSensors : AbstractMultiValueSensor
 
         var nicCountEntityName = $"{parentSensorSafeName}_total_network_card_count";
         var nicCountId = $"{Id}_total_network_card_count";
-        var nicCountSensor = new DataTypeIntSensor(_updateInterval, nicCountEntityName, "Network Card Count", nicCountId, string.Empty, "mdi:lan", string.Empty, EntityName);
+        var nicCountSensor = new DataTypeIntSensor(_updateInterval, nicCountEntityName, "Network Card Count", nicCountId, string.Empty, "measurement", "mdi:lan", string.Empty, EntityName);
         nicCountSensor.SetState(nicCount);
         AddUpdateSensor(nicCountId, nicCountSensor);
     }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/StorageSensors.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/StorageSensors.cs
@@ -117,7 +117,7 @@ public class StorageSensors : AbstractMultiValueSensor
          
         var driveCountEntityName = $"{parentSensorSafeName}_total_disk_count";
         var driveCountId = $"{Id}_total_disk_count";
-        var driveCountSensor = new DataTypeIntSensor(_updateInterval, driveCountEntityName, "Total Disk Count", driveCountId, string.Empty, "mdi:harddisk", string.Empty, EntityName);
+        var driveCountSensor = new DataTypeIntSensor(_updateInterval, driveCountEntityName, "Total Disk Count", driveCountId, string.Empty, "measurement", "mdi:harddisk", string.Empty, EntityName);
         driveCountSensor.SetState(driveCount);
 
         AddUpdateSensor(driveCountId, driveCountSensor);

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/WindowsUpdatesSensors.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/WindowsUpdatesSensors.cs
@@ -41,27 +41,27 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
 
             var driverUpdateCount = driverUpdates.Count;
             var driverUpdateCountId = $"{parentSensorSafeName}_driver_updates_pending";
-            var driverUpdateCountSensor = new DataTypeIntSensor(_updateInterval, driverUpdateCountId, "Driver Updates Pending", driverUpdateCountId, string.Empty, "mdi:microsoft-windows", string.Empty, EntityName);
+            var driverUpdateCountSensor = new DataTypeIntSensor(_updateInterval, driverUpdateCountId, "Driver Updates Pending", driverUpdateCountId, string.Empty, "measurement", "mdi:microsoft-windows", string.Empty, EntityName);
             driverUpdateCountSensor.SetState(driverUpdateCount);
             AddUpdateSensor(driverUpdateCountId, driverUpdateCountSensor);
 
             var softwareUpdateCount = softwareUpdates.Count;
             var softwareUpdateCountId = $"{parentSensorSafeName}_software_updates_pending";
-            var softwareUpdateCountSensor = new DataTypeIntSensor(_updateInterval, softwareUpdateCountId, "Software Updates Pending", softwareUpdateCountId, string.Empty, "mdi:microsoft-windows", string.Empty, EntityName);
+            var softwareUpdateCountSensor = new DataTypeIntSensor(_updateInterval, softwareUpdateCountId, "Software Updates Pending", softwareUpdateCountId, string.Empty, "measurement", "mdi:microsoft-windows", string.Empty, EntityName);
             softwareUpdateCountSensor.SetState(softwareUpdateCount);
             AddUpdateSensor(softwareUpdateCountId, softwareUpdateCountSensor);
 
             var driverUpdatesList = new WindowsUpdateInfoCollection(driverUpdates);
             var driverUpdatesStr = JsonConvert.SerializeObject(driverUpdatesList, Formatting.Indented);
             var driverUpdatesId = $"{parentSensorSafeName}_driver_updates";
-            var driverUpdatesSensor = new DataTypeIntSensor(_updateInterval, driverUpdatesId, "Available Driver Updates", driverUpdatesId, string.Empty, "mdi:microsoft-windows", string.Empty, EntityName, true);
+            var driverUpdatesSensor = new DataTypeIntSensor(_updateInterval, driverUpdatesId, "Available Driver Updates", driverUpdatesId, string.Empty, "measurement", "mdi:microsoft-windows", string.Empty, EntityName, true);
             driverUpdatesSensor.SetState(driverUpdates.Count);
             driverUpdatesSensor.SetAttributes(driverUpdatesStr);
             AddUpdateSensor(driverUpdatesId, driverUpdatesSensor);
 
             var softwareUpdatesStr = JsonConvert.SerializeObject(new WindowsUpdateInfoCollection(softwareUpdates), Formatting.Indented);
             var softwareUpdatesId = $"{parentSensorSafeName}_software_updates";
-            var softwareUpdatesSensor = new DataTypeIntSensor(_updateInterval, softwareUpdatesId, "Available Software Updates", softwareUpdatesId, string.Empty, "mdi:microsoft-windows", string.Empty, EntityName, true);
+            var softwareUpdatesSensor = new DataTypeIntSensor(_updateInterval, softwareUpdatesId, "Available Software Updates", softwareUpdatesId, string.Empty, "measurement", "mdi:microsoft-windows", string.Empty, EntityName, true);
             softwareUpdatesSensor.SetState(softwareUpdates.Count);
             softwareUpdatesSensor.SetAttributes(softwareUpdatesStr);
             AddUpdateSensor(softwareUpdatesId, softwareUpdatesSensor);

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/CurrentVolumeSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/CurrentVolumeSensor.cs
@@ -30,6 +30,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",
                 Icon = "mdi:volume-medium",
                 Unit_of_measurement = "%",
+                State_class = "measurement",
                 Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/availability"
             });
         }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/DummySensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/DummySensor.cs
@@ -25,6 +25,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",
+                State_class = "measurement",
                 Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/availability"
             });
         }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/GpuLoadSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/GpuLoadSensor.cs
@@ -40,7 +40,8 @@ public class GpuLoadSensor : AbstractSingleValueSensor
 			Device = deviceConfig,
 			State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",
 			Unit_of_measurement = "%",
-			Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/availability"
+            State_class = "measurement",
+            Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/availability"
 		});
 	}
 

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/GpuTemperatureSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/GpuTemperatureSensor.cs
@@ -39,6 +39,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",
                 Device_class = "temperature",
                 Unit_of_measurement = "°C",
+                State_class = "measurement",
                 Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/availability"
             });
         }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/MicrophoneProcessSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/MicrophoneProcessSensor.cs
@@ -46,6 +46,7 @@ public class MicrophoneProcessSensor : AbstractSingleValueSensor
             Unique_id = Id,
             Device = deviceConfig,
             State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",
+            State_class = "measurement",
             Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/sensor/{deviceConfig.Name}/availability",
             Icon = "mdi:microphone",
             Json_attributes_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/attributes"

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/ProcessActiveSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/ProcessActiveSensor.cs
@@ -36,6 +36,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",
+                State_class = "measurement",
                 Icon = "mdi:file-eye-outline",
                 Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/sensor/{deviceConfig.Name}/availability"
             });

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/WebcamProcessSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/WebcamProcessSensor.cs
@@ -41,6 +41,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",
+                State_class = "measurement",
                 Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/sensor/{deviceConfig.Name}/availability",
                 Icon = "mdi:webcam"
             };

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/PerfCounterSensors/SingleValue/CpuLoadSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/PerfCounterSensors/SingleValue/CpuLoadSensor.cs
@@ -27,6 +27,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.PerfCounterSensors.SingleValue
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",
+                State_class = "measurement",
                 Icon = "mdi:chart-areaspline",
                 Unit_of_measurement = "%",
                 Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/availability"

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/PerformanceCounterSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/PerformanceCounterSensor.cs
@@ -54,6 +54,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{EntityName}/state",
+                State_class = "measurement",
                 Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/availability"
             });
         }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/WmiSensors/SingleValue/CurrentClockSpeedSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/WmiSensors/SingleValue/CurrentClockSpeedSensor.cs
@@ -34,6 +34,8 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.WmiSensors.SingleValue
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",
+                State_class = "measurement",
+                Device_class = "frequency",
                 Icon = "mdi:speedometer",
                 Unit_of_measurement = "MHz",
                 Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/availability"

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/WmiSensors/SingleValue/MemoryUsageSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/WmiSensors/SingleValue/MemoryUsageSensor.cs
@@ -27,6 +27,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.WmiSensors.SingleValue
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",
+                State_class = "measurement",
                 Icon = "mdi:memory",
                 Unit_of_measurement = "%",
                 Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/availability"

--- a/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/MultiValue/PrintersSensors.cs
+++ b/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/MultiValue/PrintersSensors.cs
@@ -51,7 +51,7 @@ namespace HASS.Agent.HomeAssistant.Sensors.GeneralSensors.MultiValue
 
                 var printersCountEntityName = $"{parentSensorSafeName}_printers_count";
                 var printersCountId = $"{Id}_printers_count";
-                var printersCountSensor = new DataTypeIntSensor(_updateInterval, printersCountEntityName, "Printers Count", printersCountId, string.Empty, "mdi:printer", string.Empty, EntityName);
+                var printersCountSensor = new DataTypeIntSensor(_updateInterval, printersCountEntityName, "Printers Count", printersCountId, string.Empty, "measurement", "mdi:printer", string.Empty, EntityName);
                 printersCountSensor.SetState(printerInfo.PrintQueues.Count);
                 AddUpdateSensor(printersCountId, printersCountSensor);
 
@@ -63,7 +63,7 @@ namespace HASS.Agent.HomeAssistant.Sensors.GeneralSensors.MultiValue
 
                 var defaultQueueJobsEntityName = $"{parentSensorSafeName}_default_queue_jobs";
                 var defaultQueueJobsId = $"{Id}_default_queue_jobs";
-                var defaultQueueJobsSensor = new DataTypeIntSensor(_updateInterval, defaultQueueJobsEntityName, "Default Queue Jobs", defaultQueueJobsId, string.Empty, "mdi:printer", string.Empty, EntityName);
+                var defaultQueueJobsSensor = new DataTypeIntSensor(_updateInterval, defaultQueueJobsEntityName, "Default Queue Jobs", defaultQueueJobsId, string.Empty, "measurement", "mdi:printer", string.Empty, EntityName);
                 defaultQueueJobsSensor.SetState(printerInfo.DefaultQueueJobs);
                 AddUpdateSensor(defaultQueueJobsId, defaultQueueJobsSensor);
 
@@ -72,7 +72,7 @@ namespace HASS.Agent.HomeAssistant.Sensors.GeneralSensors.MultiValue
                     var printerQueueInfo = JsonConvert.SerializeObject(printer, Formatting.Indented);
                     var printerEntityName = $"{parentSensorSafeName}_{SharedHelperFunctions.GetSafeValue(printer.Name)}";
                     var printerId = $"{Id}_{SharedHelperFunctions.GetSafeValue(printer.Name)}";
-                    var printerSensor = new DataTypeIntSensor(_updateInterval, printerEntityName, $"{printer.Name}", printerId, string.Empty, "mdi:printer", string.Empty, EntityName, true);
+                    var printerSensor = new DataTypeIntSensor(_updateInterval, printerEntityName, $"{printer.Name}", printerId, string.Empty, "measurement", "mdi:printer", string.Empty, EntityName, true);
 
                     printerSensor.SetState(printer.Jobs);
                     printerSensor.SetAttributes(printerQueueInfo);

--- a/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/SingleValue/BluetoothDevicesSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/SingleValue/BluetoothDevicesSensor.cs
@@ -33,6 +33,7 @@ namespace HASS.Agent.HomeAssistant.Sensors.GeneralSensors.SingleValue
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",
+                State_class = "measurement",
                 Icon = "mdi:bluetooth",
                 Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/availability",
                 Json_attributes_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/attributes"

--- a/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/SingleValue/BluetoothLeDevicesSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/SingleValue/BluetoothLeDevicesSensor.cs
@@ -36,6 +36,7 @@ namespace HASS.Agent.HomeAssistant.Sensors.GeneralSensors.SingleValue
                 Unique_id = Id,
                 Device = deviceConfig,
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",
+                State_class = "measurement",
                 Icon = "mdi:bluetooth",
                 Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/availability",
                 Json_attributes_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/attributes"

--- a/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/SingleValue/InternalDeviceSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/SingleValue/InternalDeviceSensor.cs
@@ -48,6 +48,13 @@ namespace HASS.Agent.HomeAssistant.Sensors.GeneralSensors.SingleValue
             if (UseAttributes)
                 sensorDiscoveryConfigModel.Json_attributes_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/attributes";
 
+            if (!string.IsNullOrWhiteSpace(_internalDeviceSensor.MeasurementType))
+                sensorDiscoveryConfigModel.Device_class = _internalDeviceSensor.MeasurementType;
+            if (!string.IsNullOrWhiteSpace(_internalDeviceSensor.UnitOfMeasurement))
+                sensorDiscoveryConfigModel.Unit_of_measurement = _internalDeviceSensor.UnitOfMeasurement;
+            if (_internalDeviceSensor.IsNumeric)
+                sensorDiscoveryConfigModel.State_class = "measurement";
+
             return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(sensorDiscoveryConfigModel);
         }
 

--- a/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/AccelerometerSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/AccelerometerSensor.cs
@@ -14,6 +14,9 @@ namespace HASS.Agent.Managers.DeviceSensors
         public const string AttributeAccelerationZ = "AccelerationZ";
         public const string AttributeLastShaken = "LastShaken";
 
+        public string MeasurementType { get; } = string.Empty;
+        public string UnitOfMeasurement { get; } = string.Empty;
+
         private readonly Accelerometer _accelerometer;
 
         public bool Available => _accelerometer != null;
@@ -41,6 +44,8 @@ namespace HASS.Agent.Managers.DeviceSensors
                 ).ToString();
             }
         }
+
+        public bool IsNumeric { get; } = true;
 
         private readonly Dictionary<string, string> _attributes = new();
         public Dictionary<string, string> Attributes => _attributes;

--- a/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/ActivitySensor.cs
+++ b/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/ActivitySensor.cs
@@ -12,6 +12,9 @@ namespace HASS.Agent.Managers.DeviceSensors
         public const string AttributeConfidence = "Confidence";
         public const string AttributeTimestamp = "Timestamp";
 
+        public string MeasurementType { get; } = string.Empty;
+        public string UnitOfMeasurement { get; } = string.Empty;
+
         private readonly Windows.Devices.Sensors.ActivitySensor _activitySensor;
 
         public bool Available => _activitySensor != null;
@@ -30,6 +33,8 @@ namespace HASS.Agent.Managers.DeviceSensors
                 return sensorReading.Activity.ToString();
             }
         }
+
+        public bool IsNumeric { get; } = false;
 
         private readonly Dictionary<string, string> _attributes = new();
         public Dictionary<string, string> Attributes => _attributes;

--- a/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/AltimeterSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/AltimeterSensor.cs
@@ -11,6 +11,9 @@ namespace HASS.Agent.Managers.DeviceSensors
     {
         private readonly Altimeter _altimeter;
 
+        public string MeasurementType { get; } = "distance";
+        public string UnitOfMeasurement { get; } = "m";
+
         public bool Available => _altimeter != null;
         public InternalDeviceSensorType Type => InternalDeviceSensorType.Altimeter;
         public string Measurement
@@ -23,6 +26,8 @@ namespace HASS.Agent.Managers.DeviceSensors
                 return _altimeter.GetCurrentReading().AltitudeChangeInMeters.ToString();
             }
         }
+
+        public bool IsNumeric { get; } = true;
 
         public Dictionary<string, string> Attributes => InternalDeviceSensor.NoAttributes;
 

--- a/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/BarometerSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/BarometerSensor.cs
@@ -11,6 +11,9 @@ namespace HASS.Agent.Managers.DeviceSensors
     {
         private readonly Barometer _barometer;
 
+        public string MeasurementType { get; } = "pressure";
+        public string UnitOfMeasurement { get; } = "hPa";
+
         public bool Available => _barometer != null;
         public InternalDeviceSensorType Type => InternalDeviceSensorType.Barometer;
         public string Measurement
@@ -23,6 +26,8 @@ namespace HASS.Agent.Managers.DeviceSensors
                 return _barometer.GetCurrentReading().StationPressureInHectopascals.ToString();
             }
         }
+
+        public bool IsNumeric { get; } = true;
 
         public Dictionary<string, string> Attributes => InternalDeviceSensor.NoAttributes;
 

--- a/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/CompassSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/CompassSensor.cs
@@ -13,6 +13,9 @@ namespace HASS.Agent.Managers.DeviceSensors
 
         private readonly Compass _compass;
 
+        public string MeasurementType { get; } = string.Empty;
+        public string UnitOfMeasurement { get; } = string.Empty;
+
         public bool Available => _compass != null;
         public InternalDeviceSensorType Type => InternalDeviceSensorType.Compass;
         public string Measurement
@@ -27,6 +30,8 @@ namespace HASS.Agent.Managers.DeviceSensors
                 return Math.Round((decimal)sensorReading.HeadingTrueNorth, 2).ToString();
             }
         }
+
+        public bool IsNumeric { get; } = true;
 
         private readonly Dictionary<string, string> _attributes = new();
         public Dictionary<string, string> Attributes => _attributes;

--- a/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/GyrometerSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/GyrometerSensor.cs
@@ -15,6 +15,9 @@ namespace HASS.Agent.Managers.DeviceSensors
 
         private readonly Gyrometer _gyrometer;
 
+        public string MeasurementType { get; } = string.Empty;
+        public string UnitOfMeasurement { get; } = string.Empty;
+
         public bool Available => _gyrometer != null;
         public InternalDeviceSensorType Type => InternalDeviceSensorType.Gyrometer;
         public string Measurement
@@ -40,6 +43,8 @@ namespace HASS.Agent.Managers.DeviceSensors
                 ).ToString();
             }
         }
+
+        public bool IsNumeric { get; } = true;
 
         private readonly Dictionary<string, string> _attributes = new();
         public Dictionary<string, string> Attributes => _attributes;

--- a/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/HingeAngleSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/HingeAngleSensor.cs
@@ -11,6 +11,9 @@ namespace HASS.Agent.Managers.DeviceSensors
     {
         private readonly Windows.Devices.Sensors.HingeAngleSensor _hingeAngelSensor;
 
+        public string MeasurementType { get; } = string.Empty;
+        public string UnitOfMeasurement { get; } = string.Empty;
+
         public bool Available => _hingeAngelSensor != null;
         public InternalDeviceSensorType Type => InternalDeviceSensorType.HingeAngleSensor;
         public string Measurement
@@ -24,6 +27,8 @@ namespace HASS.Agent.Managers.DeviceSensors
                 return Math.Round((decimal)sensorReading, 2).ToString();
             }
         }
+
+        public bool IsNumeric { get; } = true;
 
         public Dictionary<string, string> Attributes => InternalDeviceSensor.NoAttributes;
 

--- a/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/IInternalDeviceSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/IInternalDeviceSensor.cs
@@ -36,6 +36,9 @@ namespace HASS.Agent.Managers.DeviceSensors
         public bool Available { get; }
         public InternalDeviceSensorType Type { get; }
         public string Measurement { get; }
+        public string MeasurementType { get; }
+        public string UnitOfMeasurement { get; }
+        public bool IsNumeric { get; }
         public Dictionary<string, string> Attributes { get; }
     }
 }

--- a/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/InclinometerSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/InclinometerSensor.cs
@@ -17,6 +17,9 @@ namespace HASS.Agent.Managers.DeviceSensors
 
         private readonly Inclinometer _inclinometer;
 
+        public string MeasurementType { get; } = string.Empty;
+        public string UnitOfMeasurement { get; } = string.Empty;
+
         public bool Available => _inclinometer != null;
         public InternalDeviceSensorType Type => InternalDeviceSensorType.Inclinometer;
         public string Measurement
@@ -36,6 +39,8 @@ namespace HASS.Agent.Managers.DeviceSensors
                 return sensorReading.Timestamp.ToLocalTime().ToString();
             }
         }
+
+        public bool IsNumeric { get; } = false;
 
         private readonly Dictionary<string, string> _attributes = new();
         public Dictionary<string, string> Attributes => _attributes;

--- a/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/LightSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/LightSensor.cs
@@ -11,6 +11,9 @@ namespace HASS.Agent.Managers.DeviceSensors
     {
         private readonly Windows.Devices.Sensors.LightSensor _lightSensor;
 
+        public string MeasurementType { get; } = "illuminance";
+        public string UnitOfMeasurement { get; } = "lx";
+
         public bool Available => _lightSensor != null;
         public InternalDeviceSensorType Type => InternalDeviceSensorType.LightSensor;
         public string Measurement
@@ -23,6 +26,8 @@ namespace HASS.Agent.Managers.DeviceSensors
                 return Math.Round((decimal)_lightSensor.GetCurrentReading().IlluminanceInLux, 2).ToString();
             }
         }
+
+        public bool IsNumeric { get; } = true;
 
         public Dictionary<string, string> Attributes => InternalDeviceSensor.NoAttributes;
 

--- a/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/MagnetometerSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/MagnetometerSensor.cs
@@ -15,6 +15,9 @@ namespace HASS.Agent.Managers.DeviceSensors
 
         private readonly Magnetometer _magnetometer;
 
+        public string MeasurementType { get; } = string.Empty;
+        public string UnitOfMeasurement { get; } = string.Empty;
+
         public bool Available => _magnetometer != null;
         public InternalDeviceSensorType Type => InternalDeviceSensorType.Magnetometer;
         public string Measurement
@@ -40,6 +43,8 @@ namespace HASS.Agent.Managers.DeviceSensors
                 ).ToString();
             }
         }
+
+        public bool IsNumeric { get; } = true;
 
         private readonly Dictionary<string, string> _attributes = new();
         public Dictionary<string, string> Attributes => _attributes;

--- a/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/OrientationSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/OrientationSensor.cs
@@ -15,6 +15,9 @@ namespace HASS.Agent.Managers.DeviceSensors
 
         private readonly Windows.Devices.Sensors.OrientationSensor _orientationSensor;
 
+        public string MeasurementType { get; } = string.Empty;
+        public string UnitOfMeasurement { get; } = string.Empty;
+
         public bool Available => _orientationSensor != null;
         public InternalDeviceSensorType Type => InternalDeviceSensorType.OrientationSensor;
         public string Measurement
@@ -31,6 +34,8 @@ namespace HASS.Agent.Managers.DeviceSensors
                 return JsonConvert.SerializeObject(sensorReading.Quaternion);
             }
         }
+
+        public bool IsNumeric { get; } = false;
 
         private readonly Dictionary<string, string> _attributes = new();
         public Dictionary<string, string> Attributes => _attributes;

--- a/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/PedometerSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/PedometerSensor.cs
@@ -11,6 +11,9 @@ namespace HASS.Agent.Managers.DeviceSensors
     {
         private readonly Pedometer _pedometer;
 
+        public string MeasurementType { get; } = string.Empty;
+        public string UnitOfMeasurement { get; } = string.Empty;
+
         public bool Available => _pedometer != null;
         public InternalDeviceSensorType Type => InternalDeviceSensorType.Pedometer;
         public string Measurement
@@ -36,6 +39,8 @@ namespace HASS.Agent.Managers.DeviceSensors
                 return totalStepCount.ToString();
             }
         }
+
+        public bool IsNumeric { get; } = true;
 
         private readonly Dictionary<string, string> _attributes = new();
         public Dictionary<string, string> Attributes => _attributes;

--- a/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/ProximitySensor.cs
+++ b/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/ProximitySensor.cs
@@ -11,6 +11,9 @@ namespace HASS.Agent.Managers.DeviceSensors
     {
         private Windows.Devices.Sensors.ProximitySensor _proximitySensor;
 
+        public string MeasurementType { get; } = "distance";
+        public string UnitOfMeasurement { get; } = "mm";
+
         public bool Available => _proximitySensor != null;
         public InternalDeviceSensorType Type => InternalDeviceSensorType.ProximitySensor;
         public string Measurement
@@ -23,6 +26,8 @@ namespace HASS.Agent.Managers.DeviceSensors
                 return _proximitySensor.GetCurrentReading().DistanceInMillimeters.ToString();
             }
         }
+
+        public bool IsNumeric { get; } = true;
 
         public Dictionary<string, string> Attributes => InternalDeviceSensor.NoAttributes;
 

--- a/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/SimpleOrientationSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/SimpleOrientationSensor.cs
@@ -11,6 +11,9 @@ namespace HASS.Agent.Managers.DeviceSensors
     {
         private readonly Windows.Devices.Sensors.SimpleOrientationSensor _simpleOrientationSensor;
 
+        public string MeasurementType { get; } = string.Empty;
+        public string UnitOfMeasurement { get; } = string.Empty;
+
         public bool Available => _simpleOrientationSensor != null;
         public InternalDeviceSensorType Type => InternalDeviceSensorType.SimpleOrientationSensor;
         public string Measurement
@@ -23,6 +26,8 @@ namespace HASS.Agent.Managers.DeviceSensors
                 return _simpleOrientationSensor.GetCurrentOrientation().ToString();
             }
         }
+
+        public bool IsNumeric { get; } = false;
 
         public Dictionary<string, string> Attributes => InternalDeviceSensor.NoAttributes;
 


### PR DESCRIPTION
This PR adjusts state class and device class of various sensors.
Previously sensors like CPU load sensor would report their value as "string" - each update would be visible as a string, not number.
After this change, Home Assistant statistics and other features will be available for the corrected sensors.