### PR TITLE
Fix: launch parameters ignored for LaunchUrlCommand

### DIFF
--- a/src/HASS.Agent/HASS.Agent/Functions/HelperFunctions.cs
+++ b/src/HASS.Agent/HASS.Agent/Functions/HelperFunctions.cs
@@ -371,9 +371,9 @@ namespace HASS.Agent.Functions
         /// </summary>
         /// <param name="url"></param>
         /// <param name="incognito"></param>
-        internal static void LaunchUrl(string url, bool incognito = false)
+        internal static void LaunchUrl(string url, bool incognito = false, bool explicitUrl = false)
         {
-            var targetUrl = StorageManager.GetElementUrl(url);
+            var targetUrl = explicitUrl ? url : StorageManager.GetElementUrl(url);
 
             // did the user provide a browser?
             if (string.IsNullOrEmpty(Variables.AppSettings.BrowserBinary))

--- a/src/HASS.Agent/HASS.Agent/HomeAssistant/Commands/InternalCommands/LaunchUrlCommand.cs
+++ b/src/HASS.Agent/HASS.Agent/HomeAssistant/Commands/InternalCommands/LaunchUrlCommand.cs
@@ -39,7 +39,7 @@ namespace HASS.Agent.HomeAssistant.Commands.InternalCommands
                 return;
             }
 
-            HelperFunctions.LaunchUrl(_url, _incognito);
+            HelperFunctions.LaunchUrl(_url, _incognito, true);
 
             State = "OFF";
         }
@@ -59,7 +59,7 @@ namespace HASS.Agent.HomeAssistant.Commands.InternalCommands
             // prepare command
             var command = string.IsNullOrWhiteSpace(_url) ? action : $"{_url} {action}";
 
-            HelperFunctions.LaunchUrl(command, _incognito);
+            HelperFunctions.LaunchUrl(command, _incognito, true);
 
             State = "OFF";
         }


### PR DESCRIPTION
This PR fixes issue reported via https://github.com/hass-agent/HASS.Agent/issues/415 by @juhavt where LaunchUrlCommand would not treat the provided action URL explicitly but instead a base URL was added (this behaviour was added to match the android companion app and LaunchUrlCommand case missed)
