### PR TITLE
Feature: quick action button press

### DIFF
--- a/src/HASS.Agent/HASS.Agent.Shared/Enums/HassAction.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Enums/HassAction.cs
@@ -50,6 +50,11 @@ namespace HASS.Agent.Shared.Enums
         [LocalizedDescription("HassAction_Trigger", typeof(Languages))]
         [Category("trigger")]
         [EnumMember(Value = "Trigger")]
-        Trigger
+        Trigger,
+
+        [LocalizedDescription("HassAction_Press", typeof(Languages))]
+        [Category("press")]
+        [EnumMember(Value = "Press")]
+        Press
     }
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/Enums/HassDomain.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Enums/HassDomain.cs
@@ -57,6 +57,11 @@ namespace HASS.Agent.Shared.Enums
         [LocalizedDescription("HassDomain_Switch", typeof(Languages))]
         [Category("switch")]
         [EnumMember(Value = "Switch")]
-        Switch
+        Switch,
+
+        [LocalizedDescription("HassDomain_Button", typeof(Languages))]
+        [Category("button")]
+        [EnumMember(Value = "Button")]
+        Button
     }
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.Designer.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.Designer.cs
@@ -3363,6 +3363,15 @@ namespace HASS.Agent.Shared.Resources.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Press.
+        /// </summary>
+        internal static string HassAction_Press {
+            get {
+                return ResourceManager.GetString("HassAction_Press", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Stop.
         /// </summary>
         internal static string HassAction_Stop {
@@ -3476,6 +3485,15 @@ namespace HASS.Agent.Shared.Resources.Localization {
         internal static string HassDomain_Automation {
             get {
                 return ResourceManager.GetString("HassDomain_Automation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Button.
+        /// </summary>
+        internal static string HassDomain_Button {
+            get {
+                return ResourceManager.GetString("HassDomain_Button", resourceCulture);
             }
         }
         

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.de.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.de.resx
@@ -3370,4 +3370,10 @@ Willst Du den Runtime Installer herunterladen?</value>
   <data name="HassAction_Trigger" xml:space="preserve">
     <value>Auslösen</value>
   </data>
+  <data name="HassDomain_Button" xml:space="preserve">
+    <value>Knopf</value>
+  </data>
+  <data name="HassAction_Press" xml:space="preserve">
+    <value>Presse</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.en.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.en.resx
@@ -3246,4 +3246,10 @@ Do you want to download the runtime installer?</value>
   <data name="HassAction_Trigger" xml:space="preserve">
     <value>Trigger</value>
   </data>
+  <data name="HassAction_Press" xml:space="preserve">
+    <value>Press</value>
+  </data>
+  <data name="HassDomain_Button" xml:space="preserve">
+    <value>Button</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.es.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.es.resx
@@ -3246,4 +3246,10 @@ Oculta, Maximizada, Minimizada, Normal y Desconocida.</value>
   <data name="HassAction_Trigger" xml:space="preserve">
     <value>Desencadenar</value>
   </data>
+  <data name="HassDomain_Button" xml:space="preserve">
+    <value>Botón</value>
+  </data>
+  <data name="HassAction_Press" xml:space="preserve">
+    <value>Prensa</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.fr.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.fr.resx
@@ -3279,4 +3279,10 @@ Do you want to download the runtime installer?</value>
   <data name="HassAction_Trigger" xml:space="preserve">
     <value>Déclencher</value>
   </data>
+  <data name="HassDomain_Button" xml:space="preserve">
+    <value>Knop</value>
+  </data>
+  <data name="HassAction_Press" xml:space="preserve">
+    <value>Presse</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.nl.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.nl.resx
@@ -3268,4 +3268,10 @@ Wil je de runtime installatie downloaden?</value>
   <data name="HassAction_Trigger" xml:space="preserve">
     <value>Activering</value>
   </data>
+  <data name="HassDomain_Button" xml:space="preserve">
+    <value>Knop</value>
+  </data>
+  <data name="HassAction_Press" xml:space="preserve">
+    <value>Pers</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.pl.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.pl.resx
@@ -3356,4 +3356,10 @@ Czy chcesz pobrać plik instalacyjny?</value>
   <data name="HassAction_Trigger" xml:space="preserve">
     <value>Wyzwól</value>
   </data>
+  <data name="HassDomain_Button" xml:space="preserve">
+    <value>Przycisk</value>
+  </data>
+  <data name="HassAction_Press" xml:space="preserve">
+    <value>Naciśnij</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.pt-br.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.pt-br.resx
@@ -3293,4 +3293,10 @@ Deseja baixar o Microsoft WebView2 runtime?</value>
   <data name="HassAction_Trigger" xml:space="preserve">
     <value>Acionar</value>
   </data>
+  <data name="HassDomain_Button" xml:space="preserve">
+    <value>Botão</value>
+  </data>
+  <data name="HassAction_Press" xml:space="preserve">
+    <value>Imprensa</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.resx
@@ -3229,4 +3229,10 @@ Do you want to download the runtime installer?</value>
   <data name="HassAction_Trigger" xml:space="preserve">
     <value>Trigger</value>
   </data>
+  <data name="HassAction_Press" xml:space="preserve">
+    <value>Press</value>
+  </data>
+  <data name="HassDomain_Button" xml:space="preserve">
+    <value>Button</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.ru.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.ru.resx
@@ -3314,4 +3314,10 @@ Home Assistant.
   <data name="HassAction_Trigger" xml:space="preserve">
     <value>Вызывать</value>
   </data>
+  <data name="HassDomain_Button" xml:space="preserve">
+    <value>Button</value>
+  </data>
+  <data name="HassAction_Press" xml:space="preserve">
+    <value>Нажимать</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.sl.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.sl.resx
@@ -3395,4 +3395,10 @@ Ali želite prenesti runtime installer?</value>
   <data name="HassAction_Trigger" xml:space="preserve">
     <value>Sprožilec</value>
   </data>
+  <data name="HassDomain_Button" xml:space="preserve">
+    <value>Gumb</value>
+  </data>
+  <data name="HassAction_Press" xml:space="preserve">
+    <value>Pritisnite</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.tr.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.tr.resx
@@ -2853,4 +2853,10 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
   <data name="HassAction_Trigger" xml:space="preserve">
     <value>Tetiklemek</value>
   </data>
+  <data name="HassDomain_Button" xml:space="preserve">
+    <value>Buton</value>
+  </data>
+  <data name="HassAction_Press" xml:space="preserve">
+    <value>Basmak</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Forms/QuickActions/QuickActionsMod.cs
+++ b/src/HASS.Agent/HASS.Agent/Forms/QuickActions/QuickActionsMod.cs
@@ -388,6 +388,14 @@ namespace HASS.Agent.Forms.QuickActions
                         CbEntity.Items.Add(item.EntityName);
                     }
                     break;
+
+                case HassDomain.Button:
+                    foreach (var item in HassApiManager.ButtonList)
+                    {
+                        CbEntity.AutoCompleteCustomSource.Add(item);
+                        CbEntity.Items.Add(item);
+                    }
+                    break;
             }
         }
 

--- a/src/HASS.Agent/HASS.Agent/HomeAssistant/HassApiManager.cs
+++ b/src/HASS.Agent/HASS.Agent/HomeAssistant/HassApiManager.cs
@@ -43,6 +43,7 @@ namespace HASS.Agent.HomeAssistant
         internal static List<string> CoverList = new();
         internal static List<string> ClimateList = new();
         internal static List<string> MediaPlayerList = new();
+        internal static List<string> ButtonList = new();
 
         private static readonly string[] OnStates = { "on", "playing", "open", "opening" };
         private static readonly string[] OffStates = { "off", "idle", "paused", "stopped", "closed", "closing" };
@@ -389,6 +390,7 @@ namespace HASS.Agent.HomeAssistant
                 CoverList.Clear();
                 ClimateList.Clear();
                 MediaPlayerList.Clear();
+                ButtonList.Clear();
             }
 
             try
@@ -402,6 +404,7 @@ namespace HASS.Agent.HomeAssistant
                 await LoadDomain("cover", CoverList);
                 await LoadDomain("climate", ClimateList);
                 await LoadDomain("media_player", MediaPlayerList);
+                await LoadDomain("button", ButtonList);
 
                 if (ManagerStatus != HassManagerStatus.Failed)
                     return;

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.Designer.cs
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.Designer.cs
@@ -3672,6 +3672,15 @@ namespace HASS.Agent.Resources.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        internal static string HassAction_Press {
+            get {
+                return ResourceManager.GetString("HassAction_Press", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Stop.
         /// </summary>
         internal static string HassAction_Stop {
@@ -3785,6 +3794,15 @@ namespace HASS.Agent.Resources.Localization {
         internal static string HassDomain_Automation {
             get {
                 return ResourceManager.GetString("HassDomain_Automation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Button.
+        /// </summary>
+        internal static string HassDomain_Button {
+            get {
+                return ResourceManager.GetString("HassDomain_Button", resourceCulture);
             }
         }
         

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.Designer.cs
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.Designer.cs
@@ -3672,7 +3672,7 @@ namespace HASS.Agent.Resources.Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to Press.
         /// </summary>
         internal static string HassAction_Press {
             get {

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.de.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.de.resx
@@ -3522,4 +3522,10 @@ Muss unter „Konfiguration -&gt; Tray-Icon“ konfiguriert werden.</value>
   <data name="HassAction_Trigger" xml:space="preserve">
     <value>Auslösen</value>
   </data>
+  <data name="HassDomain_Button" xml:space="preserve">
+    <value>Knopf</value>
+  </data>
+  <data name="HassAction_Press" xml:space="preserve">
+    <value>Presse</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.en.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.en.resx
@@ -3430,4 +3430,7 @@ Requires it to be configured in "Configuration -&gt; Tray Icon"</value>
   <data name="HassDomain_Button" xml:space="preserve">
     <value>Button</value>
   </data>
+  <data name="HassAction_Press" xml:space="preserve">
+    <value>Press</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.en.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.en.resx
@@ -3427,4 +3427,7 @@ Requires it to be configured in "Configuration -&gt; Tray Icon"</value>
   <data name="HassAction_Trigger" xml:space="preserve">
     <value>Trigger</value>
   </data>
+  <data name="HassDomain_Button" xml:space="preserve">
+    <value>Button</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.es.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.es.resx
@@ -3398,4 +3398,10 @@ Requiere que se configure en "Configuración -&gt; Icono de la bandeja"</value>
   <data name="HassAction_Trigger" xml:space="preserve">
     <value>Desencadenar</value>
   </data>
+  <data name="HassDomain_Button" xml:space="preserve">
+    <value>Botón</value>
+  </data>
+  <data name="HassAction_Press" xml:space="preserve">
+    <value>Prensa</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.fr.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.fr.resx
@@ -3431,4 +3431,10 @@ Nécessite sa configuration dans « Configuration -&gt; Icône de la barre d'ét
   <data name="HassAction_Trigger" xml:space="preserve">
     <value>Déclencher</value>
   </data>
+  <data name="HassDomain_Button" xml:space="preserve">
+    <value>Knop</value>
+  </data>
+  <data name="HassAction_Press" xml:space="preserve">
+    <value>Presse</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.nl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.nl.resx
@@ -3419,4 +3419,10 @@ Vereist dat het geconfigureerd is in "Configuratie -&gt; Tray Icon"</value>
   <data name="HassAction_Trigger" xml:space="preserve">
     <value>Activering</value>
   </data>
+  <data name="HassDomain_Button" xml:space="preserve">
+    <value>Knop</value>
+  </data>
+  <data name="HassAction_Press" xml:space="preserve">
+    <value>Pers</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pl.resx
@@ -3508,4 +3508,10 @@ Wymaga konfiguracji w „Configuration -&gt; Tray Icon”</value>
   <data name="HassAction_Trigger" xml:space="preserve">
     <value>Wyzwól</value>
   </data>
+  <data name="HassDomain_Button" xml:space="preserve">
+    <value>Przycisk</value>
+  </data>
+  <data name="HassAction_Press" xml:space="preserve">
+    <value>Naciśnij</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pt-br.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pt-br.resx
@@ -3444,4 +3444,10 @@ Requer que seja configurado em "Configuration -&gt; Tray Icon"</value>
   <data name="HassAction_Trigger" xml:space="preserve">
     <value>Acionar</value>
   </data>
+  <data name="HassDomain_Button" xml:space="preserve">
+    <value>Botão</value>
+  </data>
+  <data name="HassAction_Press" xml:space="preserve">
+    <value>Imprensa</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.resx
@@ -3421,7 +3421,7 @@ Requires it to be configured in "Configuration -&gt; Tray Icon"</value>
     <value>Trigger</value>
   </data>
   <data name="HassAction_Press" xml:space="preserve">
-    <value></value>
+    <value>Press</value>
   </data>
   <data name="HassDomain_Button" xml:space="preserve">
     <value>Button</value>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.resx
@@ -3420,4 +3420,10 @@ Requires it to be configured in "Configuration -&gt; Tray Icon"</value>
   <data name="HassAction_Trigger" xml:space="preserve">
     <value>Trigger</value>
   </data>
+  <data name="HassAction_Press" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="HassDomain_Button" xml:space="preserve">
+    <value>Button</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.ru.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.ru.resx
@@ -3467,4 +3467,10 @@ Home Assistant.
   <data name="HassAction_Trigger" xml:space="preserve">
     <value>Вызывать</value>
   </data>
+  <data name="HassDomain_Button" xml:space="preserve">
+    <value>Button</value>
+  </data>
+  <data name="HassAction_Press" xml:space="preserve">
+    <value>Нажимать</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.sl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.sl.resx
@@ -3547,4 +3547,10 @@ Zahteva, da je konfiguriran v "Konfiguracija -&gt; Ikona pladnja"</value>
   <data name="HassAction_Trigger" xml:space="preserve">
     <value>Sprožilec</value>
   </data>
+  <data name="HassDomain_Button" xml:space="preserve">
+    <value>Gumb</value>
+  </data>
+  <data name="HassAction_Press" xml:space="preserve">
+    <value>Pritisnite</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.tr.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.tr.resx
@@ -3014,4 +3014,10 @@ Not: Uydu hizmetinde kullanılırsa kullanıcı alanı uygulamalarını algılam
   <data name="HassAction_Trigger" xml:space="preserve">
     <value>Tetiklemek</value>
   </data>
+  <data name="HassDomain_Button" xml:space="preserve">
+    <value>Buton</value>
+  </data>
+  <data name="HassAction_Press" xml:space="preserve">
+    <value>Basmak</value>
+  </data>
 </root>


### PR DESCRIPTION
This PR adds feature requested via https://github.com/hass-agent/HASS.Agent/issues/118 which allows to press Home Assistant buttons via quick actions.

![vu7i3M](https://github.com/user-attachments/assets/411bdde6-8a4d-40bc-89e9-b9436256fb75)
