### PR TITLE
Feature: v3 notification features backport

### DIFF
--- a/src/HASS.Agent/HASS.Agent/API/ApiEndpoints.cs
+++ b/src/HASS.Agent/HASS.Agent/API/ApiEndpoints.cs
@@ -6,6 +6,7 @@ using HASS.Agent.Managers;
 using HASS.Agent.Media;
 using HASS.Agent.Models.HomeAssistant;
 using HASS.Agent.MQTT;
+using Newtonsoft.Json;
 using Serilog;
 using HttpMethod = System.Net.Http.HttpMethod;
 
@@ -24,7 +25,7 @@ namespace HASS.Agent.API
         public static async Task DeviceInfoRoute(IHttpContext context)
         {
             context.Response.ContentType = "application/json";
-            await context.Response.SendResponseAsync(JsonSerializer.Serialize(new
+            await context.Response.SendResponseAsync(JsonConvert.SerializeObject(new
             {
                 serial_number = Variables.SerialNumber,
                 device = Variables.DeviceConfig,
@@ -33,7 +34,7 @@ namespace HASS.Agent.API
                     notifications = Variables.AppSettings.NotificationsEnabled,
                     media_player = Variables.AppSettings.MediaPlayerEnabled
                 }
-            }, MqttManager.JsonSerializerOptions));
+            }, MqttManager.JsonSerializerSettings));
         }
         
         /// <summary>

--- a/src/HASS.Agent/HASS.Agent/API/ApiEndpoints.cs
+++ b/src/HASS.Agent/HASS.Agent/API/ApiEndpoints.cs
@@ -1,11 +1,11 @@
-﻿using Grapevine;
+﻿using System.Text.Json;
+using Grapevine;
 using HASS.Agent.Enums;
 using HASS.Agent.Extensions;
 using HASS.Agent.Managers;
 using HASS.Agent.Media;
 using HASS.Agent.Models.HomeAssistant;
 using HASS.Agent.MQTT;
-using Newtonsoft.Json;
 using Serilog;
 using HttpMethod = System.Net.Http.HttpMethod;
 
@@ -24,7 +24,7 @@ namespace HASS.Agent.API
         public static async Task DeviceInfoRoute(IHttpContext context)
         {
             context.Response.ContentType = "application/json";
-            await context.Response.SendResponseAsync(JsonConvert.SerializeObject(new
+            await context.Response.SendResponseAsync(JsonSerializer.Serialize(new
             {
                 serial_number = Variables.SerialNumber,
                 device = Variables.DeviceConfig,
@@ -33,7 +33,7 @@ namespace HASS.Agent.API
                     notifications = Variables.AppSettings.NotificationsEnabled,
                     media_player = Variables.AppSettings.MediaPlayerEnabled
                 }
-            }, MqttManager.JsonSerializerSettings));
+            }, MqttManager.JsonSerializerOptions));
         }
         
         /// <summary>

--- a/src/HASS.Agent/HASS.Agent/API/ApiEndpoints.cs
+++ b/src/HASS.Agent/HASS.Agent/API/ApiEndpoints.cs
@@ -1,11 +1,11 @@
-﻿using System.Text.Json;
-using Grapevine;
+﻿using Grapevine;
 using HASS.Agent.Enums;
 using HASS.Agent.Extensions;
 using HASS.Agent.Managers;
 using HASS.Agent.Media;
 using HASS.Agent.Models.HomeAssistant;
 using HASS.Agent.MQTT;
+using Newtonsoft.Json;
 using Serilog;
 using HttpMethod = System.Net.Http.HttpMethod;
 
@@ -24,7 +24,7 @@ namespace HASS.Agent.API
         public static async Task DeviceInfoRoute(IHttpContext context)
         {
             context.Response.ContentType = "application/json";
-            await context.Response.SendResponseAsync(JsonSerializer.Serialize(new
+            await context.Response.SendResponseAsync(JsonConvert.SerializeObject(new
             {
                 serial_number = Variables.SerialNumber,
                 device = Variables.DeviceConfig,
@@ -33,7 +33,7 @@ namespace HASS.Agent.API
                     notifications = Variables.AppSettings.NotificationsEnabled,
                     media_player = Variables.AppSettings.MediaPlayerEnabled
                 }
-            }, MqttManager.JsonSerializerOptions));
+            }, MqttManager.JsonSerializerSettings));
         }
         
         /// <summary>

