### PR TITLE
Feature: tray webview command

### DIFF
--- a/src/HASS.Agent/HASS.Agent.Shared/Enums/CommandType.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Enums/CommandType.cs
@@ -121,6 +121,10 @@ namespace HASS.Agent.Shared.Enums
         [EnumMember(Value = "WebViewCommand")]
         WebViewCommand,
 
+        [LocalizedDescription("CommandType_TrayWebViewCommand", typeof(Languages))]
+        [EnumMember(Value = "TrayWebViewCommand")]
+        TrayWebViewCommand,
+
         [LocalizedDescription("CommandType_RadioCommand", typeof(Languages))]
         [EnumMember(Value = "RadioCommand")]
         RadioCommand

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.Designer.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.Designer.cs
@@ -1339,6 +1339,15 @@ namespace HASS.Agent.Shared.Resources.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to TrayWebView.
+        /// </summary>
+        internal static string CommandType_TrayWebViewCommand {
+            get {
+                return ResourceManager.GetString("CommandType_TrayWebViewCommand", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to WebView.
         /// </summary>
         internal static string CommandType_WebViewCommand {

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.de.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.de.resx
@@ -3364,4 +3364,7 @@ Willst Du den Runtime Installer herunterladen?</value>
   <data name="CommandType_SetAudioInputCommand" xml:space="preserve">
     <value>Legen Sie den Audioeingabebefehl fest</value>
   </data>
+  <data name="CommandType_TrayWebViewCommand" xml:space="preserve">
+    <value>TrayWebView</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.en.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.en.resx
@@ -3240,4 +3240,7 @@ Do you want to download the runtime installer?</value>
   <data name="CommandType_SetAudioInputCommand" xml:space="preserve">
     <value>SetAudioInputCommand</value>
   </data>
+  <data name="CommandType_TrayWebViewCommand" xml:space="preserve">
+    <value>TrayWebView</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.es.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.es.resx
@@ -3240,4 +3240,7 @@ Oculta, Maximizada, Minimizada, Normal y Desconocida.</value>
   <data name="CommandType_SetAudioInputCommand" xml:space="preserve">
     <value>Establecer comando de entrada de audio</value>
   </data>
+  <data name="CommandType_TrayWebViewCommand" xml:space="preserve">
+    <value>Vista web de la bandeja</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.fr.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.fr.resx
@@ -3273,4 +3273,7 @@ Do you want to download the runtime installer?</value>
   <data name="CommandType_SetAudioInputCommand" xml:space="preserve">
     <value>Définir la commande d'entrée audio</value>
   </data>
+  <data name="CommandType_TrayWebViewCommand" xml:space="preserve">
+    <value>Vue Web de la barre d'état</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.nl.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.nl.resx
@@ -3262,4 +3262,7 @@ Wil je de runtime installatie downloaden?</value>
   <data name="CommandType_SetAudioInputCommand" xml:space="preserve">
     <value>Stel het audio-invoercommando in</value>
   </data>
+  <data name="CommandType_TrayWebViewCommand" xml:space="preserve">
+    <value>TrayWebView</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.pl.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.pl.resx
@@ -3350,4 +3350,7 @@ Czy chcesz pobrać plik instalacyjny?</value>
   <data name="CommandType_SetAudioInputCommand" xml:space="preserve">
     <value>Ustaw wejście audio</value>
   </data>
+  <data name="CommandType_TrayWebViewCommand" xml:space="preserve">
+    <value>TrayWebView</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.pt-br.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.pt-br.resx
@@ -3287,4 +3287,7 @@ Deseja baixar o Microsoft WebView2 runtime?</value>
   <data name="CommandType_SetAudioInputCommand" xml:space="preserve">
     <value>Definir comando de entrada de áudio</value>
   </data>
+  <data name="CommandType_TrayWebViewCommand" xml:space="preserve">
+    <value>BandejaWebView</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.resx
@@ -3223,4 +3223,7 @@ Do you want to download the runtime installer?</value>
   <data name="CommandType_SetAudioInputCommand" xml:space="preserve">
     <value>SetAudioInputCommand</value>
   </data>
+  <data name="CommandType_TrayWebViewCommand" xml:space="preserve">
+    <value>TrayWebView</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.ru.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.ru.resx
@@ -3308,4 +3308,7 @@ Home Assistant.
   <data name="CommandType_SetAudioInputCommand" xml:space="preserve">
     <value>Установить команду аудиовхода</value>
   </data>
+  <data name="CommandType_TrayWebViewCommand" xml:space="preserve">
+    <value>TrayWebView</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.sl.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.sl.resx
@@ -3389,4 +3389,7 @@ Ali želite prenesti runtime installer?</value>
   <data name="CommandType_SetAudioInputCommand" xml:space="preserve">
     <value>Nastavite ukaz za zvočni vhod</value>
   </data>
+  <data name="CommandType_TrayWebViewCommand" xml:space="preserve">
+    <value>TrayWebView</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.tr.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.tr.resx
@@ -2847,4 +2847,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
   <data name="CommandType_SetAudioInputCommand" xml:space="preserve">
     <value>Ses Giriş Komutunu Ayarla</value>
   </data>
+  <data name="CommandType_TrayWebViewCommand" xml:space="preserve">
+    <value>TepsiWebGörünümü</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Commands/CommandsManager.cs
+++ b/src/HASS.Agent/HASS.Agent/Commands/CommandsManager.cs
@@ -525,6 +525,14 @@ namespace HASS.Agent.Commands
 
             // =================================
 
+            commandInfoCard = new CommandInfoCard(CommandType.TrayWebViewCommand,
+                Languages.CommandsManager_TrayWebViewCommandDescription,
+                true, false, false);
+
+            CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
+
+            // =================================
+
             commandInfoCard = new CommandInfoCard(CommandType.RadioCommand,
                 Languages.CommandsManager_RadioCommandDescription,
                 true, false, true);

--- a/src/HASS.Agent/HASS.Agent/Forms/Main.cs
+++ b/src/HASS.Agent/HASS.Agent/Forms/Main.cs
@@ -961,16 +961,7 @@ namespace HASS.Agent.Forms
                 return;
             }
 
-            // prepare the webview
-            var webView = new WebViewInfo
-            {
-                Url = Variables.AppSettings.TrayIconWebViewUrl,
-                Height = Variables.AppSettings.TrayIconWebViewHeight,
-                Width = Variables.AppSettings.TrayIconWebViewWidth,
-            };
-
-            // show it
-            HelperFunctions.LaunchTrayIconWebView(webView);
+            HelperFunctions.LaunchTrayIconWebView();
         }
 
         private async void PbDonate_Click(object sender, EventArgs e)

--- a/src/HASS.Agent/HASS.Agent/Forms/WebView.cs
+++ b/src/HASS.Agent/HASS.Agent/Forms/WebView.cs
@@ -274,10 +274,11 @@ namespace HASS.Agent.Forms
                     return;
                 }
 
+                Opacity = 0;
+
                 // do we need to stay open?
                 if (_isTrayIcon)
                 {
-                    Opacity = 0;
                     e.Cancel = true;
                     return;
                 }

--- a/src/HASS.Agent/HASS.Agent/Functions/HelperFunctions.cs
+++ b/src/HASS.Agent/HASS.Agent/Functions/HelperFunctions.cs
@@ -531,6 +531,8 @@ namespace HASS.Agent.Functions
 
                 var webView = new WebView(webViewInfo);
                 webView.Opacity = 0;
+
+                Variables.TrayIconWebView = webView;
                 webView.Show();
             }));
         }
