### PR TITLE
Fix: service installer not using double quotes around exe path

### DIFF
--- a/src/HASS.Agent.Installer/InstallerScript-Service.iss
+++ b/src/HASS.Agent.Installer/InstallerScript-Service.iss
@@ -62,11 +62,12 @@ Root: HKLM; Subkey: "SOFTWARE\HASSAgent\SatelliteService"; ValueType: string; Va
 
 ; Service registration and removal
 [Run]
-Filename: "{sys}\sc.exe"; Parameters: "create {#ServiceName} binpath= ""{app}\{#MyAppExeName}"""; Flags: runhidden 
+Filename: "{sys}\sc.exe"; Parameters: "create {#ServiceName} binpath= ""\""{app}\{#MyAppExeName}""\"""; Flags: runhidden 
 Filename: "{sys}\sc.exe"; Parameters: "failure {#ServiceName} reset= 86400 actions= restart/60000/restart/60000//1000"; Flags: runhidden 
 Filename: "{sys}\sc.exe"; Parameters: "description {#ServiceName} ""{#ServiceDescription}"""; Flags: runhidden 
 Filename: "{sys}\sc.exe"; Parameters: "config {#ServiceName} DisplayName= ""{#ServiceDisplayName}"""; Flags: runhidden
 Filename: "{sys}\sc.exe"; Parameters: "config {#ServiceName} start= auto"; Flags: runhidden
+Filename: "{sys}\sc.exe"; Parameters: "config {#ServiceName} binpath= ""\""{app}\{#MyAppExeName}""\"""; Flags: runhidden 
 [UninstallRun]
 Filename: "{sys}\sc.exe"; Parameters: "stop {#ServiceName}"; RunOnceId: StopService; Flags: runhidden
 Filename: "{sys}\timeout.exe"; Parameters: "5"; RunOnceId: Delay1; Flags:runhidden


### PR DESCRIPTION
This PR fixes issue reported via https://github.com/hass-agent/HASS.Agent/issues/193.
According to good security practices the service exe path (ImagePath) should be enclosed in double quotes.
Thanks to @yakidd for reporting!