### PR TITLE
Fix: SetVolumeCommand ignoring payload

### DIFF
--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/InternalCommands/SetVolumeCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/InternalCommands/SetVolumeCommand.cs
@@ -70,15 +70,16 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.InternalCommands
 
             try
             {
-                var parsed = int.TryParse(action, out var volumeInt);
+                var parsed = float.TryParse(action, out var volumeFloat);
                 if (!parsed)
                 {
                     Log.Error("[SETVOLUME] [{name}] Unable to trigger command, the provided action value can't be parsed: {val}", EntityName, action);
 
                     return;
                 }
-
-                AudioManager.SetDefaultDeviceProperties(DeviceType.Output, DeviceRole.Multimedia | DeviceRole.Console, _volume, null);
+                
+                var volumeInt = (int)Math.Ceiling(volumeFloat);
+                AudioManager.SetDefaultDeviceProperties(DeviceType.Output, DeviceRole.Multimedia | DeviceRole.Console, volumeInt, null);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
This PR fixes issues of SetVolumeCommand reported via https://github.com/hass-agent/HASS.Agent/issues/173:
- ignoring payload and using internal volume set by default to -1 is not configured (causing no action to be taken)
- accepting only proper ("50") integers and failing to parse float values ("50.0", "50.5")

After the fix, payload is properly recognised and providing float values causes them to be converted to int by rounding up (i.e. "50.1" and above becomes "51")