### PR TITLE
Fix LastActiveSensor reporting wrong time after ~25 days uptime

### DIFF
--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/LastActiveSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/LastActiveSensor.cs
@@ -86,12 +86,12 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
             lastInputInfo.cbSize = Marshal.SizeOf(lastInputInfo);
             lastInputInfo.dwTime = 0;
 
-            var envTicks = Environment.TickCount;
+            var envTicks = Environment.TickCount64;
 
             if (!GetLastInputInfo(ref lastInputInfo))
                 return DateTime.Now;
 
-            var lastInputTick = Convert.ToDouble(lastInputInfo.dwTime);
+            var lastInputTick = (long)lastInputInfo.dwTime;
 
             var idleTime = envTicks - lastInputTick;
             return idleTime > 0 ? DateTime.Now - TimeSpan.FromMilliseconds(idleTime) : DateTime.Now;


### PR DESCRIPTION
## Problem

`LastActiveSensor.GetLastInputTime()` uses `Environment.TickCount` (Int32) to calculate how long ago the last user input happened. `Environment.TickCount` counts milliseconds since boot and overflows from +2,147,483,647 to -2,147,483,648 after about 24.9 days of uptime.

The Win32 `GetLastInputInfo` API returns `dwTime` as UInt32, which stays positive. After the overflow, the subtraction `envTicks - lastInputTick` always produces a negative number, so the method always returns `DateTime.Now` regardless of actual user activity.

This means `sensor.pc_lastactive` in Home Assistant always shows the current time after ~25 days of uptime, and any automation that checks idle time against this sensor stops working.

## Fix

Replace `Environment.TickCount` with `Environment.TickCount64` (Int64). This returns the same millisecond count but won't overflow for about 292 million years.

Also changed `Convert.ToDouble(lastInputInfo.dwTime)` to `(long)lastInputInfo.dwTime` so the arithmetic stays in integer types instead of going through floating point for no reason.

## Testing

Verified on a machine with 30 days of uptime. Before the fix, the sensor kept reporting `DateTime.Now` every update cycle. After the fix, the sensor correctly freezes at the last input timestamp and stays there while idle.