### PR TITLE
Feature: "MultipleKeys" command support for action parameter

### DIFF
--- a/src/HASS.Agent/HASS.Agent/Commands/CommandsManager.cs
+++ b/src/HASS.Agent/HASS.Agent/Commands/CommandsManager.cs
@@ -423,7 +423,7 @@ namespace HASS.Agent.Commands
 
             commandInfoCard = new CommandInfoCard(CommandType.MultipleKeysCommand,
                 Languages.CommandsManager_MultipleKeysCommandDescription,
-                true, false, false);
+                true, false, true);
 
             CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
 

--- a/src/HASS.Agent/HASS.Agent/Forms/Commands/CommandsMod.cs
+++ b/src/HASS.Agent/HASS.Agent/Forms/Commands/CommandsMod.cs
@@ -353,7 +353,19 @@ namespace HASS.Agent.Forms.Commands
 
 						return;
 					}
-					Command.Keys = keys;
+
+                    if (keys.Count == 0)
+                    {
+                        var q = MessageBoxAdv.Show(this, Languages.CommandsMod_BtnStore_MessageBox4, Variables.MessageBoxTitle, MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+                        if (q != DialogResult.Yes)
+                        {
+                            ActiveControl = TbSetting;
+
+                            return;
+                        }
+                    }
+
+                    Command.Keys = keys;
 					break;
 
 				case CommandType.LaunchUrlCommand:

--- a/src/HASS.Agent/HASS.Agent/Functions/HelperFunctions.cs
+++ b/src/HASS.Agent/HASS.Agent/Functions/HelperFunctions.cs
@@ -236,10 +236,7 @@ namespace HASS.Agent.Functions
             {
                 // any value?
                 if (string.IsNullOrWhiteSpace(keyString))
-                {
-                    errorMsg = Languages.HelperFunctions_ParseMultipleKeys_ErrorMsg1;
-                    return false;
-                }
+                    return true;
 
                 // any brackets?
                 if (!keyString.Contains('[') || !keyString.Contains(']'))


### PR DESCRIPTION
This PR adds functionality requested via https://github.com/hass-agent/HASS.Agent/issues/97 - action parameter support for "MultipleKeys" command.

As of now, the "Key" command has been left unchanged.

Example:
```
service: mqtt.publish
data:
  qos: 0
  retain: false
  topic: homeassistant/button/AMADEO-PC/multiplekeys/action
  payload: "[Test][ ][1][2][3]"
```