### PR TITLE
Fix: quick actions window scaling

### DIFF
--- a/src/HASS.Agent/HASS.Agent/Forms/QuickActions/QuickActions.cs
+++ b/src/HASS.Agent/HASS.Agent/Forms/QuickActions/QuickActions.cs
@@ -108,6 +108,10 @@ namespace HASS.Agent.Forms.QuickActions
             if (rows > 1)
                 Height += 5 * (rows - 1);
 
+            var scalingFactor = HelperFunctions.GetScalingFactors();
+            Width = (int)(Width * scalingFactor.dpiScalingFactor);
+            Height = (int)(Height * scalingFactor.dpiScalingFactor);
+
             // add the quickactions as controls
             var currentColumn = 0;
             var currentRow = 0;


### PR DESCRIPTION
This PR fixes issue reported by @MathisP75 via https://github.com/hass-agent/HASS.Agent/issues/258 where the quick actions window would retain the same size, even on systems with scale larger than 100%.