### PR TITLE
Fix: device & media player mute parameter

### DIFF
--- a/src/HASS.Agent/HASS.Agent.Shared/Managers/Audio/AudioManager.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Managers/Audio/AudioManager.cs
@@ -235,6 +235,7 @@ public static class AudioManager
                     Id = device.DeviceId,
                     FriendlyName = device.FriendlyName,
                     Volume = Convert.ToInt32(Math.Round(device.AudioEndpointVolume.MasterVolumeLevelScalar * 100, 0)),
+                    Muted = device.MMDevice.AudioEndpointVolume.Mute,
                     PeakVolume = loudestSession == null ? 0 : loudestSession.PeakVolume,
                     Sessions = audioSessions,
                     Default = device.DeviceId == defaultInputDeviceId || device.DeviceId == defaultOutputDeviceId


### PR DESCRIPTION
This PR fixes:
- audio devices returned from AudioManager not having "Mute" attribute assigned properly
- media player not reporting mute status (reported via https://github.com/hass-agent/HASS.Agent/issues/100)