### PR TITLE
Feature: accent color sensor

### DIFF
--- a/src/HASS.Agent/HASS.Agent.Shared/Enums/SensorType.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Enums/SensorType.cs
@@ -19,6 +19,10 @@ namespace HASS.Agent.Shared.Enums
         [EnumMember(Value = "ActiveDesktopSensor")]
         ActiveDesktopSensor,
 
+        [LocalizedDescription("SensorType_AccentColorSensor", typeof(Languages))]
+        [EnumMember(Value = "AccentColorSensor")]
+        AccentColorSensor,
+
         [LocalizedDescription("SensorType_AudioSensors", typeof(Languages))]
         [EnumMember(Value = "AudioSensors")]
         AudioSensors,

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.Designer.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.Designer.cs
@@ -6520,6 +6520,15 @@ namespace HASS.Agent.Shared.Resources.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to AccentColor.
+        /// </summary>
+        internal static string SensorType_AccentColorSensor {
+            get {
+                return ResourceManager.GetString("SensorType_AccentColorSensor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ActiveDesktop.
         /// </summary>
         internal static string SensorType_ActiveDesktopSensor {

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.de.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.de.resx
@@ -3382,4 +3382,7 @@ Willst Du den Runtime Installer herunterladen?</value>
   <data name="SensorType_NamedActiveWindowSensor" xml:space="preserve">
     <value>BenanntesAktivesFenster</value>
   </data>
+  <data name="SensorType_AccentColorSensor" xml:space="preserve">
+    <value>Akzentfarbe</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.en.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.en.resx
@@ -3258,4 +3258,7 @@ Do you want to download the runtime installer?</value>
   <data name="SensorsManager_NamedActiveWindowSensorDescription" xml:space="preserve">
     <value>Provides an ON/OFF value based on whether the focused window name contains configured string.</value>
   </data>
+  <data name="SensorType_AccentColorSensor" xml:space="preserve">
+    <value>AccentColor</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.es.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.es.resx
@@ -3258,4 +3258,7 @@ Oculta, Maximizada, Minimizada, Normal y Desconocida.</value>
   <data name="SensorType_NamedActiveWindowSensor" xml:space="preserve">
     <value>Ventana activa con nombre</value>
   </data>
+  <data name="SensorType_AccentColorSensor" xml:space="preserve">
+    <value>Color de acento</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.fr.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.fr.resx
@@ -3291,4 +3291,7 @@ Do you want to download the runtime installer?</value>
   <data name="SensorType_NamedActiveWindowSensor" xml:space="preserve">
     <value>Fenêtre active nommée</value>
   </data>
+  <data name="SensorType_AccentColorSensor" xml:space="preserve">
+    <value>AccentColor</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.nl.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.nl.resx
@@ -3280,4 +3280,7 @@ Wil je de runtime installatie downloaden?</value>
   <data name="SensorType_NamedActiveWindowSensor" xml:space="preserve">
     <value>SchermActiefNaam</value>
   </data>
+  <data name="SensorType_AccentColorSensor" xml:space="preserve">
+    <value>Accentkleur</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.pl.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.pl.resx
@@ -3368,4 +3368,7 @@ Czy chcesz pobrać plik instalacyjny?</value>
   <data name="SensorType_NamedActiveWindowSensor" xml:space="preserve">
     <value>NazwaAktywnegoOkna</value>
   </data>
+  <data name="SensorType_AccentColorSensor" xml:space="preserve">
+    <value>Kolor akcentu</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.pt-br.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.pt-br.resx
@@ -3305,4 +3305,7 @@ Deseja baixar o Microsoft WebView2 runtime?</value>
   <data name="SensorType_NamedActiveWindowSensor" xml:space="preserve">
     <value>JanelaAtiva Nomeada</value>
   </data>
+  <data name="SensorType_AccentColorSensor" xml:space="preserve">
+    <value>Cor de destaque</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.resx
@@ -3241,4 +3241,7 @@ Do you want to download the runtime installer?</value>
   <data name="SensorsManager_NamedActiveWindowSensorDescription" xml:space="preserve">
     <value>Provides an ON/OFF value based on whether the focused window name contains configured string.</value>
   </data>
+  <data name="SensorType_AccentColorSensor" xml:space="preserve">
+    <value>AccentColor</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.ru.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.ru.resx
@@ -3326,4 +3326,7 @@ Home Assistant.
   <data name="SensorType_NamedActiveWindowSensor" xml:space="preserve">
     <value>ИменованноеАктивноеОкно</value>
   </data>
+  <data name="SensorType_AccentColorSensor" xml:space="preserve">
+    <value>Акцентный цвет</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.sl.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.sl.resx
@@ -3407,4 +3407,7 @@ Ali želite prenesti runtime installer?</value>
   <data name="SensorType_NamedActiveWindowSensor" xml:space="preserve">
     <value>PoimenovanoAktivnoOkno</value>
   </data>
+  <data name="SensorType_AccentColorSensor" xml:space="preserve">
+    <value>Barva poudarka</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.tr.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.tr.resx
@@ -2865,4 +2865,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
   <data name="SensorType_NamedActiveWindowSensor" xml:space="preserve">
     <value>AdlandırılmışAktifPencere</value>
   </data>
+  <data name="SensorType_AccentColorSensor" xml:space="preserve">
+    <value>Vurgu Rengi</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/SingleValue/AccentColorSensor.cs
+++ b/src/HASS.Agent/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/SingleValue/AccentColorSensor.cs
@@ -1,0 +1,78 @@
+﻿using HASS.Agent.Managers;
+using HASS.Agent.Shared.Extensions;
+using HASS.Agent.Shared.Models.HomeAssistant;
+using Newtonsoft.Json;
+using Windows.UI.ViewManagement;
+using static HASS.Agent.Shared.Functions.Inputs;
+
+namespace HASS.Agent.HomeAssistant.Sensors.GeneralSensors.SingleValue
+{
+    /// <summary>
+    /// Sensor containing the current monitor power state
+    /// </summary>
+    public class AccentColorSensor : AbstractSingleValueSensor
+    {
+        private const string DefaultName = "accentcolor";
+
+        private readonly UISettings _uiSettings = new();
+
+        private string _attributesJson = string.Empty;
+
+        public AccentColorSensor(int? updateInterval = 120, string entityName = DefaultName, string name = DefaultName, string id = default, string advancedSettings = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 120, id, true, advancedSettings) { }
+
+        public override DiscoveryConfigModel GetAutoDiscoveryConfig()
+        {
+            if (Variables.MqttManager == null) return null;
+
+            var deviceConfig = Variables.MqttManager.GetDeviceConfigModel();
+            if (deviceConfig == null) return null;
+
+            return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
+            {
+                EntityName = EntityName,
+                Name = Name,
+                Unique_id = Id,
+                Device = deviceConfig,
+                State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",
+                Icon = "mdi:palette",
+                Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/availability",
+                Json_attributes_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/attributes"
+            });
+        }
+
+        public override string GetState()
+        {
+            var accent = TryGetColor(UIColorType.Accent);
+            _attributesJson = JsonConvert.SerializeObject(new
+            {
+                accent,
+                background = TryGetColor(UIColorType.Background),
+                foreground = TryGetColor(UIColorType.Foreground),
+                accentDark3 = TryGetColor(UIColorType.AccentDark3),
+                accentDark2 = TryGetColor(UIColorType.AccentDark2),
+                accentDark1 = TryGetColor(UIColorType.AccentDark1),
+                accentLight3 = TryGetColor(UIColorType.AccentLight3),
+                accentLight2 = TryGetColor(UIColorType.AccentLight2),
+                accentLight1 = TryGetColor(UIColorType.AccentLight1),
+                complement = TryGetColor(UIColorType.Complement),
+            });
+
+            return accent;
+        }
+
+        public override string GetAttributes() => _attributesJson;
+
+        private string TryGetColor(UIColorType colorType)
+        {
+            var color = "";
+
+            try
+            {
+                color = _uiSettings.GetColorValue(colorType).ToString().Replace("#FF", "#");
+            }
+            catch {}
+
+            return color;
+        }
+    }
+}

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.Designer.cs
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.Designer.cs
@@ -5914,6 +5914,16 @@ namespace HASS.Agent.Resources.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Provides #RRGGBB color values for system accent colors.
+        ///Main accent color is the sensor value, additional accent colors are available as attributes..
+        /// </summary>
+        internal static string SensorsManager_AccentColorSensorDescription {
+            get {
+                return ResourceManager.GetString("SensorsManager_AccentColorSensorDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Provides the ID of the currently active virtual desktop..
         /// </summary>
         internal static string SensorsManager_ActiveDesktopSensorDescription {

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.de.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.de.resx
@@ -3540,4 +3540,8 @@ Muss unter „Konfiguration -&gt; Tray-Icon“ konfiguriert werden.</value>
   <data name="SensorsManager_NamedActiveWindowSensorDescription" xml:space="preserve">
     <value>Stellt einen EIN/AUS-Wert bereit, basierend darauf, ob der fokussierte Fenstername eine konfigurierte Zeichenfolge enthält.</value>
   </data>
+  <data name="SensorsManager_AccentColorSensorDescription" xml:space="preserve">
+    <value>Stellt #RRGGBB-Farbwerte für System-Akzentfarben bereit.
+Die Hauptakzentfarbe ist der Sensorwert. Zusätzliche Akzentfarben sind als Attribute verfügbar.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.en.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.en.resx
@@ -3445,4 +3445,8 @@ Requires it to be configured in "Configuration -&gt; Tray Icon"</value>
   <data name="SensorsManager_NamedActiveWindowSensorDescription" xml:space="preserve">
     <value>Provides an ON/OFF value based on whether the focused window name contains configured string.</value>
   </data>
+  <data name="SensorsManager_AccentColorSensorDescription" xml:space="preserve">
+    <value>Provides #RRGGBB color values for system accent colors.
+Main accent color is the sensor value, additional accent colors are available as attributes.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.es.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.es.resx
@@ -3416,4 +3416,8 @@ Requiere que se configure en "Configuración -&gt; Icono de la bandeja"</value>
   <data name="SensorsManager_NamedActiveWindowSensorDescription" xml:space="preserve">
     <value>Proporciona un valor de ENCENDIDO/APAGADO según si el nombre de la ventana enfocada contiene una cadena configurada.</value>
   </data>
+  <data name="SensorsManager_AccentColorSensorDescription" xml:space="preserve">
+    <value>Proporciona valores de color #RRGGBB para los colores de acento del sistema.
+El color de acento principal es el valor del sensor; hay colores de acento adicionales disponibles como atributos.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.fr.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.fr.resx
@@ -3449,4 +3449,7 @@ Nécessite sa configuration dans « Configuration -&gt; Icône de la barre d'ét
   <data name="SensorsManager_NamedActiveWindowSensorDescription" xml:space="preserve">
     <value>Fournit une valeur ON/OFF selon que le nom de la fenêtre focalisée contient ou non une chaîne configurée.</value>
   </data>
+  <data name="SensorsManager_AccentColorSensorDescription" xml:space="preserve">
+    <value>Fournit les valeurs de couleur #RRGGBB pour les couleurs d'accentuation du système. La couleur d'accentuation principale est la valeur du capteur ; des couleurs d'accentuation supplémentaires sont disponibles sous forme d'attributs.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.nl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.nl.resx
@@ -3437,4 +3437,8 @@ Vereist dat het geconfigureerd is in "Configuratie -&gt; Tray Icon"</value>
   <data name="SensorsManager_NamedActiveWindowSensorDescription" xml:space="preserve">
     <value>Geeft een AAN/UIT-waarde op basis van het al dan niet bevatten van de focusvensternaam van een geconfigureerde tekenreeks.</value>
   </data>
+  <data name="SensorsManager_AccentColorSensorDescription" xml:space="preserve">
+    <value>Biedt #RRGGBB-kleurwaarden voor systeemaccentkleuren.
+De belangrijkste accentkleur is de sensorwaarde. Aanvullende accentkleuren zijn beschikbaar als attributen.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pl.resx
@@ -3526,4 +3526,8 @@ Wymaga konfiguracji w „Configuration -&gt; Tray Icon”</value>
   <data name="SensorsManager_NamedActiveWindowSensorDescription" xml:space="preserve">
     <value>Zapewnia wartość WŁ./WYŁ. w zależności od tego, czy nazwa wybranego okna zawiera skonfigurowany ciąg znaków.</value>
   </data>
+  <data name="SensorsManager_AccentColorSensorDescription" xml:space="preserve">
+    <value>Zapewnia wartości kolorów #RRGGBB dla kolorów akcentowych systemu.
+Główny kolor akcentowy to wartość czujnika, dodatkowe kolory akcentowe są dostępne jako atrybuty.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pt-br.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pt-br.resx
@@ -3462,4 +3462,8 @@ Requer que seja configurado em "Configuration -&gt; Tray Icon"</value>
   <data name="SensorsManager_NamedActiveWindowSensorDescription" xml:space="preserve">
     <value>Fornece um valor ON/OFF com base na presença ou não de uma string configurada no nome da janela em foco.</value>
   </data>
+  <data name="SensorsManager_AccentColorSensorDescription" xml:space="preserve">
+    <value>Fornece valores de cor #RRGGBB para as cores de destaque do sistema.
+A cor de destaque principal é o valor do sensor; cores de destaque adicionais estão disponíveis como atributos.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.resx
@@ -3438,4 +3438,8 @@ Requires it to be configured in "Configuration -&gt; Tray Icon"</value>
   <data name="SensorsManager_NamedActiveWindowSensorDescription" xml:space="preserve">
     <value>Provides an ON/OFF value based on whether the focused window name contains configured string.</value>
   </data>
+  <data name="SensorsManager_AccentColorSensorDescription" xml:space="preserve">
+    <value>Provides #RRGGBB color values for system accent colors.
+Main accent color is the sensor value, additional accent colors are available as attributes.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.ru.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.ru.resx
@@ -3485,4 +3485,8 @@ Home Assistant.
   <data name="SensorsManager_NamedActiveWindowSensorDescription" xml:space="preserve">
     <value>Предоставляет значение ВКЛ/ВЫКЛ в зависимости от того, содержит ли имя окна в фокусе настроенную строку.</value>
   </data>
+  <data name="SensorsManager_AccentColorSensorDescription" xml:space="preserve">
+    <value>Предоставляет значения цвета #RRGGBB для акцентных цветов системы.
+Основной акцентный цвет — это значение датчика, дополнительные акцентные цвета доступны в качестве атрибутов.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.sl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.sl.resx
@@ -3565,4 +3565,8 @@ Zahteva, da je konfiguriran v "Konfiguracija -&gt; Ikona pladnja"</value>
   <data name="SensorsManager_NamedActiveWindowSensorDescription" xml:space="preserve">
     <value>Zagotavlja vrednost VKLOP/IZKLOP glede na to, ali ime okna v fokusu vsebuje konfiguriran niz.</value>
   </data>
+  <data name="SensorsManager_AccentColorSensorDescription" xml:space="preserve">
+    <value>Zagotavlja barvne vrednosti #RRGGBB za sistemske poudarjene barve.
+Glavna poudarjena barva je vrednost senzorja, dodatne poudarjene barve so na voljo kot atributi.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.tr.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.tr.resx
@@ -3032,4 +3032,8 @@ Not: Uydu hizmetinde kullanılırsa kullanıcı alanı uygulamalarını algılam
   <data name="SensorsManager_NamedActiveWindowSensorDescription" xml:space="preserve">
     <value>Odaklanan pencere adının yapılandırılmış dizeyi içerip içermediğine bağlı olarak bir AÇIK/KAPALI değeri sağlar.</value>
   </data>
+  <data name="SensorsManager_AccentColorSensorDescription" xml:space="preserve">
+    <value>Sistem vurgu renkleri için #RRGGBB renk değerleri sağlar.
+Ana vurgu rengi sensör değeridir, ek vurgu renkleri öznitelikler olarak mevcuttur.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Sensors/SensorsManager.cs
+++ b/src/HASS.Agent/HASS.Agent/Sensors/SensorsManager.cs
@@ -390,6 +390,14 @@ namespace HASS.Agent.Sensors
 
             // =================================
 
+            sensorInfoCard = new SensorInfoCard(SensorType.AccentColorSensor,
+                Languages.SensorsManager_AccentColorSensorDescription,
+                120, false, true, false);
+
+            SensorInfoCards.Add(sensorInfoCard.SensorType, sensorInfoCard);
+
+            // =================================
+
             sensorInfoCard = new SensorInfoCard(SensorType.AudioSensors,
                 Languages.SensorsManager_AudioSensorsDescription,
                 20, true, true, true);

--- a/src/HASS.Agent/HASS.Agent/Settings/StoredSensors.cs
+++ b/src/HASS.Agent/HASS.Agent/Settings/StoredSensors.cs
@@ -123,6 +123,9 @@ namespace HASS.Agent.Settings
                 case SensorType.ActiveDesktopSensor:
                     abstractSensor = new ActiveDesktopSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString(), sensor.AdvancedSettings);
                     break;
+                case SensorType.AccentColorSensor:
+                    abstractSensor = new AccentColorSensor(sensor.UpdateInterval, sensor.EntityName, sensor.Name, sensor.Id.ToString(), sensor.AdvancedSettings);
+                    break;
                 case SensorType.NamedWindowSensor:
                     abstractSensor = new NamedWindowSensor(sensor.WindowName, sensor.EntityName, sensor.Name, sensor.UpdateInterval, sensor.Id.ToString(), sensor.AdvancedSettings);
                     break;


### PR DESCRIPTION
This PR adds feature requested by @kineticscreen via https://github.com/hass-agent/HASS.Agent/issues/290.
The new sensor provides main system accent color as a value and all of them as additional attributes.

Example in the mentioned PR.