### PR TITLE
Fix: windows updates sensor missing uniqueid

### DIFF
--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/WindowsUpdatesSensors.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/WindowsUpdatesSensors.cs
@@ -39,29 +39,33 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
 
             var (driverUpdates, softwareUpdates) = WindowsUpdatesManager.GetAvailableUpdates();
 
+            var driverUpdateCountEntityName = $"{parentSensorSafeName}_driver_updates_pending";
+            var driverUpdateCountId = $"{Id}_driver_updates_pending";
             var driverUpdateCount = driverUpdates.Count;
-            var driverUpdateCountId = $"{parentSensorSafeName}_driver_updates_pending";
-            var driverUpdateCountSensor = new DataTypeIntSensor(_updateInterval, driverUpdateCountId, "Driver Updates Pending", driverUpdateCountId, string.Empty, "measurement", "mdi:microsoft-windows", string.Empty, EntityName);
+            var driverUpdateCountSensor = new DataTypeIntSensor(_updateInterval, driverUpdateCountEntityName, "Driver Updates Pending", driverUpdateCountId, string.Empty, "measurement", "mdi:microsoft-windows", string.Empty, EntityName);
             driverUpdateCountSensor.SetState(driverUpdateCount);
             AddUpdateSensor(driverUpdateCountId, driverUpdateCountSensor);
 
+            var softwareUpdateCountEntityName = $"{parentSensorSafeName}_software_updates_pending";
+            var softwareUpdateCountId = $"{Id}_software_updates_pending";
             var softwareUpdateCount = softwareUpdates.Count;
-            var softwareUpdateCountId = $"{parentSensorSafeName}_software_updates_pending";
-            var softwareUpdateCountSensor = new DataTypeIntSensor(_updateInterval, softwareUpdateCountId, "Software Updates Pending", softwareUpdateCountId, string.Empty, "measurement", "mdi:microsoft-windows", string.Empty, EntityName);
+            var softwareUpdateCountSensor = new DataTypeIntSensor(_updateInterval, softwareUpdateCountEntityName, "Software Updates Pending", softwareUpdateCountId, string.Empty, "measurement", "mdi:microsoft-windows", string.Empty, EntityName);
             softwareUpdateCountSensor.SetState(softwareUpdateCount);
             AddUpdateSensor(softwareUpdateCountId, softwareUpdateCountSensor);
 
+            var driverUpdatesEntityName = $"{parentSensorSafeName}_driver_updates";
+            var driverUpdatesId = $"{Id}_driver_updates";
             var driverUpdatesList = new WindowsUpdateInfoCollection(driverUpdates);
             var driverUpdatesStr = JsonConvert.SerializeObject(driverUpdatesList, Formatting.Indented);
-            var driverUpdatesId = $"{parentSensorSafeName}_driver_updates";
-            var driverUpdatesSensor = new DataTypeIntSensor(_updateInterval, driverUpdatesId, "Available Driver Updates", driverUpdatesId, string.Empty, "measurement", "mdi:microsoft-windows", string.Empty, EntityName, true);
+            var driverUpdatesSensor = new DataTypeIntSensor(_updateInterval, driverUpdatesEntityName, "Available Driver Updates", driverUpdatesId, string.Empty, "measurement", "mdi:microsoft-windows", string.Empty, EntityName, true);
             driverUpdatesSensor.SetState(driverUpdates.Count);
             driverUpdatesSensor.SetAttributes(driverUpdatesStr);
             AddUpdateSensor(driverUpdatesId, driverUpdatesSensor);
 
+            var softwareUpdatesEntityName = $"{parentSensorSafeName}_software_updates";
+            var softwareUpdatesId = $"{Id}_software_updates";
             var softwareUpdatesStr = JsonConvert.SerializeObject(new WindowsUpdateInfoCollection(softwareUpdates), Formatting.Indented);
-            var softwareUpdatesId = $"{parentSensorSafeName}_software_updates";
-            var softwareUpdatesSensor = new DataTypeIntSensor(_updateInterval, softwareUpdatesId, "Available Software Updates", softwareUpdatesId, string.Empty, "measurement", "mdi:microsoft-windows", string.Empty, EntityName, true);
+            var softwareUpdatesSensor = new DataTypeIntSensor(_updateInterval, softwareUpdatesEntityName, "Available Software Updates", softwareUpdatesId, string.Empty, "measurement", "mdi:microsoft-windows", string.Empty, EntityName, true);
             softwareUpdatesSensor.SetState(softwareUpdates.Count);
             softwareUpdatesSensor.SetAttributes(softwareUpdatesStr);
             AddUpdateSensor(softwareUpdatesId, softwareUpdatesSensor);

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/WindowsUpdatesSensors.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/WindowsUpdatesSensors.cs
@@ -16,7 +16,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
         private const string DefaultName = "windowsupdates";
         private readonly int _updateInterval;
 