--- a/src/HASS.Agent/HASS.Agent/Functions/HelperFunctions.cs
+++ b/src/HASS.Agent/HASS.Agent/Functions/HelperFunctions.cs
@@ -25,6 +25,7 @@ using Syncfusion.Windows.Forms;
 using Task = System.Threading.Tasks.Task;
 using MediaManager = HASS.Agent.Media.MediaManager;
 using HASS.Agent.Shared.Managers;
+using Newtonsoft.Json.Serialization;
 
 namespace HASS.Agent.Functions
 {
@@ -818,5 +819,15 @@ namespace HASS.Agent.Functions
         /// <param name="name"></param>
         /// <returns></returns>
         public override string ConvertName(string name) => name.ToLowerInvariant();
+    }
+
+    public class ToLowerInvariantNamingStrategy : NamingStrategy
+    {
+        /// <summary>
+        /// Convert name to lowerinvariant
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        protected override string ResolvePropertyName(string name) => name.ToLowerInvariant();
     }
 }

--- a/src/HASS.Agent/HASS.Agent/MQTT/MqttManager.cs
+++ b/src/HASS.Agent/HASS.Agent/MQTT/MqttManager.cs
@@ -3,8 +3,6 @@ using System.IO;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using HASS.Agent.API;
 using HASS.Agent.Enums;
 using HASS.Agent.Functions;
@@ -22,6 +20,8 @@ using MQTTnet.Adapter;
 using MQTTnet.Client;
 using MQTTnet.Exceptions;
 using MQTTnet.Extensions.ManagedClient;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 using Serilog;
 
 namespace HASS.Agent.MQTT
@@ -447,7 +447,7 @@ namespace HASS.Agent.MQTT
                     if (discoverable.IgnoreAvailability)
                         payload.Availability_topic = null;
 
-                    messageBuilder.WithPayload(JsonSerializer.Serialize(payload, payload.GetType(), JsonSerializerOptions));
+                    messageBuilder.WithPayload(JsonConvert.SerializeObject(payload, payload.GetType(), JsonSerializerSettings));
                 }
                 await PublishAsync(messageBuilder.Build());
             }
@@ -472,12 +472,13 @@ namespace HASS.Agent.MQTT
         /// <summary>
         /// JSON serializer options (camelcase, casing, ignore condition, converters)
         /// </summary>
-        public static readonly JsonSerializerOptions JsonSerializerOptions = new()
+        public static readonly JsonSerializerSettings JsonSerializerSettings = new()
         {
-            PropertyNamingPolicy = new CamelCaseJsonNamingpolicy(),
-            PropertyNameCaseInsensitive = true,
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-            Converters = { new JsonStringEnumConverter() }
+            ContractResolver = new DefaultContractResolver()
+            {
+                NamingStrategy = new CamelCaseNamingStrategy()
+            },
+            NullValueHandling = NullValueHandling.Ignore
         };
 
         public async Task AnnounceAvailabilityAsync(bool offline = false)
@@ -510,7 +511,7 @@ namespace HASS.Agent.MQTT
 
                     var integrationMsgBuilder = new MqttApplicationMessageBuilder()
                         .WithTopic($"hass.agent/devices/{Variables.DeviceConfig.Name}")
-                        .WithPayload(JsonSerializer.Serialize(new
+                        .WithPayload(JsonConvert.SerializeObject(new
                         {
                             serial_number = Variables.SerialNumber,
                             device = Variables.DeviceConfig,
@@ -519,7 +520,7 @@ namespace HASS.Agent.MQTT
                                 notifications = Variables.AppSettings.NotificationsEnabled,
                                 media_player = Variables.AppSettings.MediaPlayerEnabled
                             }
-                        }, JsonSerializerOptions))
+                        }, JsonSerializerSettings))
                         .WithRetainFlag(Variables.AppSettings.MqttUseRetainFlag);
 
                     await _mqttClient.InternalClient.PublishAsync(integrationMsgBuilder.Build());
