### PR TITLE
Fix: MQTT connection test using proper username & password

### DIFF
--- a/src/HASS.Agent/HASS.Agent/MQTT/MqttManager.cs
+++ b/src/HASS.Agent/HASS.Agent/MQTT/MqttManager.cs
@@ -917,7 +917,7 @@ namespace HASS.Agent.MQTT
                     clientOptionsBuilder.WithTcpServer(address, port);
                 }
 
-                if (!string.IsNullOrEmpty(Variables.AppSettings.MqttUsername))
+                if (!string.IsNullOrEmpty(username))
                 {
                     clientOptionsBuilder.WithCredentials(username, password);
                 }


### PR DESCRIPTION
This PR fixes issue reported via https://github.com/hass-agent/HASS.Agent/issues/396 by @jwidess where MQTT connection test during initial onboarding would check "configured" username rather than the provided one.
