### PR TITLE
in installation: mention switching to security tab in user profile

### DIFF
--- a/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-3-API.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-3-API.resx
@@ -63,7 +63,8 @@ Home Assistant's API.
 
 Please provide a long-lived access token and the address of your Home Assistant instance.
 You can get a token in Home Assistant by clicking your profile picture at the bottom-left
-and navigating to the bottom of the page until you see the 'CREATE TOKEN' button.
+switch to the security tab at the top and navigating to the bottom of the page until you
+see the 'CREATE TOKEN' button.
 
 Please note, that for actionable notification functionality you need to provide admin account token.</value>
   </data>


### PR DESCRIPTION

![grafik](https://github.com/user-attachments/assets/8b6f463a-0969-4c37-8e8d-c19cde0e0dbc)

PS: you if the text supports links, one could add a direct link to the profile page: https://my.home-assistant.io/redirect/profile/