### PR TITLE
Fix: sensor's base class not saving advanced properties

### DIFF
--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/WmiQuerySensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/WmiQuerySensor.cs
@@ -19,8 +19,6 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors
         public bool ApplyRounding { get; private set; }
         public int? Round { get; private set; }
 
-        public string AdvancedSettings { get; private set; }
-
         protected readonly ObjectQuery ObjectQuery;
         protected readonly ManagementObjectSearcher Searcher;
 
@@ -30,7 +28,6 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors
             Scope = scope;
             ApplyRounding = applyRounding;
             Round = round;
-            AdvancedSettings = advancedSettings;
 
             // prepare query
             ObjectQuery = new ObjectQuery(Query);

--- a/src/HASS.Agent/HASS.Agent.Shared/Models/HomeAssistant/AbstractSingleValueSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Models/HomeAssistant/AbstractSingleValueSensor.cs
@@ -33,6 +33,7 @@ public abstract class AbstractSingleValueSensor : AbstractDiscoverable
 
         if (!string.IsNullOrWhiteSpace(advancedSettings))
         {
+            AdvancedSettings = advancedSettings;
             _advancedInfo = JsonConvert.DeserializeObject<SensorAdvancedSettings>(advancedSettings);
         }
     }


### PR DESCRIPTION
This PR fixes sensor's base class not properly parsing/saving advanced settings.