### PR TITLE
Fix: added additional service stop logic

### DIFF
--- a/src/HASS.Agent.Installer/InstallerScript-Service.iss
+++ b/src/HASS.Agent.Installer/InstallerScript-Service.iss
@@ -81,36 +81,34 @@ begin
   Result := True;
 end;
 
-//procedure CurStepChanged(CurStep: TSetupStep);
-//var 
-//  ProgressPage: TOutputProgressWizardPage;
-//  I, Step, Wait, ResultCode: Integer;
-//begin
-//  if CurStep = ssInstall then
-//  begin
-//    //MsgBox(ExpandConstant('{sys}') + '\sc.exe', mbInformation, MB_OK);
-//    //MsgBox('stop ' + ExpandConstant('{#ServiceName}'), mbInformation, MB_OK);
-//    Exec(ExpandConstant('{sys}') + '\sc.exe', 'stop ' + ExpandConstant('{#ServiceName}'), '', SW_HIDE, ewWaitUntilTerminated, ResultCode)
-//
-//    //thanks to https://stackoverflow.com/a/39827761
-//    Wait := 5000;
-//    Step := 100;
-//    ProgressPage :=
-//      CreateOutputProgressPage(
-//        WizardForm.PageNameLabel.Caption,
-//        WizardForm.PageDescriptionLabel.Caption);
-//    ProgressPage.SetText('Making sure the satellite service is stopped...', '');
-//    ProgressPage.SetProgress(0, Wait);
-//    ProgressPage.Show;
-//    try
-//      for I := 0 to Wait div Step do
-//      begin
-//        ProgressPage.SetProgress(I * Step, Wait);
-//        Sleep(Step);
-//      end;
-//    finally
-//      ProgressPage.Hide;
-//      ProgressPage.Free;
-//    end;
-//  end;
-//end;
+procedure CurStepChanged(CurStep: TSetupStep);
+var 
+  ProgressPage: TOutputProgressWizardPage;
+  I, Step, Wait, ResultCode: Integer;
+begin
+  if CurStep = ssInstall then
+  begin
+    Exec(ExpandConstant('{sys}') + '\sc.exe', 'stop ' + ExpandConstant('{#ServiceName}'), '', SW_HIDE, ewWaitUntilTerminated, ResultCode)
+
+    //thanks to https://stackoverflow.com/a/39827761
+    Wait := 5000;
+    Step := 100;
+    ProgressPage :=
+      CreateOutputProgressPage(
+        WizardForm.PageNameLabel.Caption,
+        WizardForm.PageDescriptionLabel.Caption);
+    ProgressPage.SetText('Making sure the satellite service is stopped...', '');
+    ProgressPage.SetProgress(0, Wait);
+    ProgressPage.Show;
+    try
+      for I := 0 to Wait div Step do
+      begin
+        ProgressPage.SetProgress(I * Step, Wait);
+        Sleep(Step);
+      end;
+    finally
+      ProgressPage.Hide;
+      ProgressPage.Free;
+    end;
+  end;
+end;


### PR DESCRIPTION
This PR adds additional logic into the installer that will try to make sure the satellite service is actually stopped before progressing with the install process.