### PR TITLE
Fix: bluetooth dongle radio absence causing application crash

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
         #configuration: [Debug, Release]
         configuration: [Release]
 
-    runs-on: windows-latest  # For a list of available runner types, refer to
+    runs-on: windows-2022  # For a list of available runner types, refer to
                              # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
 
     env:

--- a/src/HASS.Agent/HASS.Agent/HomeAssistant/Commands/InternalCommands/RadioCommand.cs
+++ b/src/HASS.Agent/HASS.Agent/HomeAssistant/Commands/InternalCommands/RadioCommand.cs
@@ -3,6 +3,7 @@ using HASS.Agent.Sensors;
 using HASS.Agent.Shared.Enums;
 using HASS.Agent.Shared.HomeAssistant.Commands;
 using HASS.Agent.Shared.Models.HomeAssistant;
+using Serilog;
 using Windows.Devices.Radios;
 
 namespace HASS.Agent.HomeAssistant.Commands.InternalCommands
@@ -11,29 +12,50 @@ namespace HASS.Agent.HomeAssistant.Commands.InternalCommands
     {
         private const string DefaultName = "radiocommand";
 
-        private readonly Radio _radio;
+        private Radio _radio;
 
         public string RadioName { get; set; }
 
         internal RadioCommand(string radioName, string entityName = DefaultName, string name = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(entityName ?? DefaultName, name ?? null, radioName, entityType, id)
         {
             RadioName = radioName;
-            _radio = RadioManager.AvailableRadio.First(r => r.Name == radioName);
+            _radio = RadioManager.AvailableRadio.FirstOrDefault(r => r.Name == radioName);
+
+            if (_radio == null)
+            {
+                Log.Warning("[RADIOCOMMAND] [{name}] '{radioName}' not present, will retry to find on each command execution", EntityName, radioName);
+            }
         }
 
         public override void TurnOn()
         {
-            Task.Run(async () => { await _radio.SetStateAsync(RadioState.On); });
+            if (_radio == null)
+            {
+                _radio = RadioManager.AvailableRadio.FirstOrDefault(r => r.Name == RadioName);
+            }
+
+            if (_radio != null)
+            {
+                Task.Run(async () => { await _radio.SetStateAsync(RadioState.On); });
+            }
         }
 
         public override void TurnOff()
         {
-            Task.Run(async () => { await _radio.SetStateAsync(RadioState.Off); });
+            if (_radio == null)
+            {
+                _radio = RadioManager.AvailableRadio.FirstOrDefault(r => r.Name == RadioName);
+            }
+
+            if (_radio != null)
+            {
+                Task.Run(async () => { await _radio.SetStateAsync(RadioState.Off); });
+            }
         }
 
         public override string GetState()
         {
-            return _radio.State == RadioState.On ? "ON" : "OFF";
+            return _radio != null ? (_radio.State == RadioState.On ? "ON" : "OFF") : "OFF";
         }
     }
 }


### PR DESCRIPTION
This PR fixes issue reported by @barrelltitor via https://github.com/hass-agent/HASS.Agent/issues/331 where configuring bluetooth dongle with RadioCommand and then removing the dongle would cause HASS.Agent to crash/be unable to start.