### PR TITLE
Fix: NullReferenceException in Satellite Service on unknown types

### DIFF
--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/Settings/StoredCommands.cs
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/Settings/StoredCommands.cs
@@ -1,4 +1,4 @@
-﻿using HASS.Agent.Shared.Enums;
+using HASS.Agent.Shared.Enums;
 using HASS.Agent.Shared.Models.Config;
 using HASS.Agent.Shared.HomeAssistant.Commands;
 using HASS.Agent.Shared.HomeAssistant.Commands.CustomCommands;
@@ -56,7 +56,10 @@ namespace HASS.Agent.Satellite.Service.Settings
                 // convert to abstract commands
                 await Task.Run(delegate
                 {
-                    foreach (var abstractCommand in configuredCommands.Select(ConvertConfiguredToAbstract)) Variables.Commands.Add(abstractCommand!);
+                    foreach (var abstractCommand in configuredCommands.Select(ConvertConfiguredToAbstract))
+                    {
+                        if (abstractCommand != null) Variables.Commands.Add(abstractCommand);
+                    }
                 });
 
                 // all good

--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/Settings/StoredSensors.cs
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/Settings/StoredSensors.cs
@@ -1,4 +1,4 @@
-﻿using HASS.Agent.Shared.Enums;
+using HASS.Agent.Shared.Enums;
 using HASS.Agent.Shared.Models.Config;
 using HASS.Agent.Satellite.Service.Extensions;
 using HASS.Agent.Shared.HomeAssistant.Sensors;
@@ -61,8 +61,16 @@ namespace HASS.Agent.Satellite.Service.Settings
                 {
                     foreach (var sensor in configuredSensors)
                     {
-                        if (sensor.IsSingleValue()) Variables.SingleValueSensors.Add(ConvertConfiguredToAbstractSingleValue(sensor)!);
-                        else Variables.MultiValueSensors.Add(ConvertConfiguredToAbstractMultiValue(sensor)!);
+                        if (sensor.IsSingleValue())
+                        {
+                            var abstractSensor = ConvertConfiguredToAbstractSingleValue(sensor);
+                            if (abstractSensor != null) Variables.SingleValueSensors.Add(abstractSensor);
+                        }
+                        else
+                        {
+                            var abstractSensor = ConvertConfiguredToAbstractMultiValue(sensor);
+                            if (abstractSensor != null) Variables.MultiValueSensors.Add(abstractSensor);
+                        }
                     }
                 });
 


### PR DESCRIPTION
The Satellite Service currently crashes with a NullReferenceException if the configuration contains entity types it doesn't support (like WebView commands or Bluetooth sensors). This happens because the conversion logic returns null but the caller still adds it to the active collection and later tries to publish it. This PR adds null checks to safely skip these unknown types. Without the fix it gives no indication to the user that something went wrong and instead constantly fails silently in the service logs.