### PR TITLE
Fix: missing ignore version parameter

### DIFF
--- a/src/HASS.Agent.Installer/InstallerScript-Service.iss
+++ b/src/HASS.Agent.Installer/InstallerScript-Service.iss
@@ -52,7 +52,7 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 [Files]
 ; Service files
-Source: "..\HASS.Agent\HASS.Agent.Satellite.Service\bin\Publish-x64\Release\*"; DestDir: "{app}"; Flags: recursesubdirs createallsubdirs
+Source: "..\HASS.Agent\HASS.Agent.Satellite.Service\bin\Publish-x64\Release\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 
 [Run]
 Filename: "{sys}\sc.exe"; Parameters: "start {#ServiceName}"; Description: "Start Satellite Service"; Flags: postinstall runhidden runascurrentuser 
@@ -80,3 +80,16 @@ begin
   Dependency_AddDotNet60Desktop;
   Result := True;
 end;
+
+//procedure CurStepChanged(CurStep: TSetupStep);
+//var
+//    ResultCode: Integer;
+//    wmicommand: string;
+//begin
+//    // before installation begins
+//    if CurStep = ssInstall then
+//    begin
+//        MsgBox(ExpandConstant('{sys}') + '\sc.exe' + '|||' + 'stop {#ServiceName}', mbInformation, MB_OK);
+//         Exec(ExpandConstant('{sys}') + '\sc.exe', 'stop {#ServiceName}', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+//     end;
+// end;

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/WmiQuerySensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/WmiQuerySensor.cs
@@ -19,8 +19,6 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors
         public bool ApplyRounding { get; private set; }
         public int? Round { get; private set; }
 
-        public string AdvancedSettings { get; private set; }
-
         protected readonly ObjectQuery ObjectQuery;
         protected readonly ManagementObjectSearcher Searcher;
 
@@ -30,7 +28,6 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors
             Scope = scope;
             ApplyRounding = applyRounding;
             Round = round;
-            AdvancedSettings = advancedSettings;
 
             // prepare query
             ObjectQuery = new ObjectQuery(Query);

--- a/src/HASS.Agent/HASS.Agent.Shared/Models/HomeAssistant/AbstractSingleValueSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Models/HomeAssistant/AbstractSingleValueSensor.cs
@@ -33,6 +33,7 @@ public abstract class AbstractSingleValueSensor : AbstractDiscoverable
 
         if (!string.IsNullOrWhiteSpace(advancedSettings))
         {
+            AdvancedSettings = advancedSettings;
             _advancedInfo = JsonConvert.DeserializeObject<SensorAdvancedSettings>(advancedSettings);
         }
     }


### PR DESCRIPTION
This PR adds "ignoreversion" parameter to the service installer.
Will allow for easier development build tests.