@@ -775,7 +776,7 @@ namespace HASS.Agent.MQTT
                 // process as a notification
                 if (applicationMessage.Topic == $"hass.agent/notifications/{HelperFunctions.GetConfiguredDeviceName()}")
                 {
-                    var notification = JsonSerializer.Deserialize<Notification>(applicationMessage.PayloadSegment, JsonSerializerOptions)!;
+                    var notification = JsonConvert.DeserializeObject<Notification>(Encoding.UTF8.GetString(applicationMessage.PayloadSegment), JsonSerializerSettings)!;
                     _ = Task.Run(() => NotificationManager.ShowNotification(notification));
 
                     return Task.CompletedTask;
@@ -784,7 +785,7 @@ namespace HASS.Agent.MQTT
                 // process as a mediaplyer command
                 if (applicationMessage.Topic == $"hass.agent/media_player/{HelperFunctions.GetConfiguredDeviceName()}/cmd")
                 {
-                    var command = JsonSerializer.Deserialize<MqttMediaPlayerCommand>(applicationMessage.PayloadSegment, JsonSerializerOptions)!;
+                    var command = JsonConvert.DeserializeObject<MqttMediaPlayerCommand>(Encoding.UTF8.GetString(applicationMessage.PayloadSegment), JsonSerializerSettings)!;
 
                     switch (command.Command)
                     {

--- a/src/HASS.Agent/HASS.Agent/MQTT/MqttManager.cs
+++ b/src/HASS.Agent/HASS.Agent/MQTT/MqttManager.cs
@@ -3,6 +3,8 @@ using System.IO;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using HASS.Agent.API;
 using HASS.Agent.Enums;
 using HASS.Agent.Functions;
@@ -20,8 +22,6 @@ using MQTTnet.Adapter;
 using MQTTnet.Client;
 using MQTTnet.Exceptions;
 using MQTTnet.Extensions.ManagedClient;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 using Serilog;
 
 namespace HASS.Agent.MQTT
@@ -447,7 +447,7 @@ namespace HASS.Agent.MQTT
                     if (discoverable.IgnoreAvailability)
                         payload.Availability_topic = null;
 
-                    messageBuilder.WithPayload(JsonConvert.SerializeObject(payload, payload.GetType(), JsonSerializerSettings));
+                    messageBuilder.WithPayload(JsonSerializer.Serialize(payload, payload.GetType(), JsonSerializerOptions));
                 }
                 await PublishAsync(messageBuilder.Build());
             }
@@ -472,13 +472,12 @@ namespace HASS.Agent.MQTT
         /// <summary>
         /// JSON serializer options (camelcase, casing, ignore condition, converters)
         /// </summary>
-        public static readonly JsonSerializerSettings JsonSerializerSettings = new()
+        public static readonly JsonSerializerOptions JsonSerializerOptions = new()
         {
-            ContractResolver = new DefaultContractResolver()
-            {
-                NamingStrategy = new CamelCaseNamingStrategy()
-            },
-            NullValueHandling = NullValueHandling.Ignore
+            PropertyNamingPolicy = new CamelCaseJsonNamingpolicy(),
+            PropertyNameCaseInsensitive = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            Converters = { new JsonStringEnumConverter() }
         };
 
         public async Task AnnounceAvailabilityAsync(bool offline = false)
@@ -511,7 +510,7 @@ namespace HASS.Agent.MQTT
 
                     var integrationMsgBuilder = new MqttApplicationMessageBuilder()
                         .WithTopic($"hass.agent/devices/{Variables.DeviceConfig.Name}")
-                        .WithPayload(JsonConvert.SerializeObject(new
+                        .WithPayload(JsonSerializer.Serialize(new
                         {
                             serial_number = Variables.SerialNumber,
                             device = Variables.DeviceConfig,
@@ -520,7 +519,7 @@ namespace HASS.Agent.MQTT
                                 notifications = Variables.AppSettings.NotificationsEnabled,
                                 media_player = Variables.AppSettings.MediaPlayerEnabled
                             }
-                        }, JsonSerializerSettings))
+                        }, JsonSerializerOptions))
                         .WithRetainFlag(Variables.AppSettings.MqttUseRetainFlag);
 
                     await _mqttClient.InternalClient.PublishAsync(integrationMsgBuilder.Build());
