### PR TITLE
Onboarding - Detect german language keyboard layouts

### DIFF
--- a/src/HASS.Agent/HASS.Agent/Functions/HelperFunctions.cs
+++ b/src/HASS.Agent/HASS.Agent/Functions/HelperFunctions.cs
@@ -578,6 +578,9 @@ namespace HASS.Agent.Functions
                 }
             }
 
+            if (InputLanguage.CurrentInputLanguage.LayoutName == "German") //system *language* might be english, but keyboard layout is still *german*
+                germanLayoutDetected = true;
+
             if (KnownNotOkInputLanguage.ContainsKey(inputLanguage) || germanLayoutDetected)
             {
                 // get human-readable name


### PR DESCRIPTION
`InputLanguageCheckDiffers()` only checks agains intput **language**, but the input **language** might be non-german and the **keyboard layout** still is. 

fixed with info from: https://stackoverflow.com/a/27747405 