### PR TITLE
Fix: command friendly name not saving

### DIFF
--- a/src/HASS.Agent/HASS.Agent/Forms/Commands/CommandsMod.cs
+++ b/src/HASS.Agent/HASS.Agent/Forms/Commands/CommandsMod.cs
@@ -265,7 +265,7 @@ namespace HASS.Agent.Forms.Commands
                 MessageBoxAdv.Show(this, Languages.CommandsMod_BtnStore_DeviceNameInSensorName, Variables.MessageBoxTitle, MessageBoxButtons.OK, MessageBoxIcon.Warning);
             }
 
-			var friendlyName = string.IsNullOrEmpty(TbName.Text.Trim()) ? name : TbName.Text.Trim();
+			var friendlyName = string.IsNullOrEmpty(TbFriendlyName.Text.Trim()) ? name : TbFriendlyName.Text.Trim();
 
 			var sanitized = SharedHelperFunctions.GetSafeValue(name);
 			if (sanitized != name)


### PR DESCRIPTION
This PR fixed commands friendly name not being properly saved when creating/editing sensors - entity name was used instead.