### PR TITLE
Fix: added missing AudioManager initialization from satellite service

### DIFF
--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/Functions/HelperFunctions.cs
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/Functions/HelperFunctions.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using HASS.Agent.Satellite.Service.Commands;
 using HASS.Agent.Satellite.Service.Sensors;
+using HASS.Agent.Shared.Managers.Audio;
 using Serilog;
 
 namespace HASS.Agent.Satellite.Service.Functions
@@ -58,6 +59,9 @@ namespace HASS.Agent.Satellite.Service.Functions
 
                 // log our demise
                 Log.Information("[SYSTEM] Service shutting down");
+
+                //stop audio manager
+                AudioManager.Shutdown();
 
                 // stop mqtt
                 await Variables.MqttManager.AnnounceAvailabilityAsync(true);

--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/Worker.cs
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/Worker.cs
@@ -7,6 +7,7 @@ using HASS.Agent.Satellite.Service.Sensors;
 using HASS.Agent.Satellite.Service.Settings;
 using Serilog;
 using HASS.Agent.Shared.Managers;
+using HASS.Agent.Shared.Managers.Audio;
 
 namespace HASS.Agent.Satellite.Service
 {
@@ -57,6 +58,9 @@ namespace HASS.Agent.Satellite.Service
                 // initialize the RPC server
                 _ = Task.Run(RpcManager.Initialize, stoppingToken);
                 
+                // initialize the audio manager
+                _ = Task.Run(AudioManager.Initialize, stoppingToken);
+
                 // initialize the mqtt manager
                 _ = Task.Run(Variables.MqttManager.Initialize, stoppingToken);
 


### PR DESCRIPTION
This PR fixes issue reported via https://github.com/hass-agent/HASS.Agent/issues/311.
There was missing AudioManager initialisation in the worker code that causes AudioSensor not to function properly.