@@ -562,12 +564,12 @@ namespace HASS.Agent.Functions
             // check for known OK languages
             if (KnownOkInputLanguage.ContainsKey(inputLanguage))
                 return false;
-            
+
             // check for known NOT OK languages
             var germanLayoutDetected = false;
-            foreach(InputLanguage language in InputLanguage.InstalledInputLanguages)
+            foreach (InputLanguage language in InputLanguage.InstalledInputLanguages)
             {
-                if(language.Culture.TwoLetterISOLanguageName == "de")
+                if (language.Culture.TwoLetterISOLanguageName == "de")
                 {
                     germanLayoutDetected = true;
                     break;

--- a/src/HASS.Agent/HASS.Agent/Functions/HelperFunctions.cs
+++ b/src/HASS.Agent/HASS.Agent/Functions/HelperFunctions.cs
@@ -447,13 +447,29 @@ namespace HASS.Agent.Functions
             Variables.MainForm.Invoke(new MethodInvoker(delegate
             {
                 // optionally close an existing one
-                if (Variables.TrayIconWebView != null) Variables.TrayIconWebView.ForceClose();
+                Variables.TrayIconWebView?.ForceClose();
 
                 // bind the new one
                 Variables.TrayIconWebView = new WebView(webViewInfo);
                 Variables.TrayIconWebView.Opacity = 0;
                 Variables.TrayIconWebView.Show();
             }));
+        }
+
+        /// <summary>
+        /// Shows the user-configured webview form near the tray icon
+        /// </summary>
+        /// <param name="webViewInfo"></param>
+        internal static void LaunchTrayIconWebView()
+        {
+            var webView = new WebViewInfo
+            {
+                Url = Variables.AppSettings.TrayIconWebViewUrl,
+                Height = Variables.AppSettings.TrayIconWebViewHeight,
+                Width = Variables.AppSettings.TrayIconWebViewWidth,
+            };
+
+            LaunchTrayIconWebView(webView);
         }
 
         /// <summary>
@@ -491,7 +507,8 @@ namespace HASS.Agent.Functions
             Variables.MainForm.Invoke(new MethodInvoker(delegate
             {
                 // make sure it's ready
-                if (Variables.TrayIconWebView == null || Variables.TrayIconWebView.IsDisposed) PrepareTrayIconWebView();
+                if (Variables.TrayIconWebView == null || Variables.TrayIconWebView.IsDisposed)
+                    PrepareTrayIconWebView();
 
                 // show it
                 Variables.TrayIconWebView?.MakeVisible();

--- a/src/HASS.Agent/HASS.Agent/HomeAssistant/Commands/InternalCommands/TrayWebViewCommand.cs
+++ b/src/HASS.Agent/HASS.Agent/HomeAssistant/Commands/InternalCommands/TrayWebViewCommand.cs
@@ -1,0 +1,58 @@
+﻿using HASS.Agent.Functions;
+using HASS.Agent.Models.Internal;
+using HASS.Agent.Resources.Localization;
+using HASS.Agent.Shared.Enums;
+using HASS.Agent.Shared.HomeAssistant.Commands;
+using Newtonsoft.Json;
+using Serilog;
+using Syncfusion.Windows.Forms;
+
+namespace HASS.Agent.HomeAssistant.Commands.InternalCommands
+{
+    internal class TrayWebViewCommand : InternalCommand
+    {
+        private const string DefaultName = "traywebview";
+
+        internal TrayWebViewCommand(string entityName = DefaultName, string name = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(entityName ?? DefaultName, name ?? null, string.Empty, entityType, id)
+        {
+            State = "OFF";
+        }
+
+        public override void TurnOn()
+        {
+            if (string.IsNullOrEmpty(Variables.AppSettings.TrayIconWebViewUrl))
+            {
+                Log.Warning("[TRAYWEBVIEW] [{name}] No webview URL is configured in 'Configuration -> Tray Icon'", EntityName);
+                return;
+            }
+
+            HelperFunctions.LaunchTrayIconWebView();
+        }
+
+        public override void TurnOff()
+        {
+            Variables.MainForm.Invoke(() =>
+            {
+                if(Variables.TrayIconWebView == null)
+                    return;
+
+                Variables.TrayIconWebView.Opacity = 0;
+
+                if (!Variables.AppSettings.TrayIconWebViewBackgroundLoading) { 
+                    Variables.TrayIconWebView.ForceClose();
+                    Variables.TrayIconWebView.Dispose();
+                }
+            });
+        }
+
+        public override string GetState()
+        {
+            return Variables.TrayIconWebView != null && Variables.TrayIconWebView.Opacity != 0 ? "ON" : "OFF";
+        }
+
+        public override void TurnOnWithAction(string action)
+        {
+            Log.Warning("[TRAYWEBVIEW] [{name}] Launching with action is not supported", EntityName);
+        }
+    }
+}

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.Designer.cs
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.Designer.cs
@@ -716,6 +716,15 @@ namespace HASS.Agent.Resources.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Shows / hides the Tray Icon Web View.
+        /// </summary>
+        internal static string CommandsManager_TrayWebViewCommandDescription {
+            get {
+                return ResourceManager.GetString("CommandsManager_TrayWebViewCommandDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Shows a window with the provided URL.
         ///
         ///This differs from the &apos;LaunchUrl&apos; command in that it doesn&apos;t load a full-fledged browser, just the provided URL in its own window.

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.Designer.cs
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.Designer.cs
@@ -717,6 +717,7 @@ namespace HASS.Agent.Resources.Localization {
         
         /// <summary>
         ///   Looks up a localized string similar to Shows / hides the Tray Icon Web View.
+        ///Requires it to be configured in &quot;Configuration -&gt; Tray Icon&quot;.
         /// </summary>
         internal static string CommandsManager_TrayWebViewCommandDescription {
             get {

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.de.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.de.resx
@@ -3515,4 +3515,8 @@ Hinweis: Bei Verwendung im Satellitendienst werden keine Userspace-Anwendungen e
   <data name="AdvancedSensorConfig_Warning" xml:space="preserve">
     <value>Achtung: Das Hinzufügen der folgenden Einstellungen (Überschreibungen) kann zur Beschädigung des Sensors führen. Gehen Sie daher vorsichtig vor!</value>
   </data>
+  <data name="CommandsManager_TrayWebViewCommandDescription" xml:space="preserve">
+    <value>Zeigt/verbirgt das Tray-Icon-Web-View.
+Muss unter „Konfiguration -&gt; Tray-Icon“ konfiguriert werden.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.en.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.en.resx
@@ -3421,6 +3421,7 @@ Note: if used in the satellite service, it won't detect userspace applications.<
     <value>Advanced Settings</value>
   </data>
   <data name="CommandsManager_TrayWebViewCommandDescription" xml:space="preserve">
-    <value>Shows / hides the Tray Icon Web View</value>
+    <value>Shows / hides the Tray Icon Web View.
+Requires it to be configured in "Configuration -&gt; Tray Icon"</value>
   </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.en.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.en.resx
@@ -3420,4 +3420,7 @@ Note: if used in the satellite service, it won't detect userspace applications.<
   <data name="AdvancedSensorConfig_Title" xml:space="preserve">
     <value>Advanced Settings</value>
   </data>
+  <data name="CommandsManager_TrayWebViewCommandDescription" xml:space="preserve">
+    <value>Shows / hides the Tray Icon Web View</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.es.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.es.resx
@@ -3391,4 +3391,8 @@ Nota: si se usa en el servicio satelital, no detectará aplicaciones del espacio
   <data name="AdvancedSensorConfig_Warning" xml:space="preserve">
     <value>Advertencia, agregar las siguientes configuraciones (anulaciones) puede dañar el sensor, ¡úselo con precaución!</value>
   </data>
+  <data name="CommandsManager_TrayWebViewCommandDescription" xml:space="preserve">
+    <value>Muestra u oculta la vista web del icono de la bandeja.
+Requiere que se configure en "Configuración -&gt; Icono de la bandeja"</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.fr.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.fr.resx
@@ -3424,4 +3424,8 @@ Remarque : s'il est utilisé dans le service satellite, il ne détectera pas les
   <data name="AdvancedSensorConfig_Warning" xml:space="preserve">
     <value>Attention, l'ajout des paramètres suivants (remplacements) peut casser le capteur, à utiliser avec prudence !</value>
   </data>
+  <data name="CommandsManager_TrayWebViewCommandDescription" xml:space="preserve">
+    <value>Affiche/masque l'affichage Web de l'icône de la barre d'état système.
+Nécessite sa configuration dans « Configuration -&gt; Icône de la barre d'état système »</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.nl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.nl.resx
@@ -3412,4 +3412,8 @@ Opmerking: indien gebruikt in de satellietdienst, zal het geen gebruikersruimtet
   <data name="AdvancedSensorConfig_Warning" xml:space="preserve">
     <value>Waarschuwing: het toevoegen van de volgende instellingen (overschrijvingen) kan de sensor kapot maken, wees voorzichtig!</value>
   </data>
+  <data name="CommandsManager_TrayWebViewCommandDescription" xml:space="preserve">
+    <value>Toont/verbergt het Tray Icon Web View.
+Vereist dat het geconfigureerd is in "Configuratie -&gt; Tray Icon"</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pl.resx
@@ -3501,4 +3501,8 @@ Uwaga: jeśli jest używany w usłudze satelitarnej, nie wykryje aplikacji przes
   <data name="AdvancedSensorConfig_Warning" xml:space="preserve">
     <value>Uwaga, dodanie następujących ustawień (nadpisań) może spowodować uszkodzenie czujnika, zachowaj ostrożność!</value>
   </data>
+  <data name="CommandsManager_TrayWebViewCommandDescription" xml:space="preserve">
+    <value>Pokazuje/ukrywa Tray Icon Web View.
+Wymaga konfiguracji w „Configuration -&gt; Tray Icon”</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pt-br.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pt-br.resx
@@ -3437,4 +3437,8 @@ Nota: se usado no serviço de satélite, não detectará aplicações no espaço
   <data name="AdvancedSensorConfig_Warning" xml:space="preserve">
     <value>Atenção, adicionar as seguintes configurações (substituições) pode quebrar o sensor, use com cuidado!</value>
   </data>
+  <data name="CommandsManager_TrayWebViewCommandDescription" xml:space="preserve">
+    <value>Mostra/oculta o Tray Icon Web View.
+Requer que seja configurado em "Configuration -&gt; Tray Icon"</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.resx
@@ -3414,6 +3414,7 @@ Requires audio device name as a payload.</value>
     <value>Advanced Settings</value>
   </data>
   <data name="CommandsManager_TrayWebViewCommandDescription" xml:space="preserve">
-    <value>Shows / hides the Tray Icon Web View</value>
+    <value>Shows / hides the Tray Icon Web View.
+Requires it to be configured in "Configuration -&gt; Tray Icon"</value>
   </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.resx
@@ -3413,4 +3413,7 @@ Requires audio device name as a payload.</value>
   <data name="AdvancedSensorConfig_Title" xml:space="preserve">
     <value>Advanced Settings</value>
   </data>
+  <data name="CommandsManager_TrayWebViewCommandDescription" xml:space="preserve">
+    <value>Shows / hides the Tray Icon Web View</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.ru.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.ru.resx
@@ -3460,4 +3460,8 @@ Home Assistant.
   <data name="AdvancedSensorConfig_Warning" xml:space="preserve">
     <value>Внимание! Добавление следующих настроек (переопределений) может привести к поломке датчика, используйте с осторожностью!</value>
   </data>
+  <data name="CommandsManager_TrayWebViewCommandDescription" xml:space="preserve">
+    <value>Показывает/скрывает веб-представление значка в трее.
+Требует настройки в разделе «Конфигурация -&gt; Значок в трее»</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.sl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.sl.resx
@@ -3540,4 +3540,8 @@ Opomba: če se uporablja v satelitski storitvi, ne bo zaznal aplikacij uporabni�
   <data name="AdvancedSensorConfig_Warning" xml:space="preserve">
     <value>Opozorilo, dodajanje naslednjih nastavitev (preglasitev) lahko pokvari senzor, uporabljajte previdno!</value>
   </data>
+  <data name="CommandsManager_TrayWebViewCommandDescription" xml:space="preserve">
+    <value>Prikaže/skrije spletni pogled ikone pladnja.
+Zahteva, da je konfiguriran v "Konfiguracija -&gt; Ikona pladnja"</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.tr.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.tr.resx
@@ -3007,4 +3007,8 @@ Not: Uydu hizmetinde kullanılırsa kullanıcı alanı uygulamalarını algılam
   <data name="AdvancedSensorConfig_Warning" xml:space="preserve">
     <value>Uyarı, aşağıdaki ayarların (geçersiz kılmaların) eklenmesi sensörü bozabilir, dikkatli kullanın!</value>
   </data>
+  <data name="CommandsManager_TrayWebViewCommandDescription" xml:space="preserve">
+    <value>Tepsi Simgesi Web Görünümünü gösterir/gizler.
+"Yapılandırma -&gt; Tepsi Simgesi"nde yapılandırılması gerekir</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Settings/StoredCommands.cs
+++ b/src/HASS.Agent/HASS.Agent/Settings/StoredCommands.cs
@@ -160,6 +160,9 @@ namespace HASS.Agent.Settings
                 case CommandType.WebViewCommand:
                     abstractCommand = new WebViewCommand(command.EntityName, command.Name, command.Command, command.EntityType, command.Id.ToString());
                     break;
+                case CommandType.TrayWebViewCommand:
+                    abstractCommand = new TrayWebViewCommand(command.EntityName, command.Name, command.EntityType, command.Id.ToString());
+                    break;
                 case CommandType.MonitorSleepCommand:
                     abstractCommand = new MonitorSleepCommand(command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;


### PR DESCRIPTION
This PR adds feature requested via https://github.com/hass-agent/HASS.Agent/issues/116 - a command (best working as switch) that allows to show/hide the configured tray web view.