### PR TITLE
Fix: MonitorSleepCommand causes Ctrl+C in the active console

### DIFF
--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/InternalCommands/MonitorSleepCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Commands/InternalCommands/MonitorSleepCommand.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Windows.Forms;
 using HASS.Agent.Shared.Enums;
 using HASS.Agent.Shared.Functions;
 using Serilog;
@@ -25,7 +26,8 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.InternalCommands
         {
             State = "ON";
 
-            NativeMethods.PostMessage(NativeMethods.HWND_BROADCAST, NativeMethods.WM_SYSCOMMAND, (IntPtr)NativeMethods.SC_MONITORPOWER, (IntPtr)2);
+            using var form = new Form();
+            NativeMethods.SendMessage(form.Handle, NativeMethods.WM_SYSCOMMAND, (IntPtr)NativeMethods.SC_MONITORPOWER, (IntPtr)2);
 
             State = "OFF";
         }


### PR DESCRIPTION
## Problem

The `MonitorSleepCommand` uses `PostMessage` with `HWND_BROADCAST` to send `WM_SYSCOMMAND`/`SC_MONITORPOWER`. This broadcasts the message to every top-level window in the system, which is unnecessary and causes an annoying side effect: the active console window receives a Ctrl+C signal whenever the monitor goes to sleep.

This cancels running commands and interrupts long-running terminal sessions, which is pretty frustrating if you have builds, SSH sessions, or anything else running in a terminal.

## Fix

- Replace `HWND_BROADCAST` with a temporary `Form` handle
- Use `SendMessage` instead of `PostMessage`

`DefWindowProc` handles `SC_MONITORPOWER` at the system level regardless of which window receives the message, so the monitor still turns off correctly. Only one window needs to get the message.

Microsoft also recommends against using `HWND_BROADCAST` for this purpose:
- https://learn.microsoft.com/en-us/answers/questions/895451
- https://learn.microsoft.com/en-us/windows-hardware/drivers/devtest/28601-avoid-blocking-on-hwnd-broadcast

## Test plan

- [x] Verified that the monitor still goes to sleep when the command is triggered
- [x] Verified that console windows no longer receive Ctrl+C
- [x] Build passes with no new warnings