### PR TITLE
Fix: internal device sensor null checks

### DIFF
--- a/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/AccelerometerSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/AccelerometerSensor.cs
@@ -29,6 +29,9 @@ namespace HASS.Agent.Managers.DeviceSensors
                     return null;
 
                 var sensorReading = _accelerometer.GetCurrentReading();
+                if(sensorReading == null)
+                    return null;
+
                 var accX = Math.Round((decimal)sensorReading.AccelerationX, 2);
                 var accY = Math.Round((decimal)sensorReading.AccelerationX, 2);
                 var accZ = Math.Round((decimal)sensorReading.AccelerationX, 2);

--- a/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/ActivitySensor.cs
+++ b/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/ActivitySensor.cs
@@ -27,6 +27,9 @@ namespace HASS.Agent.Managers.DeviceSensors
                     return null;
 
                 var sensorReading = _activitySensor.GetCurrentReadingAsync().AsTask().Result;
+                if (sensorReading == null)
+                    return null;
+
                 _attributes[AttributeConfidence] = sensorReading.Confidence.ToString();
                 _attributes[AttributeTimestamp] = sensorReading.Timestamp.ToLocalTime().ToString();
 

--- a/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/AltimeterSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/AltimeterSensor.cs
@@ -23,7 +23,11 @@ namespace HASS.Agent.Managers.DeviceSensors
                 if (!Available)
                     return null;
 
-                return _altimeter.GetCurrentReading().AltitudeChangeInMeters.ToString();
+                var sensorReading = _altimeter.GetCurrentReading();
+                if (sensorReading == null)
+                    return null;
+
+                return sensorReading.AltitudeChangeInMeters.ToString();
             }
         }
 

--- a/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/BarometerSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/BarometerSensor.cs
@@ -23,7 +23,11 @@ namespace HASS.Agent.Managers.DeviceSensors
                 if (!Available)
                     return null;
 
-                return _barometer.GetCurrentReading().StationPressureInHectopascals.ToString();
+                var sensorReading = _barometer.GetCurrentReading();
+                if (sensorReading == null)
+                    return null;
+
+                return sensorReading.StationPressureInHectopascals.ToString();
             }
         }
 

--- a/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/CompassSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/CompassSensor.cs
@@ -26,6 +26,9 @@ namespace HASS.Agent.Managers.DeviceSensors
                     return null;
 
                 var sensorReading = _compass.GetCurrentReading();
+                if (sensorReading == null)
+                    return null;
+
                 _attributes[AttributeMagneticNorth] = Math.Round((decimal)sensorReading.HeadingMagneticNorth, 2).ToString();
                 return Math.Round((decimal)sensorReading.HeadingTrueNorth, 2).ToString();
             }

--- a/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/GyrometerSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/GyrometerSensor.cs
@@ -28,6 +28,9 @@ namespace HASS.Agent.Managers.DeviceSensors
                     return null;
 
                 var sensorReading = _gyrometer.GetCurrentReading();
+                if (sensorReading == null)
+                    return null;
+
                 var angVelX = Math.Round((decimal)sensorReading.AngularVelocityX, 2);
                 var angVelY = Math.Round((decimal)sensorReading.AngularVelocityY, 2);
                 var angVelZ = Math.Round((decimal)sensorReading.AngularVelocityZ, 2);

--- a/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/HingeAngleSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/HingeAngleSensor.cs
@@ -23,8 +23,11 @@ namespace HASS.Agent.Managers.DeviceSensors
                 if (!Available)
                     return null;
 
-                var sensorReading = _hingeAngelSensor.GetCurrentReadingAsync().AsTask().Result.AngleInDegrees;
-                return Math.Round((decimal)sensorReading, 2).ToString();
+                var sensorReading = _hingeAngelSensor.GetCurrentReadingAsync().AsTask().Result;
+                if (sensorReading == null)
+                    return null;
+
+                return Math.Round((decimal)sensorReading.AngleInDegrees, 2).ToString();
             }
         }
 

