### PR TITLE
Fix: update check showing running newest version when no internet is available

### DIFF
--- a/src/HASS.Agent/HASS.Agent/Forms/Main.cs
+++ b/src/HASS.Agent/HASS.Agent/Forms/Main.cs
@@ -833,11 +833,15 @@ namespace HASS.Agent.Forms
                 BtnCheckForUpdate.Text = Languages.Main_Checking;
 
                 var (isAvailable, version) = await UpdateManager.CheckIsUpdateAvailableAsync();
-                if (!isAvailable)
+                if (!isAvailable && version != null)
                 {
                     var beta = Variables.Beta ? " [BETA]" : string.Empty;
                     MessageBoxAdv.Show(this, string.Format(Languages.Main_CheckForUpdate_MessageBox1, Variables.Version, beta), Variables.MessageBoxTitle, MessageBoxButtons.OK, MessageBoxIcon.Information);
-
+                    return;
+                }
+                else
+                {
+                    MessageBoxAdv.Show(this, "failed to get update");
                     return;
                 }
 

--- a/src/HASS.Agent/HASS.Agent/Forms/Main.cs
+++ b/src/HASS.Agent/HASS.Agent/Forms/Main.cs
@@ -839,9 +839,9 @@ namespace HASS.Agent.Forms
                     MessageBoxAdv.Show(this, string.Format(Languages.Main_CheckForUpdate_MessageBox1, Variables.Version, beta), Variables.MessageBoxTitle, MessageBoxButtons.OK, MessageBoxIcon.Information);
                     return;
                 }
-                else
+                else if(!isAvailable)
                 {
-                    MessageBoxAdv.Show(this, "failed to get update");
+                    MessageBoxAdv.Show(this, Languages.Main_CheckForUpdateFailed_MessageBox1, Variables.MessageBoxTitle, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return;
                 }
 

--- a/src/HASS.Agent/HASS.Agent/Managers/UpdateManager.cs
+++ b/src/HASS.Agent/HASS.Agent/Managers/UpdateManager.cs
@@ -111,7 +111,7 @@ internal static class UpdateManager
         catch (Exception ex)
         {
             Log.Fatal(ex, "[UPDATER] Error checking for updates: {err}", ex.Message);
-            return (false, pendingUpdate);
+            return (false, null);
         }
     }
 
