### PR TITLE
Fix: change default hotkey to Shift+Control+Q

### DIFF
--- a/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-6-HotKey.cs
+++ b/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-6-HotKey.cs
@@ -59,7 +59,7 @@ namespace HASS.Agent.Controls.Onboarding
             if (!HelperFunctions.InputLanguageCheckDiffers(out var knownToCollide, out var warning)) return;
 
             // the system's input language is unknown or collides with our hotkey, let the user know if it's set to default
-            if (Variables.AppSettings.QuickActionsHotKey != "Shift, Alt + Q") return;
+            if (Variables.AppSettings.QuickActionsHotKey != "Control, Alt + Q") return;
 
             if (knownToCollide) LblLanguageWarning.Text = warning;
         }

--- a/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-6-HotKey.cs
+++ b/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-6-HotKey.cs
@@ -17,30 +17,41 @@ namespace HASS.Agent.Controls.Onboarding
             // config quick actions hotkey selector
             _hotkeySelector.Enable(TbQuickActionsHotkey);
 
-            // if nothing set, load default
-            if (string.IsNullOrEmpty(Variables.AppSettings.QuickActionsHotKey)) LoadDefault();
-            // if set to empty, show empty
-            else if (Variables.AppSettings.QuickActionsHotKey == _hotkeySelector.EmptyHotkeyText) TbQuickActionsHotkey.Text = _hotkeySelector.EmptyHotkeyText;
-            // show set value
-            else LoadSetValue();
+
+            if (string.IsNullOrEmpty(Variables.AppSettings.QuickActionsHotKey))
+            {
+                // if nothing set, load default
+                LoadDefault();
+            }
+            else if (Variables.AppSettings.QuickActionsHotKey == _hotkeySelector.EmptyHotkeyText)
+            {
+                // if set to empty, show empty
+                TbQuickActionsHotkey.Text = _hotkeySelector.EmptyHotkeyText;
+            }
+            else
+            {
+                // show set value
+                LoadSetValue();
+            }
         }
 
         private void LoadDefault()
         {
-            if (!HelperFunctions.InputLanguageCheckDiffers(out var knownToCollide, out var warning))
-            {
-                TbQuickActionsHotkey.Text = "Shift, Alt + Q";
-                LblLanguageWarning.Visible = false;
-                return;
-            }
+            /*            if (!HelperFunctions.InputLanguageCheckDiffers(out var knownToCollide, out var warning))
+                        {
+                            TbQuickActionsHotkey.Text = "Shift, Alt + Q";
+                            LblLanguageWarning.Visible = false;
+                            return;
+                        }
 
-            if (knownToCollide)
-            {
-                // the system's input language collides with our hotkey, let the user know and set empty key
-                LblLanguageWarning.Text = warning;
-                TbQuickActionsHotkey.Text = _hotkeySelector.EmptyHotkeyText;
-                return;
-            }
+                        if (knownToCollide)
+                        {
+                            // the system's input language collides with our hotkey, let the user know and set empty key
+                            LblLanguageWarning.Text = warning;
+                            TbQuickActionsHotkey.Text = _hotkeySelector.EmptyHotkeyText;
+                            return;
+                        }*/
+            //Amadeo(Note): above was commented out when we changed default hotkey to ctrl+shift+q, leaving this here because reasons
 
             // the system's input language is unknown, we're presetting the default but warn the user
             // deprecated, we're not doing this anymore
@@ -56,12 +67,15 @@ namespace HASS.Agent.Controls.Onboarding
         {
             TbQuickActionsHotkey.Text = Variables.AppSettings.QuickActionsHotKey;
 
-            if (!HelperFunctions.InputLanguageCheckDiffers(out var knownToCollide, out var warning)) return;
+            if (!HelperFunctions.InputLanguageCheckDiffers(out var knownToCollide, out var warning))
+                return;
 
             // the system's input language is unknown or collides with our hotkey, let the user know if it's set to default
-            if (Variables.AppSettings.QuickActionsHotKey != "Control, Alt + Q") return;
+            if (Variables.AppSettings.QuickActionsHotKey != "Control, Alt + Q")
+                return;
 
-            if (knownToCollide) LblLanguageWarning.Text = warning;
+            if (knownToCollide)
+                LblLanguageWarning.Text = warning;
         }
 
         internal bool Store()

--- a/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-6-HotKey.cs
+++ b/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-6-HotKey.cs
@@ -29,7 +29,7 @@ namespace HASS.Agent.Controls.Onboarding
         {
             if (!HelperFunctions.InputLanguageCheckDiffers(out var knownToCollide, out var warning))
             {
-                TbQuickActionsHotkey.Text = "Control, Alt + Q";
+                TbQuickActionsHotkey.Text = "Shift, Alt + Q";
                 LblLanguageWarning.Visible = false;
                 return;
             }
@@ -44,11 +44,11 @@ namespace HASS.Agent.Controls.Onboarding
 
             // the system's input language is unknown, we're presetting the default but warn the user
             // deprecated, we're not doing this anymore
-            //TbQuickActionsHotkey.Text = "Control, Alt + Q";
+            //TbQuickActionsHotkey.Text = "Shift, Alt + Q";
             //LblLanguageWarning.ForeColor = Color.DarkOrange;
             //LblLanguageWarning.Text = warning;
 
-            TbQuickActionsHotkey.Text = "Control, Alt + Q";
+            TbQuickActionsHotkey.Text = "Shift, Alt + Q";
             LblLanguageWarning.Visible = false;
         }
 
@@ -59,7 +59,7 @@ namespace HASS.Agent.Controls.Onboarding
             if (!HelperFunctions.InputLanguageCheckDiffers(out var knownToCollide, out var warning)) return;
 
             // the system's input language is unknown or collides with our hotkey, let the user know if it's set to default
-            if (Variables.AppSettings.QuickActionsHotKey != "Control, Alt + Q") return;
+            if (Variables.AppSettings.QuickActionsHotKey != "Shift, Alt + Q") return;
 
             if (knownToCollide) LblLanguageWarning.Text = warning;
         }


### PR DESCRIPTION
This PR (hopefully once and for all) fixes issue reported by @FatalMerlin via https://github.com/hass-agent/HASS.Agent/issues/219 where the Alt+Control+Q hotkey would mess up with german keyboard layouts.
The default hotkey is changed to Shift+Control+Q as suggested in the issue.

More details can be found within the issue report itself.