### PR TITLE
Fix: audio library/sleep management/playback

### DIFF
--- a/src/HASS.Agent/HASS.Agent.Shared/HASS.Agent.Shared.csproj
+++ b/src/HASS.Agent/HASS.Agent.Shared/HASS.Agent.Shared.csproj
@@ -33,11 +33,11 @@
     <PackageReference Include="ByteSize" Version="2.1.2" />
     <PackageReference Include="Cassia.NetStandard" Version="1.0.0" />
     <PackageReference Include="CliWrap" Version="3.6.6" />
-    <PackageReference Include="CSCore" Version="1.2.1.2" />
     <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.3" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="Microsoft.Win32.SystemEvents" Version="8.0.0" />
     <PackageReference Include="MQTTnet" Version="4.3.3.952" />
+    <PackageReference Include="NAudio" Version="2.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="8.0.0" />

--- a/src/HASS.Agent/HASS.Agent.Shared/Managers/Audio/AudioManager.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Managers/Audio/AudioManager.cs
@@ -50,6 +50,7 @@ public static class AudioManager
 
             case DeviceState.NotPresent:
             case DeviceState.UnPlugged:
+            case DeviceState.Disabled:
                 _devicesToBeRemoved.Enqueue(e.DeviceId);
                 break;
 

--- a/src/HASS.Agent/HASS.Agent.Shared/Managers/Audio/AudioManager.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Managers/Audio/AudioManager.cs
@@ -15,7 +15,8 @@ public static class AudioManager
 {
     private static bool _initialized = false;
 
-    private static readonly MMDeviceEnumerator _enumerator = new();
+    private static MMDeviceEnumerator _enumerator = new();
+    private static MMNotificationClient _notificationClient = null;
 
     private static readonly ConcurrentDictionary<string, InternalAudioDevice> _devices = new();
     private static readonly ConcurrentQueue<string> _devicesToBeRemoved = new();
@@ -23,57 +24,61 @@ public static class AudioManager
 
     private static readonly Dictionary<int, string> _applicationNameCache = new();
 
-    public static void Initialize()
+    private static void InitializeDevices()
     {
-        Log.Debug("[AUDIOMGR] Audio Manager initializing");
-
         foreach (var device in _enumerator.EnumAudioEndpoints(DataFlow.All, DeviceState.Active))
             _devices[device.DeviceID] = new InternalAudioDevice(device);
 
-        var nc = new MMNotificationClient(_enumerator);
-        nc.DeviceAdded += (sender, e) =>
-        {
-            if (_devices.ContainsKey(e.DeviceId))
-                return;
-
-            _devicesToBeAdded.Enqueue(e.DeviceId);
-        };
-
-        nc.DeviceRemoved += (sender, e) =>
-        {
-            _devicesToBeRemoved.Enqueue(e.DeviceId);
-        };
+        _notificationClient = new MMNotificationClient(_enumerator);
+        _notificationClient.DeviceAdded += DeviceAdded;
+        _notificationClient.DeviceRemoved += DeviceRemoved;
+        _notificationClient.DeviceStateChanged += DeviceStateChanged;
 
         _initialized = true;
-
-        nc.DeviceStateChanged += (sender, e) =>
-        {
-            switch (e.DeviceState)
-            {
-                case DeviceState.Active:
-                    if (_devices.ContainsKey(e.DeviceId))
-                        return;
-
-                    _devicesToBeAdded.Enqueue(e.DeviceId);
-                    break;
-
-                case DeviceState.NotPresent:
-                case DeviceState.UnPlugged:
-                    _devicesToBeRemoved.Enqueue(e.DeviceId);
-                    break;
-
-                default:
-                    break;
-            }
-        };
-
-        Log.Information("[AUDIOMGR] Audio Manager initialized");
     }
 
-    private static void CheckInitialization()
+    private static void DeviceStateChanged(object sender, DeviceStateChangedEventArgs e)
+    {
+        switch (e.DeviceState)
+        {
+            case DeviceState.Active:
+                if (_devices.ContainsKey(e.DeviceId))
+                    return;
+
+                _devicesToBeAdded.Enqueue(e.DeviceId);
+                break;
+
+            case DeviceState.NotPresent:
+            case DeviceState.UnPlugged:
+                _devicesToBeRemoved.Enqueue(e.DeviceId);
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    private static void DeviceRemoved(object sender, DeviceNotificationEventArgs e)
+    {
+        _devicesToBeRemoved.Enqueue(e.DeviceId);
+    }
+
+    private static void DeviceAdded(object sender, DeviceNotificationEventArgs e)
+    {
+        if (_devices.ContainsKey(e.DeviceId))
+            return;
+
+        _devicesToBeAdded.Enqueue(e.DeviceId);
+    }
+
+    private static bool CheckInitialization()
     {
         if (!_initialized)
-            throw new InvalidOperationException("AudioManager is not initialized");
+        {
+            Log.Warning("[AUDIOMGR] not yet initialized!");
+
+            return false;
+        }
 
         while (_devicesToBeRemoved.TryDequeue(out var deviceId))
         {
@@ -86,6 +91,8 @@ public static class AudioManager
             var device = _enumerator.GetDevice(deviceId);
             _devices[deviceId] = new InternalAudioDevice(device);
         }
+
+        return true;
     }
 
     private static string GetSessionDisplayName(InternalAudioSession session)
@@ -155,37 +162,81 @@ public static class AudioManager
         };
     }
 
+    public static void Initialize()
+    {
+        Log.Debug("[AUDIOMGR] initializing");
+
+        InitializeDevices();
+
+        Log.Information("[AUDIOMGR] initialized");
+    }
+
+    public static void ReInitialize()
+    {
+        if (_initialized)
+            CleanupDevices();
+
+        Log.Debug("[AUDIOMGR] re-initializing");
+
+        _enumerator = new MMDeviceEnumerator();
+        InitializeDevices();
+
+        Log.Information("[AUDIOMGR] re-initialized");
+    }
+
+    public static void CleanupDevices()
+    {
+        Log.Debug("[AUDIOMGR] starting cleanup");
+        _initialized = false;
+
+        foreach (var device in _devices.Values)
+            device.Dispose();
+
+        _enumerator.Dispose();
+
+        _devices.Clear();
+        Log.Debug("[AUDIOMGR] cleanup completed");
+    }
+
     public static List<AudioDevice> GetDevices()
     {
-        CheckInitialization();
-
         var audioDevices = new List<AudioDevice>();
 
-        using var defaultInputDevice = _enumerator.GetDefaultAudioEndpoint(DataFlow.Capture, Role.Multimedia);
-        using var defaultOutputDevice = _enumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
+        if (!CheckInitialization())
+            return audioDevices;
 
-        var defaultInputDeviceId = defaultInputDevice.DeviceID;
-        var defaultOutputDeviceId = defaultOutputDevice.DeviceID;
-
-        foreach (var device in _devices.Values.Where(d => d.MMDevice.DeviceState == DeviceState.Active))
+        try
         {
+            using var defaultInputDevice = _enumerator.GetDefaultAudioEndpoint(DataFlow.Capture, Role.Multimedia);
+            using var defaultOutputDevice = _enumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
 
-            var audioSessions = GetDeviceSessions(device);
-            var loudestSession = audioSessions.MaxBy(s => s.PeakVolume);
+            var defaultInputDeviceId = defaultInputDevice.DeviceID;
+            var defaultOutputDeviceId = defaultOutputDevice.DeviceID;
 
-            var audioDevice = new AudioDevice
+            foreach (var device in _devices.Values.Where(d => d.MMDevice.DeviceState == DeviceState.Active))
             {
-                State = GetReadableState(device.MMDevice.DeviceState),
-                Type = device.MMDevice.DataFlow == DataFlow.Capture ? DeviceType.Input : DeviceType.Output,
-                Id = device.DeviceId,
-                FriendlyName = device.FriendlyName,
-                Volume = Convert.ToInt32(Math.Round(device.AudioEndpointVolume.GetMasterVolumeLevelScalar() * 100, 0)),
-                PeakVolume = loudestSession == null ? 0 : loudestSession.PeakVolume,
-                Sessions = audioSessions,
-                Default = device.DeviceId == defaultInputDeviceId || device.DeviceId == defaultOutputDeviceId
-            };
 
-            audioDevices.Add(audioDevice);
+                var audioSessions = GetDeviceSessions(device);
+                var loudestSession = audioSessions.MaxBy(s => s.PeakVolume);
+
+                var audioDevice = new AudioDevice
+                {
+                    State = GetReadableState(device.MMDevice.DeviceState),
+                    Type = device.MMDevice.DataFlow == DataFlow.Capture ? DeviceType.Input : DeviceType.Output,
+                    Id = device.DeviceId,
+                    FriendlyName = device.FriendlyName,
+                    Volume = Convert.ToInt32(Math.Round(device.AudioEndpointVolume.GetMasterVolumeLevelScalar() * 100, 0)),
+                    PeakVolume = loudestSession == null ? 0 : loudestSession.PeakVolume,
+                    Sessions = audioSessions,
+                    Default = device.DeviceId == defaultInputDeviceId || device.DeviceId == defaultOutputDeviceId
+                };
+
+                audioDevices.Add(audioDevice);
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Debug(ex, "[AUDIOMGR] Failed to retrieve devices: {msg}", ex.Message);
         }
 
         return audioDevices;
@@ -193,6 +244,9 @@ public static class AudioManager
 
     public static string GetDefaultDeviceId(DeviceType deviceType, DeviceRole deviceRole)
     {
+        if (!CheckInitialization())
+            return string.Empty;
+
         var dataFlow = deviceType == DeviceType.Input ? DataFlow.Capture : DataFlow.Render;
         var role = (Role)deviceRole;
 
@@ -203,6 +257,9 @@ public static class AudioManager
 
     public static void Activate(AudioDevice audioDevice)
     {
+        if (!CheckInitialization())
+            return;
+
         if (!_devices.TryGetValue(audioDevice.Id, out var device))
             return;
 
@@ -211,6 +268,9 @@ public static class AudioManager
 
     public static void SetVolume(AudioDevice audioDevice, int volume)
     {
+        if (!CheckInitialization())
+            return;
+
         if (!_devices.TryGetValue(audioDevice.Id, out var device))
             return;
 
@@ -220,6 +280,9 @@ public static class AudioManager
 
     public static void SetVolume(AudioSession audioSession, int volume)
     {
+        if (!CheckInitialization())
+            return;
+
         var device = _devices.Values.Where(d => d.FriendlyName == audioSession.PlaybackDevice).FirstOrDefault();
         if (device == null)
             return;
@@ -233,6 +296,9 @@ public static class AudioManager
 
     public static void SetMute(AudioDevice audioDevice, bool mute)
     {
+        if (!CheckInitialization())
+            return;
+
         if (!_devices.TryGetValue(audioDevice.Id, out var device))
             return;
 
@@ -241,6 +307,9 @@ public static class AudioManager
 
     public static void SetMute(AudioSession audioSession, bool mute)
     {
+        if (!CheckInitialization())
+            return;
+
         var device = _devices.Values.Where(d => d.FriendlyName == audioSession.PlaybackDevice).FirstOrDefault();
         if (device == null)
             return;
@@ -253,18 +322,15 @@ public static class AudioManager
 
     public static void Shutdown()
     {
-        Log.Debug("[AUDIOMGR] Audio Manager shutting down");
+        Log.Debug("[AUDIOMGR] shutting down");
         try
         {
-            foreach(var device in _devices.Values)
-                device.Dispose();
-
-            _enumerator.Dispose();
+            CleanupDevices();
         }
         catch (Exception ex)
         {
-            Log.Fatal(ex, "[AUDIOMGR] Audio Manager shutdown fatal error: {ex}", ex.Message);
+            Log.Fatal(ex, "[AUDIOMGR] shutdown fatal error: {ex}", ex.Message);
         }
-        Log.Debug("[AUDIOMGR] Audio Manager shutdown completed");
+        Log.Debug("[AUDIOMGR] shutdown completed");
     }
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/Managers/Audio/Internal/CPolicyConfigVistaClient.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Managers/Audio/Internal/CPolicyConfigVistaClient.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
-using CSCore.CoreAudioAPI;
+using NAudio.CoreAudioApi;
 
 namespace HASS.Agent.Shared.Managers.Audio.Internal;
 

--- a/src/HASS.Agent/HASS.Agent.Shared/Managers/Audio/Internal/DeviceChangeEventArgs.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Managers/Audio/Internal/DeviceChangeEventArgs.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NAudio.CoreAudioApi;
+
+namespace HASS.Agent.Shared.Managers.Audio.Internal;
+
+internal class DeviceNotificationEventArgs : EventArgs
+{
+    public string DeviceId { get; private set; }
+
+    public DeviceNotificationEventArgs(string deviceId)
+    {
+        DeviceId = deviceId;
+    }
+}
+
+internal class DefaultDeviceChangedEventArgs : DeviceNotificationEventArgs
+{
+    public DataFlow DataFlow { get; private set; }
+    public Role Role { get; private set; }
+
+    public DefaultDeviceChangedEventArgs(string deviceId, DataFlow dataFlow, Role role) : base(deviceId)
+    {
+        DataFlow = dataFlow;
+        Role = role;
+    }
+}
+
+internal class DeviceStateChangedEventArgs : DeviceNotificationEventArgs
+{
+    public DeviceState DeviceState { get; private set; }
+
+    public DeviceStateChangedEventArgs(string deviceId, DeviceState deviceState) : base(deviceId)
+    {
+        DeviceState = deviceState;
+    }
+}
+
+internal class DevicePropertyChangedEventArgs : DeviceNotificationEventArgs
+{
+    public PropertyKey PropertyKey { get; private set; }
+
+    public DevicePropertyChangedEventArgs(string deviceId, PropertyKey propertyKey) : base(deviceId)
+    {
+        PropertyKey = propertyKey;
+    }
+}

--- a/src/HASS.Agent/HASS.Agent.Shared/Managers/Audio/Internal/IPolicyConfigVista.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Managers/Audio/Internal/IPolicyConfigVista.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
-using CSCore.CoreAudioAPI;
+using NAudio.CoreAudioApi;
 
 namespace HASS.Agent.Shared.Managers.Audio.Internal;
 

--- a/src/HASS.Agent/HASS.Agent.Shared/Managers/Audio/Internal/InternalAudioDevice.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Managers/Audio/Internal/InternalAudioDevice.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using CSCore.CoreAudioAPI;
+using NAudio.CoreAudioApi;
 
 namespace HASS.Agent.Shared.Managers.Audio.Internal;
 internal class InternalAudioDevice : IDisposable
@@ -19,18 +19,17 @@ internal class InternalAudioDevice : IDisposable
     public InternalAudioDevice(MMDevice device)
     {
         MMDevice = device;
-        var sessionManager2 = AudioSessionManager2.FromMMDevice(device);
-        Manager = new InternalAudioSessionManager(sessionManager2);
-        AudioEndpointVolume = AudioEndpointVolume.FromDevice(device);
+        Manager = new InternalAudioSessionManager(device.AudioSessionManager);
+        AudioEndpointVolume = device.AudioEndpointVolume;
 
-        DeviceId = device.DeviceID;
+        DeviceId = device.ID;
         FriendlyName = device.FriendlyName;
     }
 
     public void Activate()
     {
         using var configClient = new CPolicyConfigVistaClient();
-        configClient.SetDefaultDevice(MMDevice.DeviceID);
+        configClient.SetDefaultDevice(MMDevice.ID);
     }
 
     public void Dispose()

--- a/src/HASS.Agent/HASS.Agent.Shared/Managers/Audio/Internal/InternalAudioSession.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Managers/Audio/Internal/InternalAudioSession.cs
@@ -3,78 +3,73 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using CSCore.CoreAudioAPI;
+using NAudio.CoreAudioApi;
+using NAudio.CoreAudioApi.Interfaces;
 
 namespace HASS.Agent.Shared.Managers.Audio.Internal;
-internal class InternalAudioSession : IDisposable, IAudioSessionEvents
+internal class InternalAudioSession : IDisposable, IAudioSessionEventsHandler
 {
     public AudioSessionControl Control { get; private set; }
-    public AudioSessionControl2 Control2 { get; private set; }
     public SimpleAudioVolume Volume { get; private set; }
     public AudioMeterInformation MeterInformation { get; private set; }
 
     public string DisplayName { get; private set; }
     public int ProcessId { get; private set; }
+
     public bool Expired { get; private set; } = false;
 
     public InternalAudioSession(AudioSessionControl audioSessionControl)
     {
         Control = audioSessionControl;
-        Control2 = audioSessionControl.QueryInterface<AudioSessionControl2>();
-        Volume = audioSessionControl.QueryInterface<SimpleAudioVolume>();
-        MeterInformation = audioSessionControl.QueryInterface<AudioMeterInformation>();
+        Volume = audioSessionControl.SimpleAudioVolume;
+        MeterInformation = audioSessionControl.AudioMeterInformation;
 
-        DisplayName = Control2.DisplayName;
-        ProcessId = Control2.ProcessID;
+        DisplayName = Control.DisplayName;
+        ProcessId = Convert.ToInt32(Control.GetProcessID);
 
-        Control.RegisterAudioSessionNotification(this);
+        Control.RegisterEventClient(this);
     }
 
     public void Dispose()
     {
-        Control.UnregisterAudioSessionNotification(this);
+        Control.UnRegisterEventClient(this);
 
-        MeterInformation?.Dispose();
+        //MeterInformation?.Dispose();
         Volume?.Dispose();
-        Control2?.Dispose();
+        //Control2?.Dispose();
         Control?.Dispose();
 
         GC.SuppressFinalize(this);
     }
 
-    ~InternalAudioSession()
-    {
-        Dispose();
-    }
-
-    public void OnDisplayNameChanged(string newDisplayName, ref Guid eventContext)
+    public void OnVolumeChanged(float volume, bool isMuted)
     {
 
     }
 
-    public void OnIconPathChanged(string newIconPath, ref Guid eventContext)
+    public void OnDisplayNameChanged(string displayName)
     {
 
     }
 
-    public void OnSimpleVolumeChanged(float newVolume, bool newMute, ref Guid eventContext)
+    public void OnIconPathChanged(string iconPath)
     {
 
     }
 
-    public void OnChannelVolumeChanged(int channelCount, float[] newChannelVolumeArray, int changedChannel, ref Guid eventContext)
+    public void OnChannelVolumeChanged(uint channelCount, nint newVolumes, uint channelIndex)
     {
 
     }
 
-    public void OnGroupingParamChanged(ref Guid newGroupingParam, ref Guid eventContext)
+    public void OnGroupingParamChanged(ref Guid groupingId)
     {
 
     }
 
-    public void OnStateChanged(AudioSessionState newState)
+    public void OnStateChanged(AudioSessionState state)
     {
-        if (newState == AudioSessionState.AudioSessionStateExpired)
+        if (state == AudioSessionState.AudioSessionStateExpired)
             Expired = true;
     }
 
@@ -82,4 +77,10 @@ internal class InternalAudioSession : IDisposable, IAudioSessionEvents
     {
 
     }
+
+    ~InternalAudioSession()
+    {
+        Dispose();
+    }
+
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/Managers/Audio/Internal/InternalAudioSession.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Managers/Audio/Internal/InternalAudioSession.cs
@@ -34,9 +34,7 @@ internal class InternalAudioSession : IDisposable, IAudioSessionEventsHandler
     {
         Control.UnRegisterEventClient(this);
 
-        //MeterInformation?.Dispose();
         Volume?.Dispose();
-        //Control2?.Dispose();
         Control?.Dispose();
 
         GC.SuppressFinalize(this);

--- a/src/HASS.Agent/HASS.Agent.Shared/Managers/Audio/Internal/InternalAudioSessionManager.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Managers/Audio/Internal/InternalAudioSessionManager.cs
@@ -54,9 +54,7 @@ internal class InternalAudioSessionManager : IDisposable
             Manager.OnSessionCreated -= Manager_OnSessionCreated;
 
         foreach (var session in Sessions.Values)
-        {
             session?.Dispose();
-        }
 
         Manager?.Dispose();
 

--- a/src/HASS.Agent/HASS.Agent.Shared/Managers/Audio/Internal/InternalAudioSessionManager.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Managers/Audio/Internal/InternalAudioSessionManager.cs
@@ -4,39 +4,40 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using CSCore.CoreAudioAPI;
+using NAudio.CoreAudioApi;
 
 namespace HASS.Agent.Shared.Managers.Audio.Internal;
 internal class InternalAudioSessionManager : IDisposable
 {
-    public AudioSessionManager2 Manager { get; private set; }
+    public AudioSessionManager Manager { get; private set; }
     public ConcurrentDictionary<string, InternalAudioSession> Sessions { get; private set; } = new();
-    public InternalAudioSessionManager(AudioSessionManager2 sessionManager2)
+    public InternalAudioSessionManager(AudioSessionManager sessionManager2)
     {
         Manager = sessionManager2;
 
-        using var sessionEnumerator = Manager.GetSessionEnumerator();
-        foreach (var session in sessionEnumerator)
+        var sessions = Manager.Sessions;
+        for (var i = 0; i < sessions.Count; i++)
         {
+            var session = sessions[i];
             var internalSession = new InternalAudioSession(session);
-            Sessions[internalSession.Control2.SessionInstanceIdentifier] = internalSession;
+            Sessions[internalSession.Control.GetSessionInstanceIdentifier] = internalSession;
         }
 
-        Manager.SessionCreated += Manager_SessionCreated;
+        Manager.OnSessionCreated += Manager_OnSessionCreated;
     }
 
-    private void Manager_SessionCreated(object? sender, SessionCreatedEventArgs e)
+    private void Manager_OnSessionCreated(object sender, NAudio.CoreAudioApi.Interfaces.IAudioSessionControl newSession)
     {
-        if (e.NewSession != null)
+        if (newSession != null)
         {
-            var internalSession = new InternalAudioSession(e.NewSession);
-            Sessions[internalSession.Control2.SessionInstanceIdentifier] = internalSession;
+            var internalSession = new InternalAudioSession(new AudioSessionControl(newSession));
+            Sessions[internalSession.Control.GetSessionInstanceIdentifier] = internalSession;
         }
     }
 
     public void RemoveDisconnectedSessions()
     {
-        var expiredSessionsId = Sessions.Values.Where(s => s.Expired).Select(s => s.Control2.SessionInstanceIdentifier);
+        var expiredSessionsId = Sessions.Values.Where(s => s.Expired).Select(s => s.Control.GetSessionInstanceIdentifier);
         if (!expiredSessionsId.Any())
             return;
 
@@ -50,7 +51,7 @@ internal class InternalAudioSessionManager : IDisposable
     public void Dispose()
     {
         if (Manager != null)
-            Manager.SessionCreated -= Manager_SessionCreated;
+            Manager.OnSessionCreated -= Manager_OnSessionCreated;
 
         foreach (var session in Sessions.Values)
         {

--- a/src/HASS.Agent/HASS.Agent.Shared/Managers/Audio/Internal/MMNotificationClient.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Managers/Audio/Internal/MMNotificationClient.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NAudio.CoreAudioApi.Interfaces;
+using NAudio.CoreAudioApi;
+
+namespace HASS.Agent.Shared.Managers.Audio.Internal;
+
+internal class MMNotificationClient : IMMNotificationClient
+{
+    public event EventHandler<DeviceStateChangedEventArgs> DeviceStateChanged;
+    public event EventHandler<DeviceNotificationEventArgs> DeviceAdded;
+    public event EventHandler<DeviceNotificationEventArgs> DeviceRemoved;
+    public event EventHandler<DefaultDeviceChangedEventArgs> DefaultDeviceChanged;
+    public event EventHandler<DevicePropertyChangedEventArgs> DevicePropertyChanged;
+
+    void IMMNotificationClient.OnDeviceStateChanged(string deviceId, DeviceState deviceState)
+    {
+        DeviceStateChanged?.Invoke(this, new DeviceStateChangedEventArgs(deviceId, deviceState));
+    }
+
+    void IMMNotificationClient.OnDeviceAdded(string deviceId)
+    {
+        DeviceAdded?.Invoke(this, new DeviceNotificationEventArgs(deviceId));
+    }
+
+    void IMMNotificationClient.OnDeviceRemoved(string deviceId)
+    {
+        DeviceRemoved?.Invoke(this, new DeviceNotificationEventArgs(deviceId));
+    }
+
+    void IMMNotificationClient.OnDefaultDeviceChanged(DataFlow dataFlow, Role role, string deviceId)
+    {
+        DefaultDeviceChanged?.Invoke(this, new DefaultDeviceChangedEventArgs(deviceId, dataFlow, role));
+    }
+
+    void IMMNotificationClient.OnPropertyValueChanged(string deviceId, PropertyKey key)
+    {
+        DevicePropertyChanged?.Invoke(this, new DevicePropertyChangedEventArgs(deviceId, key));
+    }
+}

--- a/src/HASS.Agent/HASS.Agent/Managers/SystemStateManager.cs
+++ b/src/HASS.Agent/HASS.Agent/Managers/SystemStateManager.cs
@@ -1,6 +1,7 @@
 ﻿using System.Runtime.InteropServices;
 using HASS.Agent.Functions;
 using HASS.Agent.Shared.Enums;
+using HASS.Agent.Shared.Managers.Audio;
 using Microsoft.Win32;
 using Serilog;
 
@@ -200,6 +201,9 @@ namespace HASS.Agent.Managers
                     Log.Information("[SYSTEMSTATE] Session resuming");
                     Task.Run(() => Variables.MqttManager.AnnounceAvailabilityAsync());
                     LastSystemStateEvent = SystemStateEvent.Resume;
+
+                    AudioManager.ReInitialize();
+
                     break;
 
                 case PowerModes.Suspend:
@@ -209,6 +213,9 @@ namespace HASS.Agent.Managers
                     Log.Information("[SYSTEMSTATE] Session halting: system suspending");
                     Task.Run(() => Variables.MqttManager.AnnounceAvailabilityAsync(true));
                     LastSystemStateEvent = SystemStateEvent.Suspend;
+
+                    AudioManager.CleanupDevices();
+
                     break;
             }
         }

--- a/src/HASS.Agent/HASS.Agent/Media/MediaManager.cs
+++ b/src/HASS.Agent/HASS.Agent/Media/MediaManager.cs
@@ -12,6 +12,7 @@ using MQTTnet;
 using Serilog;
 using MediaPlayerState = HASS.Agent.Enums.MediaPlayerState;
 using Octokit;
+using Windows.Media.Core;
 
 namespace HASS.Agent.Media
 {
@@ -406,7 +407,7 @@ namespace HASS.Agent.Media
                 if (Variables.MediaPlayer.CurrentState == Windows.Media.Playback.MediaPlayerState.Playing) Variables.MediaPlayer.Pause();
 
                 // set the uri source
-                Variables.MediaPlayer.SetUriSource(new Uri(localFile));
+                Variables.MediaPlayer.Source = MediaSource.CreateFromUri(new Uri(localFile));
 
                 if (Variables.ExtendedLogging) Log.Information("[MEDIA] Playing: {file}", Path.GetFileName(localFile));
 


### PR DESCRIPTION
This PR:
- changes the audio library to NAudio
- fixed issue with media playback using deprecated method that occasionally resulted in access memory violation
- adds additional logic to handle audio management after system has been put to sleep

Related to https://github.com/hass-agent/HASS.Agent/issues/64