--- a/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/InclinometerSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/InclinometerSensor.cs
@@ -30,6 +30,9 @@ namespace HASS.Agent.Managers.DeviceSensors
                     return null;
 
                 var sensorReading = _inclinometer.GetCurrentReading();
+                if (sensorReading == null)
+                    return null;
+
                 _attributes[AttributePitchDegrees] = Math.Round((decimal)sensorReading.PitchDegrees, 2).ToString();
                 _attributes[AttributeYawDegrees] = Math.Round((decimal)sensorReading.YawDegrees, 2).ToString();
                 _attributes[AttributeRollDegrees] = Math.Round((decimal)sensorReading.RollDegrees, 2).ToString();

--- a/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/LightSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/LightSensor.cs
@@ -22,8 +22,12 @@ namespace HASS.Agent.Managers.DeviceSensors
             {
                 if (!Available)
                     return null;
+                
+                var sensorReading = _lightSensor.GetCurrentReading();
+                if (sensorReading == null)
+                    return null;
 
-                return Math.Round((decimal)_lightSensor.GetCurrentReading().IlluminanceInLux, 2).ToString();
+                return Math.Round((decimal)sensorReading.IlluminanceInLux, 2).ToString();
             }
         }
 

--- a/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/MagnetometerSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/MagnetometerSensor.cs
@@ -28,6 +28,9 @@ namespace HASS.Agent.Managers.DeviceSensors
                     return null;
 
                 var sensorReading = _magnetometer.GetCurrentReading();
+                if (sensorReading == null)
+                    return null;
+
                 var magFieldX = Math.Round((decimal)sensorReading.MagneticFieldX,2);
                 var magFieldY = Math.Round((decimal)sensorReading.MagneticFieldY, 2);
                 var magFieldZ = Math.Round((decimal)sensorReading.MagneticFieldZ, 2);

--- a/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/OrientationSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/OrientationSensor.cs
@@ -28,6 +28,9 @@ namespace HASS.Agent.Managers.DeviceSensors
                     return null;
 
                 var sensorReading = _orientationSensor.GetCurrentReading();
+                if (sensorReading == null)
+                    return null;
+
                 _attributes[AttributeRotationMatrix] = JsonConvert.SerializeObject(sensorReading.RotationMatrix);
                 _attributes[AttributeYawAccuracy] = sensorReading.YawAccuracy.ToString();
 

--- a/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/PedometerSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/PedometerSensor.cs
@@ -26,7 +26,10 @@ namespace HASS.Agent.Managers.DeviceSensors
                 var totalStepCount = 0;
 
                 var sensorReadings = _pedometer.GetCurrentReadings();
-                foreach(var sensorReading in sensorReadings)
+                if (sensorReadings == null)
+                    return null;
+
+                foreach (var sensorReading in sensorReadings)
                 {
                     var attributeCumulativeSteps = $"{sensorReading.Key}CumulativeSteps";
                     _attributes[attributeCumulativeSteps] = sensorReading.Value.CumulativeSteps.ToString();

--- a/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/ProximitySensor.cs
+++ b/src/HASS.Agent/HASS.Agent/Managers/DeviceSensors/ProximitySensor.cs
@@ -23,7 +23,11 @@ namespace HASS.Agent.Managers.DeviceSensors
                 if (!Available)
                     return null;
 
-                return _proximitySensor.GetCurrentReading().DistanceInMillimeters.ToString();
+                var sensorReading = _proximitySensor.GetCurrentReading();
+                if (sensorReading == null)
+                    return null;
+
+                return sensorReading.DistanceInMillimeters.ToString();
             }
         }
 


### PR DESCRIPTION
This PR adds additional logic to prevent null exceptions when one of the sensors is malfunctioning.

Explanation: one of my devices has a light sensor that causes exception each time then measurement is accessed despite the "sensor" being enumerated properly.