### PR TITLE
Fix: URI not being properly launched when attached to a button

### DIFF
--- a/src/HASS.Agent/HASS.Agent/Managers/NotificationManager.cs
+++ b/src/HASS.Agent/HASS.Agent/Managers/NotificationManager.cs
@@ -233,7 +233,7 @@ namespace HASS.Agent.Managers
                 var uri = GetValueFromEventArgs(e, UriPrefix);
                 var clickAction = GetValueFromEventArgs(e, ClickActionPrefix);
 
-                if (string.IsNullOrWhiteSpace(uri) && Variables.AppSettings.NotificationsOpenActionUri)
+                if (!string.IsNullOrWhiteSpace(uri) && Variables.AppSettings.NotificationsOpenActionUri)
                     HelperFunctions.LaunchUrl(uri);
                 else if (!string.IsNullOrWhiteSpace(clickAction))
                     HelperFunctions.LaunchUrl(clickAction);


### PR DESCRIPTION
This PR fixes a bug where the URI option attached to a button wouldn't open the URI upon clicking on it.