### PR TITLE
Fix: autodiscvoery messaages were not republished after MQTT connection was recovered

### DIFF
--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/Commands/CommandsManager.cs
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/Commands/CommandsManager.cs
@@ -114,7 +114,7 @@ namespace HASS.Agent.Satellite.Service.Commands
                     // is mqtt available?
                     if (Variables.MqttManager.GetStatus() != MqttStatus.Connected)
                     {
-                        // nothing to do
+                        _discoveryPublished = false;
                         continue;
                     }
 

--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/Sensors/SensorsManager.cs
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/Sensors/SensorsManager.cs
@@ -111,7 +111,7 @@ namespace HASS.Agent.Satellite.Service.Sensors
                     // is mqtt available?
                     if (Variables.MqttManager.GetStatus() != MqttStatus.Connected)
                     {
-                        // nothing to do
+                        _discoveryPublished = false;
                         continue;
                     }
 

--- a/src/HASS.Agent/HASS.Agent/Commands/CommandsManager.cs
+++ b/src/HASS.Agent/HASS.Agent/Commands/CommandsManager.cs
@@ -103,7 +103,10 @@ namespace HASS.Agent.Commands
                     await Task.Delay(firstRun ? TimeSpan.FromSeconds(1) : TimeSpan.FromMilliseconds(750));
 
                     if (_pause || Variables.MqttManager.GetStatus() != MqttStatus.Connected || !CommandsPresent())
+                    {
+                        _discoveryPublished = false;
                         continue;
+                    }
 
                     firstRun = false;
 

--- a/src/HASS.Agent/HASS.Agent/Sensors/SensorsManager.cs
+++ b/src/HASS.Agent/HASS.Agent/Sensors/SensorsManager.cs
@@ -95,7 +95,7 @@ namespace HASS.Agent.Sensors
                     // is mqtt available?
                     if (Variables.MqttManager.GetStatus() != MqttStatus.Connected)
                     {
-                        // nothing to do
+                        _discoveryPublished = false;
                         continue;
                     }
 


### PR DESCRIPTION
This PR fixes bug reported via https://github.com/hass-agent/HASS.Agent/issues/228 where after MQTT connection is restored, the autodiscovery messages are not sent. This causes entities to be unavailable in Home Assistant.