### PR TITLE
Fix: application not displaying properly with scale other than 100%

### DIFF
--- a/src/HASS.Agent/HASS.Agent/Program.cs
+++ b/src/HASS.Agent/HASS.Agent/Program.cs
@@ -85,8 +85,7 @@ namespace HASS.Agent
                 }
 
                 LocalizationManager.Initialize();
-
-                Application.SetHighDpiMode(HighDpiMode.DpiUnaware);
+                                                                                               
                 Application.SetDefaultFont(Variables.DefaultFont);
 
                 Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
@@ -95,6 +94,9 @@ namespace HASS.Agent
 
                 if (LaunchedAsChildApplication(args))
                     return;
+
+                Application.EnableVisualStyles();
+                Application.SetCompatibleTextRenderingDefault(false);
 
                 Variables.MainForm = new Main();
 

--- a/src/HASS.Agent/HASS.Agent/app.manifest
+++ b/src/HASS.Agent/HASS.Agent/app.manifest
@@ -48,12 +48,12 @@
       <!--<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />-->
 
       <!-- Windows 10 -->
-      <!--<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />-->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
 
     </application>
   </compatibility>
 
-  <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
+	<!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
        DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
        to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
        also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. 
@@ -64,7 +64,8 @@
     <windowsSettings>
       <!-- <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware> -->
       <!-- <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware> -->
-    </windowsSettings>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+	</windowsSettings>
   </application>
 
 


### PR DESCRIPTION
This PR fixes HASS.Agent UI looking blurry on devices where scaling is set to values other than 100%
Thanks to @IsaacInsoll for reporting! https://github.com/hass-agent/HASS.Agent/issues/183