### PR TITLE
Fix: satellite service sensors/commands not being properly saved

### DIFF
--- a/src/HASS.Agent.Installer/InstallerScript-Service.iss
+++ b/src/HASS.Agent.Installer/InstallerScript-Service.iss
@@ -52,7 +52,7 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 [Files]
 ; Service files
-Source: "..\HASS.Agent\HASS.Agent.Satellite.Service\bin\Publish-x64\Release\*"; DestDir: "{app}"; Flags: recursesubdirs createallsubdirs
+Source: "..\HASS.Agent\HASS.Agent.Satellite.Service\bin\Publish-x64\Release\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 
 [Run]
 Filename: "{sys}\sc.exe"; Parameters: "start {#ServiceName}"; Description: "Start Satellite Service"; Flags: postinstall runhidden runascurrentuser 
@@ -79,4 +79,38 @@ begin
   Dependency_ForceX86 := False;
   Dependency_AddDotNet60Desktop;
   Result := True;
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+var 
+  ProgressPage: TOutputProgressWizardPage;
+  I, Step, Wait, ResultCode: Integer;
+begin
+  if CurStep = ssInstall then
+  begin
+    //MsgBox(ExpandConstant('{sys}') + '\sc.exe', mbInformation, MB_OK);
+    //MsgBox('stop ' + ExpandConstant('{#ServiceName}'), mbInformation, MB_OK);
+    Exec(ExpandConstant('{sys}') + '\sc.exe', 'stop ' + ExpandConstant('{#ServiceName}'), '', SW_HIDE, ewWaitUntilTerminated, ResultCode)
+
+    //thanks to https://stackoverflow.com/a/39827761
+//    Wait := 5000;
+//    Step := 100;
+//    ProgressPage :=
+//      CreateOutputProgressPage(
+//        WizardForm.PageNameLabel.Caption,
+//        WizardForm.PageDescriptionLabel.Caption);
+//    ProgressPage.SetText('Making sure the satellite service is stopped...', '');
+//    ProgressPage.SetProgress(0, Wait);
+//    ProgressPage.Show;
+//    try
+//      for I := 0 to Wait div Step do
+//      begin
+//        ProgressPage.SetProgress(I * Step, Wait);
+//        Sleep(Step);
+//      end;
+//    finally
+//      ProgressPage.Hide;
+//      ProgressPage.Free;
+//    end;
+  end;
 end;

--- a/src/HASS.Agent.Installer/InstallerScript-Service.iss
+++ b/src/HASS.Agent.Installer/InstallerScript-Service.iss
@@ -81,18 +81,18 @@ begin
   Result := True;
 end;
 
-procedure CurStepChanged(CurStep: TSetupStep);
-var 
-  ProgressPage: TOutputProgressWizardPage;
-  I, Step, Wait, ResultCode: Integer;
-begin
-  if CurStep = ssInstall then
-  begin
-    //MsgBox(ExpandConstant('{sys}') + '\sc.exe', mbInformation, MB_OK);
-    //MsgBox('stop ' + ExpandConstant('{#ServiceName}'), mbInformation, MB_OK);
-    Exec(ExpandConstant('{sys}') + '\sc.exe', 'stop ' + ExpandConstant('{#ServiceName}'), '', SW_HIDE, ewWaitUntilTerminated, ResultCode)
-
-    //thanks to https://stackoverflow.com/a/39827761
+//procedure CurStepChanged(CurStep: TSetupStep);
+//var 
+//  ProgressPage: TOutputProgressWizardPage;
+//  I, Step, Wait, ResultCode: Integer;
+//begin
+//  if CurStep = ssInstall then
+//  begin
+//    //MsgBox(ExpandConstant('{sys}') + '\sc.exe', mbInformation, MB_OK);
+//    //MsgBox('stop ' + ExpandConstant('{#ServiceName}'), mbInformation, MB_OK);
+//    Exec(ExpandConstant('{sys}') + '\sc.exe', 'stop ' + ExpandConstant('{#ServiceName}'), '', SW_HIDE, ewWaitUntilTerminated, ResultCode)
+//
+//    //thanks to https://stackoverflow.com/a/39827761
 //    Wait := 5000;
 //    Step := 100;
 //    ProgressPage :=