@@ -776,7 +775,7 @@ namespace HASS.Agent.MQTT
                 // process as a notification
                 if (applicationMessage.Topic == $"hass.agent/notifications/{HelperFunctions.GetConfiguredDeviceName()}")
                 {
-                    var notification = JsonConvert.DeserializeObject<Notification>(Encoding.UTF8.GetString(applicationMessage.PayloadSegment), JsonSerializerSettings)!;
+                    var notification = JsonSerializer.Deserialize<Notification>(applicationMessage.PayloadSegment, JsonSerializerOptions)!;
                     _ = Task.Run(() => NotificationManager.ShowNotification(notification));
 
                     return Task.CompletedTask;
@@ -785,7 +784,7 @@ namespace HASS.Agent.MQTT
                 // process as a mediaplyer command
                 if (applicationMessage.Topic == $"hass.agent/media_player/{HelperFunctions.GetConfiguredDeviceName()}/cmd")
                 {
-                    var command = JsonConvert.DeserializeObject<MqttMediaPlayerCommand>(Encoding.UTF8.GetString(applicationMessage.PayloadSegment), JsonSerializerSettings)!;
+                    var command = JsonSerializer.Deserialize<MqttMediaPlayerCommand>(applicationMessage.PayloadSegment, JsonSerializerOptions)!;
 
                     switch (command.Command)
                     {

--- a/src/HASS.Agent/HASS.Agent/Media/MediaManager.cs
+++ b/src/HASS.Agent/HASS.Agent/Media/MediaManager.cs
@@ -1,5 +1,4 @@
 ﻿using System.IO;
-using System.Text.Json;
 using Windows.Media.Control;
 using Windows.Media.Playback;
 using HASS.Agent.Enums;
@@ -14,6 +13,7 @@ using MediaPlayerState = HASS.Agent.Enums.MediaPlayerState;
 using Octokit;
 using Windows.Media.Core;
 using HASS.Agent.Shared.Managers.Audio;
+using Newtonsoft.Json;
 
 namespace HASS.Agent.Media
 {
@@ -224,7 +224,7 @@ namespace HASS.Agent.Media
                     {
                         var haMessageBuilder = new MqttApplicationMessageBuilder()
                             .WithTopic($"hass.agent/media_player/{Variables.DeviceConfig.Name}/state")
-                            .WithPayload(JsonSerializer.Serialize(message, MqttManager.JsonSerializerOptions));
+                            .WithPayload(JsonConvert.SerializeObject(message, MqttManager.JsonSerializerSettings));
                         await Variables.MqttManager.PublishAsync(haMessageBuilder.Build());
                     }
 

--- a/src/HASS.Agent/HASS.Agent/Media/MediaManager.cs
+++ b/src/HASS.Agent/HASS.Agent/Media/MediaManager.cs
@@ -14,6 +14,7 @@ using MediaPlayerState = HASS.Agent.Enums.MediaPlayerState;
 using Octokit;
 using Windows.Media.Core;
 using HASS.Agent.Shared.Managers.Audio;
+using Newtonsoft.Json;
 
 namespace HASS.Agent.Media
 {
@@ -224,7 +225,7 @@ namespace HASS.Agent.Media
                     {
                         var haMessageBuilder = new MqttApplicationMessageBuilder()
                             .WithTopic($"hass.agent/media_player/{Variables.DeviceConfig.Name}/state")
-                            .WithPayload(JsonSerializer.Serialize(message, MqttManager.JsonSerializerOptions));
+                            .WithPayload(JsonConvert.SerializeObject(message, MqttManager.JsonSerializerSettings));
                         await Variables.MqttManager.PublishAsync(haMessageBuilder.Build());
                     }
 

--- a/src/HASS.Agent/HASS.Agent/Media/MediaManager.cs
+++ b/src/HASS.Agent/HASS.Agent/Media/MediaManager.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Text.Json;
 using Windows.Media.Control;
 using Windows.Media.Playback;
 using HASS.Agent.Enums;
@@ -13,7 +14,6 @@ using MediaPlayerState = HASS.Agent.Enums.MediaPlayerState;
 using Octokit;
 using Windows.Media.Core;
 using HASS.Agent.Shared.Managers.Audio;
-using Newtonsoft.Json;
 
 namespace HASS.Agent.Media
 {
@@ -224,7 +224,7 @@ namespace HASS.Agent.Media
                     {
                         var haMessageBuilder = new MqttApplicationMessageBuilder()
                             .WithTopic($"hass.agent/media_player/{Variables.DeviceConfig.Name}/state")
-                            .WithPayload(JsonConvert.SerializeObject(message, MqttManager.JsonSerializerSettings));
+                            .WithPayload(JsonSerializer.Serialize(message, MqttManager.JsonSerializerOptions));
                         await Variables.MqttManager.PublishAsync(haMessageBuilder.Build());
                     }
 

--- a/src/HASS.Agent/HASS.Agent/Models/HomeAssistant/MqttMediaPlayerCommand.cs
+++ b/src/HASS.Agent/HASS.Agent/Models/HomeAssistant/MqttMediaPlayerCommand.cs
@@ -1,10 +1,11 @@
-﻿using System.Text.Json;
+﻿using System.Text.Json.Nodes;
 using HASS.Agent.Enums;
+using Newtonsoft.Json.Linq;
 
 namespace HASS.Agent.Models.HomeAssistant;
 
 public class MqttMediaPlayerCommand
 {
     public MediaPlayerCommand Command { get; set; }
-    public JsonElement Data { get; set; }
+    public JValue Data { get; set; }
 }

--- a/src/HASS.Agent/HASS.Agent/Models/HomeAssistant/Notification.cs
+++ b/src/HASS.Agent/HASS.Agent/Models/HomeAssistant/Notification.cs
@@ -1,4 +1,6 @@
-﻿namespace HASS.Agent.Models.HomeAssistant
+﻿using Newtonsoft.Json;
+
+namespace HASS.Agent.Models.HomeAssistant
 {
     public class NotificationAction
     {
@@ -16,12 +18,22 @@
 
     public class NotificationData
     {
+        public const string NoAction = "noAction";
+        public const string ImportanceHigh = "high";
+
         public int Duration { get; set; } = 0;
-        public string Image { get; set; }
+        public string Image { get; set; } = string.Empty;
+        public string ClickAction { get; set; } = NoAction;
+        public string Tag { get; set; } = string.Empty;
+        public string Group { get; set; } = string.Empty;
+        [JsonProperty("icon_url")]
+        public string IconUrl { get; set; } = string.Empty;
+        public bool Sticky { get; set; }
+        public string Importance { get; set; } = string.Empty;
 
-        public List<NotificationAction> Actions { get; set; } = new();
+        public List<NotificationAction> Actions { get; set; } = new List<NotificationAction>();
 
-        public List<NotificationInput> Inputs { get; set; } = new();
+        public List<NotificationInput> Inputs { get; set; } = new List<NotificationInput>();
     }
 
     public class Notification

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.Designer.cs
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.Designer.cs
@@ -4513,6 +4513,15 @@ namespace HASS.Agent.Resources.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Dismiss.
+        /// </summary>
+        internal static string Notification_Dismiss {
+            get {
+                return ResourceManager.GetString("Notification_Dismiss", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Error trying to bind the API to port {0}.
         ///
         ///Make sure no other instance of HASS.Agent is running and the port is available and registered..

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.de.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.de.resx
@@ -3528,4 +3528,7 @@ Muss unter „Konfiguration -&gt; Tray-Icon“ konfiguriert werden.</value>
   <data name="HassAction_Press" xml:space="preserve">
     <value>Presse</value>
   </data>
+  <data name="Notification_Dismiss" xml:space="preserve">
+    <value>Zurückweisen</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.en.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.en.resx
@@ -3433,4 +3433,7 @@ Requires it to be configured in "Configuration -&gt; Tray Icon"</value>
   <data name="HassAction_Press" xml:space="preserve">
     <value>Press</value>
   </data>
+  <data name="Notification_Dismiss" xml:space="preserve">
+    <value>Dismiss</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.es.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.es.resx
@@ -3404,4 +3404,7 @@ Requiere que se configure en "Configuración -&gt; Icono de la bandeja"</value>
   <data name="HassAction_Press" xml:space="preserve">
     <value>Prensa</value>
   </data>
+  <data name="Notification_Dismiss" xml:space="preserve">
+    <value>Despedir</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.fr.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.fr.resx
@@ -3437,4 +3437,7 @@ Nécessite sa configuration dans « Configuration -&gt; Icône de la barre d'ét
   <data name="HassAction_Press" xml:space="preserve">
     <value>Presse</value>
   </data>
+  <data name="Notification_Dismiss" xml:space="preserve">
+    <value>Rejeter</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.nl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.nl.resx
@@ -3425,4 +3425,7 @@ Vereist dat het geconfigureerd is in "Configuratie -&gt; Tray Icon"</value>
   <data name="HassAction_Press" xml:space="preserve">
     <value>Pers</value>
   </data>
+  <data name="Notification_Dismiss" xml:space="preserve">
+    <value>Afwijzen</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pl.resx
@@ -3514,4 +3514,7 @@ Wymaga konfiguracji w „Configuration -&gt; Tray Icon”</value>
   <data name="HassAction_Press" xml:space="preserve">
     <value>Naciśnij</value>
   </data>
+  <data name="Notification_Dismiss" xml:space="preserve">
+    <value>Odrzuć</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pt-br.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pt-br.resx
@@ -3450,4 +3450,7 @@ Requer que seja configurado em "Configuration -&gt; Tray Icon"</value>
   <data name="HassAction_Press" xml:space="preserve">
     <value>Imprensa</value>
   </data>
+  <data name="Notification_Dismiss" xml:space="preserve">
+    <value>Dispensar</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.resx
@@ -3426,4 +3426,7 @@ Requires it to be configured in "Configuration -&gt; Tray Icon"</value>
   <data name="HassDomain_Button" xml:space="preserve">
     <value>Button</value>
   </data>
+  <data name="Notification_Dismiss" xml:space="preserve">
+    <value>Dismiss</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.ru.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.ru.resx
@@ -3473,4 +3473,7 @@ Home Assistant.
   <data name="HassAction_Press" xml:space="preserve">
     <value>Нажимать</value>
   </data>
+  <data name="Notification_Dismiss" xml:space="preserve">
+    <value>Увольнять</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.sl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.sl.resx
@@ -3553,4 +3553,7 @@ Zahteva, da je konfiguriran v "Konfiguracija -&gt; Ikona pladnja"</value>
   <data name="HassAction_Press" xml:space="preserve">
     <value>Pritisnite</value>
   </data>
+  <data name="Notification_Dismiss" xml:space="preserve">
+    <value>Odpusti</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.tr.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.tr.resx
@@ -3020,4 +3020,7 @@ Not: Uydu hizmetinde kullanılırsa kullanıcı alanı uygulamalarını algılam
   <data name="HassAction_Press" xml:space="preserve">
     <value>Basmak</value>
   </data>
+  <data name="Notification_Dismiss" xml:space="preserve">
+    <value>Azletmek</value>
+  </data>
 </root>


### PR DESCRIPTION
This PR backports features that were developed as part of "v3 rewrite" project.
The added features were based on the Home Assistant's Android notifications documentation - https://companion.home-assistant.io/docs/notifications/notifications-basic/

Example 1: notification with 3 buttons, one input and tag & group so it can be cleared
```
service: notify.amadeo_pc
data:
  title: Fancy title
  message: Test message
  data:
    image: >-
      https://smea.uw.edu/wp-content/uploads/sites/11/2017/03/CURRENTSBLOG_Cat_2.jpg
    actions:
      - action: "yes"
        title: "Yes"
      - action: "no"
        title: "No"
      - action: "openuri"
        title: "Open URI"
        uri: "https://www.cat-lovers-only.com"
    inputs:
      - id: testId
        text: testText
        title: testTitle
    clickAction: "https://www.home-assistant.io/"
    tag: "dogsAreCoolToo"
    group: "cuddlyOnesTho"
```

Example 2: clear notification from "Example 1"
```
service: notify.amadeo_pc
data:
  message: clear_notification
  data:
    tag: "dogsAreCoolToo"
    group: "cuddlyOnesTho"
```
	
Example 3a: sticky notification (always requires a button so if there is no defined, a one called "Dismiss" will be automatically added)
```
service: notify.amadeo_pc
data:
  title: "I'm sticky"
  message: Gonna stay here I think
  data:
    sticky: true
```
	
Example 3b: sticky notification
```
service: notify.amadeo_pc
data:
  title: "I'm sticky"
  message: Gonna stay here I think
  data:
    actions:
      - action: "ok"
        title: "Ok"
    sticky: true
```
	
Example 4: "important notification"
```
service: notify.amadeo_pc
data:
  title: "Don't miss me"
  message: "You're out of tea!"
  data:
    actions:
      - action: "buy"
        title: "Buy more"
      - action: "waterbros"
        title: "Water this time"
    importance: high
```
