### PR TITLE
Fix: crash when trayicon web view screen was not manually configured

### DIFF
--- a/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigTrayIcon.cs
+++ b/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigTrayIcon.cs
@@ -21,41 +21,28 @@ namespace HASS.Agent.Controls.Configuration
 
         private void InitMultiScreenConfig()
         {
-            var primaryScreenIndex = 0;
-            var displays = Screen.AllScreens;
-
+            if (Variables.AppSettings.TrayIconWebViewScreen == -1)
+            {
+                HelperFunctions.InitMultiScreenConfig();
+            }
+            
             if (Screen.AllScreens.Length == 1)
             {
-                Variables.AppSettings.TrayIconWebViewScreen = 0;
                 NumWebViewScreen.Visible = true;
                 NumWebViewScreen.Items.Add("Single Screen Mode");
                 NumWebViewScreen.Enabled = false;
             }
             else
             {
-                for (var i = 0; i < displays.Length; i++)
+                foreach (var display in Screen.AllScreens)
                 {
-                    var display = displays[i];
-
-                    if (display.Primary)
-                    {
-                        primaryScreenIndex = i;
-                    }
-
-                    string label = display.Primary ? $"{display.DeviceName} (Primary)" : display.DeviceName;
+                    var label = display.Primary ? $"{display.DeviceName} (Primary)" : display.DeviceName;
                     NumWebViewScreen.Items.Add(label);
                 }
             }
 
-            var selectedScreenIndex = Variables.AppSettings.TrayIconWebViewScreen;
-
-            if (selectedScreenIndex == -1)
-            {
-                selectedScreenIndex = primaryScreenIndex;
-            }
-
-            NumWebViewScreen.SelectedIndex = selectedScreenIndex;
-            SelectedScreen = selectedScreenIndex;
+            NumWebViewScreen.SelectedIndex = Variables.AppSettings.TrayIconWebViewScreen;
+            SelectedScreen = Variables.AppSettings.TrayIconWebViewScreen;
         }
 
         private void CbDefaultMenu_CheckedChanged(object sender, EventArgs e)

--- a/src/HASS.Agent/HASS.Agent/Functions/HelperFunctions.cs
+++ b/src/HASS.Agent/HASS.Agent/Functions/HelperFunctions.cs
@@ -522,6 +522,12 @@ namespace HASS.Agent.Functions
 
         private static void LaunchTrayIconCustomWebView(WebViewInfo webViewInfo, int screenIndex = 0)
         {
+            if (screenIndex == -1)
+            {
+                InitMultiScreenConfig();
+                screenIndex = Variables.AppSettings.TrayIconWebViewScreen;
+            }
+
             Variables.MainForm.Invoke(new MethodInvoker(delegate
             {
                 var totalX = 0;
@@ -552,8 +558,34 @@ namespace HASS.Agent.Functions
                 webView.Top = targetScreen.WorkingArea.Bottom - webView.Height;
 
                 Variables.TrayIconWebView = webView;
-                
+
             }));
+        }
+
+        public static void InitMultiScreenConfig()
+        {
+            var primaryScreenIndex = 0;
+            var displays = Screen.AllScreens;
+
+            if (Screen.AllScreens.Length == 1)
+            {
+                Variables.AppSettings.TrayIconWebViewScreen = 0;
+            }
+            else
+            {
+                for (var i = 0; i < displays.Length; i++)
+                {
+                    var display = displays[i];
+
+                    if (display.Primary)
+                    {
+                        primaryScreenIndex = i;
+                        break;
+                    }
+                }
+            }
+
+            Variables.AppSettings.TrayIconWebViewScreen = primaryScreenIndex;
         }
 
         private static readonly Dictionary<IntPtr, string> KnownOkInputLanguage = new()


### PR DESCRIPTION
This PR fixes issue reported via https://github.com/hass-agent/HASS.Agent/issues/343 where the default webview screen configuration would not be initialised before showing the webview. This resulted in application crash.