### PR TITLE
Release: 2.1.1-beta3

### DIFF
--- a/src/HASS.Agent.Installer/InstallerScript-Service.iss
+++ b/src/HASS.Agent.Installer/InstallerScript-Service.iss
@@ -9,7 +9,7 @@
 
 ; Standard installation constants
 #define MyAppName "HASS.Agent Satellite Service"
-#define MyAppVersion "2.1.1-beta2"
+#define MyAppVersion "2.1.1-beta3"
 #define MyAppPublisher "HASS.Agent Team"
 #define MyAppURL "https://hass-agent.io"
 #define MyAppExeName "HASS.Agent.Satellite.Service.exe"

--- a/src/HASS.Agent.Installer/InstallerScript.iss
+++ b/src/HASS.Agent.Installer/InstallerScript.iss
@@ -9,7 +9,7 @@
 
 ; Standard installation constants
 #define MyAppName "HASS.Agent"
-#define MyAppVersion "2.1.1-beta2"
+#define MyAppVersion "2.1.1-beta3"
 #define MyAppPublisher "HASS.Agent Team"
 #define MyAppURL "https://hass-agent.io"
 #define MyAppExeName "HASS.Agent.exe"

--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/HASS.Agent.Satellite.Service.csproj
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/HASS.Agent.Satellite.Service.csproj
@@ -8,7 +8,7 @@
     <UserSecretsId>dotnet-HASSAgentSatelliteService-6E4FA50A-3AC9-4E66-8671-9FAB92372154</UserSecretsId>
     <PlatformTarget>x64</PlatformTarget>
     <Platforms>x64;x86</Platforms>
-    <Version>2.1.1-beta2</Version>
+    <Version>2.1.1-beta3</Version>
     <Company>HASS.Agent Team</Company>
     <Product>HASS.Agent Satellite Service</Product>
     <AssemblyName>HASS.Agent.Satellite.Service</AssemblyName>

--- a/src/HASS.Agent/HASS.Agent.Shared/HASS.Agent.Shared.csproj
+++ b/src/HASS.Agent/HASS.Agent.Shared/HASS.Agent.Shared.csproj
@@ -12,7 +12,7 @@
     <RepositoryUrl>https://github.com/hass-agent/HASS.Agent</RepositoryUrl>
     <AssemblyVersion>2.1.1</AssemblyVersion>
     <FileVersion>2.1.1</FileVersion>
-    <Version>2.1.1-beta2</Version>
+    <Version>2.1.1-beta3</Version>
     <PackageIcon>logo_128.png</PackageIcon>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <ApplicationIcon>hassagent.ico</ApplicationIcon>

--- a/src/HASS.Agent/HASS.Agent/HASS.Agent.csproj
+++ b/src/HASS.Agent/HASS.Agent/HASS.Agent.csproj
@@ -12,7 +12,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <Platforms>x64;x86</Platforms>
     <DebugType>full</DebugType>
-    <Version>2.1.1-beta2</Version>
+    <Version>2.1.1-beta3</Version>
     <Company>HASS.Agent Team</Company>
     <Authors>HASS.Agent Team</Authors>
     <Description>Windows-based client for Home Assistant. Provides notifications, quick actions, commands, sensors and more. </Description>


### PR DESCRIPTION
- Satellite Service exe path is now properly enclosed in double quotes according to good security practices (thanks to @yakidd for reporting) https://github.com/hass-agent/HASS.Agent/pull/221
- Media playback via Music Assistant wasn't working correctly (thanks to @felipecrs and @whc2001 for reporting, providing a lot of information and testing) https://github.com/hass-agent/HASS.Agent/pull/220
- PowershellCommand argument handling where passing arguments containing spaces/quotes would cause the command to fail (thanks @greghesp for reporting) https://github.com/hass-agent/HASS.Agent/pull/204
- Restarting "Windows Management Instrumentation (WMI)" while HASS.Agent is running causes all WMI based sensors to stop functioning (thanks to @jack5mikemotown for reporting) https://github.com/hass-agent/HASS.Agent/pull/205