### PR TITLE
Fix: advanced settings not being saved for satellite sensors

### DIFF
--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/Extensions/RpcExtensions.cs
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/Extensions/RpcExtensions.cs
@@ -108,7 +108,8 @@ namespace HASS.Agent.Satellite.Service.Extensions
                 Counter = rpcConfiguredSensor.Counter,
                 Instance = rpcConfiguredSensor.Instance,
                 EntityName = rpcConfiguredSensor.EntityName,
-                Name = rpcConfiguredSensor.Name
+                Name = rpcConfiguredSensor.Name,
+                AdvancedSettings = rpcConfiguredSensor.AdvancedSettings,
             };
 
             return configuredSensor;
@@ -149,7 +150,8 @@ namespace HASS.Agent.Satellite.Service.Extensions
                 Counter = configuredSensor.Counter ?? string.Empty,
                 Instance = configuredSensor.Instance ?? string.Empty,
                 Name = configuredSensor.Name ?? string.Empty,
-                EntityName = configuredSensor?.EntityName ?? string.Empty
+                EntityName = configuredSensor?.EntityName ?? string.Empty,
+                AdvancedSettings = configuredSensor?.AdvancedSettings ?? string.Empty,
             };
 
             return configuredRpcSensor;

--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/RPC/Protos/hassagentsatellite.proto
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/RPC/Protos/hassagentsatellite.proto
@@ -134,6 +134,7 @@ message RpcConfiguredServerSensor {
   string instance = 9;
   string name = 10;
   string entityName = 11;
+  string advancedSettings = 12;
 }
 
 message RpcConfiguredServerCommand {

--- a/src/HASS.Agent/HASS.Agent/Extensions/RpcExtensions.cs
+++ b/src/HASS.Agent/HASS.Agent/Extensions/RpcExtensions.cs
@@ -109,7 +109,8 @@ namespace HASS.Agent.Extensions
                 Counter = rpcConfiguredSensor.Counter,
                 Instance = rpcConfiguredSensor.Instance,
                 EntityName = rpcConfiguredSensor.EntityName,
-                Name = rpcConfiguredSensor.Name
+                Name = rpcConfiguredSensor.Name,
+                AdvancedSettings = rpcConfiguredSensor.AdvancedSettings,
             };
 
             return configuredSensor;
@@ -150,7 +151,8 @@ namespace HASS.Agent.Extensions
                 Counter = configuredSensor.Counter ?? string.Empty,
                 Instance = configuredSensor.Instance ?? string.Empty,
                 Name = configuredSensor.Name ?? string.Empty,
-                EntityName = configuredSensor.EntityName ?? string.Empty
+                EntityName = configuredSensor.EntityName ?? string.Empty,
+                AdvancedSettings = configuredSensor?.AdvancedSettings ?? string.Empty,
             };
 
             return configuredRpcSensor;

--- a/src/HASS.Agent/HASS.Agent/Service/Protos/hassagentsatellite.proto
+++ b/src/HASS.Agent/HASS.Agent/Service/Protos/hassagentsatellite.proto
@@ -134,6 +134,7 @@ message RpcConfiguredServerSensor {
   string instance = 9;
   string name = 10;
   string entityName = 11;
+  string advancedSettings = 12;
 }
 
 message RpcConfiguredServerCommand {


### PR DESCRIPTION
This PR fixes advanced settings not being properly saved for satellite sensors.
Thanks to @spikeygg for reporting.

Related to following request: https://github.com/hass-agent/HASS.Agent/issues/66