@@ -112,5 +112,5 @@ begin
 //      ProgressPage.Hide;
 //      ProgressPage.Free;
 //    end;
-  end;
-end;
+//  end;
+//end;

--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/Extensions/RpcExtensions.cs
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/Extensions/RpcExtensions.cs
@@ -110,6 +110,9 @@ namespace HASS.Agent.Satellite.Service.Extensions
                 EntityName = rpcConfiguredSensor.EntityName,
                 Name = rpcConfiguredSensor.Name,
                 AdvancedSettings = rpcConfiguredSensor.AdvancedSettings,
+                IgnoreAvailability = rpcConfiguredSensor.IgnoreAvailability,
+                ApplyRounding = rpcConfiguredSensor.ApplyRounding,
+                Round = rpcConfiguredSensor.RoundValue,
             };
 
             return configuredSensor;
@@ -152,6 +155,9 @@ namespace HASS.Agent.Satellite.Service.Extensions
                 Name = configuredSensor.Name ?? string.Empty,
                 EntityName = configuredSensor?.EntityName ?? string.Empty,
                 AdvancedSettings = configuredSensor?.AdvancedSettings ?? string.Empty,
+                IgnoreAvailability = configuredSensor?.IgnoreAvailability ?? false,
+                ApplyRounding = configuredSensor?.ApplyRounding ?? false,
+                RoundValue = configuredSensor?.Round ?? 0,
             };
 
             return configuredRpcSensor;

--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/RPC/Protos/hassagentsatellite.proto
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/RPC/Protos/hassagentsatellite.proto
@@ -135,6 +135,9 @@ message RpcConfiguredServerSensor {
   string name = 10;
   string entityName = 11;
   string advancedSettings = 12;
+  bool applyRounding = 13;
+  int32 roundValue = 14;
+  bool ignoreAvailability = 15;
 }
 
 message RpcConfiguredServerCommand {

--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/Settings/StoredSensors.cs
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/Settings/StoredSensors.cs
@@ -172,6 +172,9 @@ namespace HASS.Agent.Satellite.Service.Settings
                     break;
             }
 
+            if (abstractSensor != null)
+                abstractSensor.IgnoreAvailability = sensor.IgnoreAvailability;
+
             return abstractSensor;
         }
 
@@ -231,6 +234,7 @@ namespace HASS.Agent.Satellite.Service.Settings
                             Name = wmiSensor.Name,
                             Type = type,
                             UpdateInterval = wmiSensor.UpdateIntervalSeconds,
+                            IgnoreAvailability = wmiSensor.IgnoreAvailability,
                             Scope = wmiSensor.Scope,
                             Query = wmiSensor.Query,
                             ApplyRounding = wmiSensor.ApplyRounding,
@@ -249,6 +253,7 @@ namespace HASS.Agent.Satellite.Service.Settings
                             Name = namedWindowSensor.EntityName,
                             Type = type,
                             UpdateInterval = namedWindowSensor.UpdateIntervalSeconds,
+                            IgnoreAvailability = namedWindowSensor.IgnoreAvailability,
                             WindowName = namedWindowSensor.WindowName,
                             AdvancedSettings = namedWindowSensor.AdvancedSettings
                         };
@@ -264,6 +269,7 @@ namespace HASS.Agent.Satellite.Service.Settings
                             Name = performanceCounterSensor.EntityName,
                             Type = type,
                             UpdateInterval = performanceCounterSensor.UpdateIntervalSeconds,
+                            IgnoreAvailability = performanceCounterSensor.IgnoreAvailability,
                             Category = performanceCounterSensor.CategoryName,
                             Counter = performanceCounterSensor.CounterName,
                             Instance = performanceCounterSensor.InstanceName,
@@ -283,6 +289,7 @@ namespace HASS.Agent.Satellite.Service.Settings
                             Name = processActiveSensor.EntityName,
                             Type = type,
                             UpdateInterval = processActiveSensor.UpdateIntervalSeconds,
