### PR TITLE
Fix: WinRing0/LibreHardwareMonitor dependency

### DIFF
--- a/src/HASS.Agent/HASS.Agent.Shared/HASS.Agent.Shared.csproj
+++ b/src/HASS.Agent/HASS.Agent.Shared/HASS.Agent.Shared.csproj
@@ -33,7 +33,6 @@
     <PackageReference Include="ByteSize" Version="2.1.2" />
     <PackageReference Include="Cassia.NetStandard" Version="1.0.0" />
     <PackageReference Include="CliWrap" Version="3.6.6" />
-    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.3" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="Microsoft.Win32.SystemEvents" Version="8.0.0" />
     <PackageReference Include="MQTTnet" Version="4.3.3.952" />

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/GpuLoadSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/GpuLoadSensor.cs
@@ -60,7 +60,7 @@ public class GpuLoadSensor : AbstractSingleValueSensor
                 .ToList();
 
             gpuCounters.ForEach(x => { _ = x.NextValue(); });
-            Thread.Sleep(10);
+            Thread.Sleep(10); //TODO(Amadeo): fix this
 
             return gpuCounters.Sum(x => x.NextValue());
         }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/GpuLoadSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/GpuLoadSensor.cs
@@ -1,8 +1,9 @@
-﻿using System.Globalization;
+﻿using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
+using System.Threading;
 using HASS.Agent.Shared.Managers;
 using HASS.Agent.Shared.Models.HomeAssistant;
-using LibreHardwareMonitor.Hardware;
 
 namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue;
 
@@ -11,54 +12,61 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue;
 /// </summary>
 public class GpuLoadSensor : AbstractSingleValueSensor
 {
-	private const string DefaultName = "gpuload";
-	private readonly IHardware _gpu;
+    private const string DefaultName = "gpuload";
 
-	public GpuLoadSensor(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default, string advancedSettings = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 30, id, advancedSettings: advancedSettings)
-	{
-		_gpu = HardwareManager.Hardware.FirstOrDefault(
-			h => h.HardwareType == HardwareType.GpuAmd ||
-			h.HardwareType == HardwareType.GpuNvidia ||
-            h.HardwareType == HardwareType.GpuIntel
-		);
-	}
+    public GpuLoadSensor(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default, string advancedSettings = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 30, id, advancedSettings: advancedSettings)
+    {
 
-	public override DiscoveryConfigModel GetAutoDiscoveryConfig()
-	{
-		if (Variables.MqttManager == null)
-			return null;
+    }
 
-		var deviceConfig = Variables.MqttManager.GetDeviceConfigModel();
-		if (deviceConfig == null)
-			return null;
+    public override DiscoveryConfigModel GetAutoDiscoveryConfig()
+    {
+        if (Variables.MqttManager == null)
+            return null;
 
-		return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
-		{
-			EntityName = EntityName,
-			Name = Name,
-			Unique_id = Id,
-			Device = deviceConfig,
-			State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",
-			Unit_of_measurement = "%",
+        var deviceConfig = Variables.MqttManager.GetDeviceConfigModel();
+        if (deviceConfig == null)
+            return null;
+
+        return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
+        {
+            EntityName = EntityName,
+            Name = Name,
+            Unique_id = Id,
+            Device = deviceConfig,
+            State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",
+            Unit_of_measurement = "%",
             State_class = "measurement",
             Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/availability"
-		});
-	}
+        });
+    }
 
-	public override string GetState()
-	{
-		if (_gpu == null)
-			return null;
+    public override string GetState()
+    {
+        return GetGPUUsage().ToString("#.##", CultureInfo.InvariantCulture);
+    }
 
-		_gpu.Update();
+    public override string GetAttributes() => string.Empty;
 
-		var sensor = _gpu.Sensors.FirstOrDefault(s => s.SensorType == SensorType.Load);
+    public float GetGPUUsage()
+    {
+        try
+        {
+            var category = new PerformanceCounterCategory("GPU Engine");
+            var gpuCounters = category.GetInstanceNames()
+                .Where(name => name.EndsWith("engtype_3D"))
+                .SelectMany(name => category.GetCounters(name))
+                .Where(counter => counter.CounterName.Equals("Utilization Percentage"))
+                .ToList();
 
-		if (sensor?.Value == null)
-			return null;
+            gpuCounters.ForEach(x => { _ = x.NextValue(); });
+            Thread.Sleep(10);
 
-		return sensor.Value.HasValue ? sensor.Value.Value.ToString("#.##", CultureInfo.InvariantCulture) : null;
-	}
-
-	public override string GetAttributes() => string.Empty;
+            return gpuCounters.Sum(x => x.NextValue());
+        }
+        catch
+        {
+            return 0;
+        }
+    }
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/GpuTemperatureSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/GpuTemperatureSensor.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using HASS.Agent.Shared.Managers;
 using HASS.Agent.Shared.Models.HomeAssistant;
-using LibreHardwareMonitor.Hardware;
 
 namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
 {
@@ -12,15 +11,15 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
     public class GpuTemperatureSensor : AbstractSingleValueSensor
     {
         private const string DefaultName = "gputemperature";
-        private readonly IHardware _gpu;
+        //private readonly IHardware _gpu;
 
         public GpuTemperatureSensor(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default, string advancedSettings = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 30, id, advancedSettings: advancedSettings)
         {
-			_gpu = HardwareManager.Hardware.FirstOrDefault(
+/*			_gpu = HardwareManager.Hardware.FirstOrDefault(
 				h => h.HardwareType == HardwareType.GpuAmd ||
 				h.HardwareType == HardwareType.GpuNvidia ||
                 h.HardwareType == HardwareType.GpuIntel
-			);
+			);*/
 		}
 
         public override DiscoveryConfigModel GetAutoDiscoveryConfig()
@@ -46,7 +45,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
 
         public override string GetState()
         {
-            if (_gpu == null)
+/*            if (_gpu == null)
                 return null;
 
             _gpu.Update();
@@ -56,7 +55,8 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
             if (sensor?.Value == null)
                 return null;
 
-            return sensor.Value.HasValue ? sensor.Value.Value.ToString("#.##", CultureInfo.InvariantCulture) : null;
+            return sensor.Value.HasValue ? sensor.Value.Value.ToString("#.##", CultureInfo.InvariantCulture) : null;*/
+            return "0";
         }
 
         public override string GetAttributes() => string.Empty;


### PR DESCRIPTION
This PR removes dependency on LibreHardwareMonitor.
GPU sensors are affected by this change:
- GPU Load Sensor - logic has been replaced with performance counter
- GPU Temperature Sensor - always returns 0, at this point there is no practical way to get this data. A documentation page is going to be prepared how to create a WMI sensor that receives the data from the standalone version of LibreHardwareMonitor. @DrR0X-glitch let me know please if you could do this.