-        public sealed override Dictionary<string, AbstractSingleValueSensor> Sensors { get; protected set; } = new Dictionary<string, AbstractSingleValueSensor>();
+        public override sealed Dictionary<string, AbstractSingleValueSensor> Sensors { get; protected set; } = new Dictionary<string, AbstractSingleValueSensor>();
 
         public WindowsUpdatesSensors(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 900, id)
         {
@@ -33,7 +33,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
                 Sensors[sensorId] = sensor;
         }
 
-        public sealed override void UpdateSensorValues()
+        public override sealed void UpdateSensorValues()
         {
             var parentSensorSafeName = SharedHelperFunctions.GetSafeValue(EntityName);
 
@@ -41,33 +41,36 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
 
             var driverUpdateCountEntityName = $"{parentSensorSafeName}_driver_updates_pending";
             var driverUpdateCountId = $"{Id}_driver_updates_pending";
-            var driverUpdateCount = driverUpdates.Count;
             var driverUpdateCountSensor = new DataTypeIntSensor(_updateInterval, driverUpdateCountEntityName, "Driver Updates Pending", driverUpdateCountId, string.Empty, "measurement", "mdi:microsoft-windows", string.Empty, EntityName);
-            driverUpdateCountSensor.SetState(driverUpdateCount);
+            driverUpdateCountSensor.SetState(driverUpdates.Count);
             AddUpdateSensor(driverUpdateCountId, driverUpdateCountSensor);
 
             var softwareUpdateCountEntityName = $"{parentSensorSafeName}_software_updates_pending";
             var softwareUpdateCountId = $"{Id}_software_updates_pending";
-            var softwareUpdateCount = softwareUpdates.Count;
             var softwareUpdateCountSensor = new DataTypeIntSensor(_updateInterval, softwareUpdateCountEntityName, "Software Updates Pending", softwareUpdateCountId, string.Empty, "measurement", "mdi:microsoft-windows", string.Empty, EntityName);
-            softwareUpdateCountSensor.SetState(softwareUpdateCount);
+            softwareUpdateCountSensor.SetState(softwareUpdates.Count);
             AddUpdateSensor(softwareUpdateCountId, softwareUpdateCountSensor);
 
             var driverUpdatesEntityName = $"{parentSensorSafeName}_driver_updates";
             var driverUpdatesId = $"{Id}_driver_updates";
-            var driverUpdatesList = new WindowsUpdateInfoCollection(driverUpdates);
-            var driverUpdatesStr = JsonConvert.SerializeObject(driverUpdatesList, Formatting.Indented);
             var driverUpdatesSensor = new DataTypeIntSensor(_updateInterval, driverUpdatesEntityName, "Available Driver Updates", driverUpdatesId, string.Empty, "measurement", "mdi:microsoft-windows", string.Empty, EntityName, true);
             driverUpdatesSensor.SetState(driverUpdates.Count);
-            driverUpdatesSensor.SetAttributes(driverUpdatesStr);
+            driverUpdatesSensor.SetAttributes(
+                JsonConvert.SerializeObject(
+                    new WindowsUpdateInfoCollection(driverUpdates)
+                , Formatting.Indented)
+            );
             AddUpdateSensor(driverUpdatesId, driverUpdatesSensor);
 
             var softwareUpdatesEntityName = $"{parentSensorSafeName}_software_updates";
             var softwareUpdatesId = $"{Id}_software_updates";
-            var softwareUpdatesStr = JsonConvert.SerializeObject(new WindowsUpdateInfoCollection(softwareUpdates), Formatting.Indented);
             var softwareUpdatesSensor = new DataTypeIntSensor(_updateInterval, softwareUpdatesEntityName, "Available Software Updates", softwareUpdatesId, string.Empty, "measurement", "mdi:microsoft-windows", string.Empty, EntityName, true);
             softwareUpdatesSensor.SetState(softwareUpdates.Count);
-            softwareUpdatesSensor.SetAttributes(softwareUpdatesStr);
+            softwareUpdatesSensor.SetAttributes(
+                JsonConvert.SerializeObject(
+                    new WindowsUpdateInfoCollection(softwareUpdates)
+                , Formatting.Indented)
+            );
             AddUpdateSensor(softwareUpdatesId, softwareUpdatesSensor);
         }
 


### PR DESCRIPTION
This PR fixes issue reported by @zanix - https://github.com/hass-agent/HASS.Agent/issues/89 - where windows updates sensors would use entity name as the unique UI.
This resulted in Home Assistant rejecting the sensors if more than one device in one MQTT network reported them.