+                            IgnoreAvailability = processActiveSensor.IgnoreAvailability,
                             Query = processActiveSensor.ProcessName,
                             AdvancedSettings = processActiveSensor.AdvancedSettings
                         };
@@ -298,6 +305,7 @@ namespace HASS.Agent.Satellite.Service.Settings
                             Name = serviceStateSensor.EntityName,
                             Type = type,
                             UpdateInterval = serviceStateSensor.UpdateIntervalSeconds,
+                            IgnoreAvailability = serviceStateSensor.IgnoreAvailability,
                             Query = serviceStateSensor.ServiceName,
                             AdvancedSettings = serviceStateSensor.AdvancedSettings
                         };
@@ -313,6 +321,7 @@ namespace HASS.Agent.Satellite.Service.Settings
                             Name = powershellSensor.EntityName,
                             Type = type,
                             UpdateInterval = powershellSensor.UpdateIntervalSeconds,
+                            IgnoreAvailability = powershellSensor.IgnoreAvailability,
                             Query = powershellSensor.Command,
                             ApplyRounding = powershellSensor.ApplyRounding,
                             Round = powershellSensor.Round,
@@ -330,6 +339,7 @@ namespace HASS.Agent.Satellite.Service.Settings
                             Name = windowStateSensor.EntityName,
                             Type = type,
                             UpdateInterval = windowStateSensor.UpdateIntervalSeconds,
+                            IgnoreAvailability = windowStateSensor.IgnoreAvailability,
                             Query = windowStateSensor.ProcessName,
                             AdvancedSettings = windowStateSensor.AdvancedSettings
                         };
@@ -345,6 +355,7 @@ namespace HASS.Agent.Satellite.Service.Settings
                             Name = sensor.EntityName,
                             Type = type,
                             UpdateInterval = sensor.UpdateIntervalSeconds,
+                            IgnoreAvailability = sensor.IgnoreAvailability,
                             AdvancedSettings = sensor.AdvancedSettings
                         };
                     }

--- a/src/HASS.Agent/HASS.Agent/Extensions/RpcExtensions.cs
+++ b/src/HASS.Agent/HASS.Agent/Extensions/RpcExtensions.cs
@@ -111,6 +111,9 @@ namespace HASS.Agent.Extensions
                 EntityName = rpcConfiguredSensor.EntityName,
                 Name = rpcConfiguredSensor.Name,
                 AdvancedSettings = rpcConfiguredSensor.AdvancedSettings,
+                IgnoreAvailability = rpcConfiguredSensor.IgnoreAvailability,
+                ApplyRounding = rpcConfiguredSensor.ApplyRounding,
+                Round = rpcConfiguredSensor.RoundValue,
             };
 
             return configuredSensor;
@@ -153,6 +156,9 @@ namespace HASS.Agent.Extensions
                 Name = configuredSensor.Name ?? string.Empty,
                 EntityName = configuredSensor.EntityName ?? string.Empty,
                 AdvancedSettings = configuredSensor?.AdvancedSettings ?? string.Empty,
+                IgnoreAvailability = configuredSensor?.IgnoreAvailability ?? false,
+                ApplyRounding = configuredSensor?.ApplyRounding ?? false,
+                RoundValue = configuredSensor?.Round ?? 0,
             };
 
             return configuredRpcSensor;

--- a/src/HASS.Agent/HASS.Agent/Service/Protos/hassagentsatellite.proto
+++ b/src/HASS.Agent/HASS.Agent/Service/Protos/hassagentsatellite.proto
@@ -135,6 +135,9 @@ message RpcConfiguredServerSensor {
   string name = 10;
   string entityName = 11;
   string advancedSettings = 12;
+  bool applyRounding = 13;
+  int32 roundValue = 14;
+  bool ignoreAvailability = 15;
 }
 
 message RpcConfiguredServerCommand {


### PR DESCRIPTION
This PR fixes satellite sensors/commands:
- not saving advanced settings
- not saving round configuration
- not saving "ignore availability" option