@@ -160,7 +160,7 @@ internal static class UpdateManager
         catch (Exception ex)
         {
             Log.Fatal(ex, "[UPDATER] Error checking for beta updates: {err}", ex.Message);
-            return (false, pendingUpdate);
+            return (false, null);
         }
     }
 

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.Designer.cs
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.Designer.cs
@@ -4204,6 +4204,15 @@ namespace HASS.Agent.Resources.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed checking for update!.
+        /// </summary>
+        internal static string Main_CheckForUpdateFailed_MessageBox1 {
+            get {
+                return ResourceManager.GetString("Main_CheckForUpdateFailed_MessageBox1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Check for Updates.
         /// </summary>
         internal static string Main_CheckForUpdates {

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.de.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.de.resx
@@ -3531,4 +3531,7 @@ Muss unter „Konfiguration -&gt; Tray-Icon“ konfiguriert werden.</value>
   <data name="Notification_Dismiss" xml:space="preserve">
     <value>Zurückweisen</value>
   </data>
+  <data name="Main_CheckForUpdateFailed_MessageBox1" xml:space="preserve">
+    <value>Suche nach Update fehlgeschlagen!</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.en.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.en.resx
@@ -3436,4 +3436,7 @@ Requires it to be configured in "Configuration -&gt; Tray Icon"</value>
   <data name="Notification_Dismiss" xml:space="preserve">
     <value>Dismiss</value>
   </data>
+  <data name="Main_CheckForUpdateFailed_MessageBox1" xml:space="preserve">
+    <value>Failed checking for update!</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.es.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.es.resx
@@ -3407,4 +3407,7 @@ Requiere que se configure en "Configuración -&gt; Icono de la bandeja"</value>
   <data name="Notification_Dismiss" xml:space="preserve">
     <value>Despedir</value>
   </data>
+  <data name="Main_CheckForUpdateFailed_MessageBox1" xml:space="preserve">
+    <value>Error al comprobar la actualización.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.fr.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.fr.resx
@@ -3440,4 +3440,7 @@ Nécessite sa configuration dans « Configuration -&gt; Icône de la barre d'ét
   <data name="Notification_Dismiss" xml:space="preserve">
     <value>Rejeter</value>
   </data>
+  <data name="Main_CheckForUpdateFailed_MessageBox1" xml:space="preserve">
+    <value>Échec de la vérification de la mise à jour !</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.nl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.nl.resx
@@ -3428,4 +3428,7 @@ Vereist dat het geconfigureerd is in "Configuratie -&gt; Tray Icon"</value>
   <data name="Notification_Dismiss" xml:space="preserve">
     <value>Afwijzen</value>
   </data>
+  <data name="Main_CheckForUpdateFailed_MessageBox1" xml:space="preserve">
+    <value>Controle op update mislukt!</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pl.resx
@@ -3517,4 +3517,7 @@ Wymaga konfiguracji w „Configuration -&gt; Tray Icon”</value>
   <data name="Notification_Dismiss" xml:space="preserve">
     <value>Odrzuć</value>
   </data>
+  <data name="Main_CheckForUpdateFailed_MessageBox1" xml:space="preserve">
+    <value>Sprawdzanie aktualizacji nie powiodło się!</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pt-br.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pt-br.resx
@@ -3453,4 +3453,7 @@ Requer que seja configurado em "Configuration -&gt; Tray Icon"</value>
   <data name="Notification_Dismiss" xml:space="preserve">
     <value>Dispensar</value>
   </data>
+  <data name="Main_CheckForUpdateFailed_MessageBox1" xml:space="preserve">
+    <value>Falha na verificação da atualização!</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.resx
@@ -3429,4 +3429,7 @@ Requires it to be configured in "Configuration -&gt; Tray Icon"</value>
   <data name="Notification_Dismiss" xml:space="preserve">
     <value>Dismiss</value>
   </data>
+  <data name="Main_CheckForUpdateFailed_MessageBox1" xml:space="preserve">
+    <value>Failed checking for update!</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.ru.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.ru.resx
@@ -3476,4 +3476,7 @@ Home Assistant.
   <data name="Notification_Dismiss" xml:space="preserve">
     <value>Увольнять</value>
   </data>
+  <data name="Main_CheckForUpdateFailed_MessageBox1" xml:space="preserve">
+    <value>Не удалось проверить обновление!</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.sl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.sl.resx
@@ -3556,4 +3556,7 @@ Zahteva, da je konfiguriran v "Konfiguracija -&gt; Ikona pladnja"</value>
   <data name="Notification_Dismiss" xml:space="preserve">
     <value>Odpusti</value>
   </data>
+  <data name="Main_CheckForUpdateFailed_MessageBox1" xml:space="preserve">
+    <value>Neuspešno preverjanje posodobitve!</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.tr.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.tr.resx
@@ -3023,4 +3023,7 @@ Not: Uydu hizmetinde kullanılırsa kullanıcı alanı uygulamalarını algılam
   <data name="Notification_Dismiss" xml:space="preserve">
     <value>Azletmek</value>
   </data>
+  <data name="Main_CheckForUpdateFailed_MessageBox1" xml:space="preserve">
+    <value>Güncelleme kontrolü başarısız oldu!</value>
+  </data>
 </root>


### PR DESCRIPTION
This PR fixes issue reported via https://github.com/hass-agent/HASS.Agent/issues/240 where HASS.Agent would show notification stating "running newest version" even when no internet was available.
Thanks to @patienttruth for reporting!