### PR TITLE
feat(satellite): prioritize service-specific configuration files

### DIFF
--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/Settings/StoredCommands.cs
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/Settings/StoredCommands.cs
@@ -28,7 +28,11 @@ namespace HASS.Agent.Satellite.Service.Settings
                 Variables.Commands = new List<AbstractCommand>();
 
                 // check for existing file
-                if (!File.Exists(Variables.CommandsFile))
+                Variables.LoadedCommandsFile = File.Exists(Variables.ServiceCommandsFile)
+                    ? Variables.ServiceCommandsFile
+                    : Variables.CommandsFile;
+
+                if (!File.Exists(Variables.LoadedCommandsFile))
                 {
                     // none yet
                     Log.Information("[SETTINGS_COMMANDS] Config not found, no entities loaded");
@@ -36,7 +40,7 @@ namespace HASS.Agent.Satellite.Service.Settings
                 }
 
                 // read the content
-                var commandsRaw = await File.ReadAllTextAsync(Variables.CommandsFile);
+                var commandsRaw = await File.ReadAllTextAsync(Variables.LoadedCommandsFile);
                 if (string.IsNullOrWhiteSpace(commandsRaw))
                 {
                     Log.Information("[SETTINGS_COMMANDS] Config is empty, no entities loaded");
@@ -265,7 +269,7 @@ namespace HASS.Agent.Satellite.Service.Settings
 
                 // serialize to file
                 var commands = JsonConvert.SerializeObject(configuredCommands, Formatting.Indented);
-                File.WriteAllText(Variables.CommandsFile, commands);
+                File.WriteAllText(Variables.LoadedCommandsFile ?? Variables.CommandsFile, commands);
 
                 // done
                 Log.Information("[SETTINGS_COMMANDS] Stored {count} entities", Variables.Commands.Count);

--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/Settings/StoredCommands.cs
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/Settings/StoredCommands.cs
@@ -1,4 +1,4 @@
-﻿using HASS.Agent.Shared.Enums;
+using HASS.Agent.Shared.Enums;
 using HASS.Agent.Shared.Models.Config;
 using HASS.Agent.Shared.HomeAssistant.Commands;
 using HASS.Agent.Shared.HomeAssistant.Commands.CustomCommands;
@@ -56,7 +56,10 @@ namespace HASS.Agent.Satellite.Service.Settings
                 // convert to abstract commands
                 await Task.Run(delegate
                 {
-                    foreach (var abstractCommand in configuredCommands.Select(ConvertConfiguredToAbstract)) Variables.Commands.Add(abstractCommand!);
+                    foreach (var abstractCommand in configuredCommands.Select(ConvertConfiguredToAbstract))
+                    {
+                        if (abstractCommand != null) Variables.Commands.Add(abstractCommand);
+                    }
                 });
 
                 // all good

--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/Settings/StoredSensors.cs
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/Settings/StoredSensors.cs
@@ -31,7 +31,11 @@ namespace HASS.Agent.Satellite.Service.Settings
                 Variables.MultiValueSensors = new List<AbstractMultiValueSensor>();
 
                 // check for existing file
-                if (!File.Exists(Variables.SensorsFile))
+                Variables.LoadedSensorsFile = File.Exists(Variables.ServiceSensorsFile)
+                    ? Variables.ServiceSensorsFile
+                    : Variables.SensorsFile;
+
+                if (!File.Exists(Variables.LoadedSensorsFile))
                 {
                     // none yet
                     Log.Information("[SETTINGS_SENSORS] Config not found, no entities loaded");
@@ -39,7 +43,7 @@ namespace HASS.Agent.Satellite.Service.Settings
                 }
 
                 // read the content
-                var sensorsRaw = await File.ReadAllTextAsync(Variables.SensorsFile);
+                var sensorsRaw = await File.ReadAllTextAsync(Variables.LoadedSensorsFile);
                 if (string.IsNullOrWhiteSpace(sensorsRaw))
                 {
                     Log.Information("[SETTINGS_SENSORS] Config is empty, no entities loaded");
@@ -504,7 +508,7 @@ namespace HASS.Agent.Satellite.Service.Settings
 
                 // serialize to file
                 var sensors = JsonConvert.SerializeObject(configuredSensors, Formatting.Indented);
-                File.WriteAllText(Variables.SensorsFile, sensors);
+                File.WriteAllText(Variables.LoadedSensorsFile ?? Variables.SensorsFile, sensors);
 
                 // done
                 Log.Information("[SETTINGS_SENSORS] Stored {count} entities", (Variables.SingleValueSensors.Count + Variables.MultiValueSensors.Count));

--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/Settings/StoredSensors.cs
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/Settings/StoredSensors.cs
@@ -1,4 +1,4 @@
-﻿using HASS.Agent.Shared.Enums;
+using HASS.Agent.Shared.Enums;
 using HASS.Agent.Shared.Models.Config;
 using HASS.Agent.Satellite.Service.Extensions;
 using HASS.Agent.Shared.HomeAssistant.Sensors;
@@ -61,8 +61,16 @@ namespace HASS.Agent.Satellite.Service.Settings
                 {
                     foreach (var sensor in configuredSensors)
                     {
-                        if (sensor.IsSingleValue()) Variables.SingleValueSensors.Add(ConvertConfiguredToAbstractSingleValue(sensor)!);
-                        else Variables.MultiValueSensors.Add(ConvertConfiguredToAbstractMultiValue(sensor)!);
+                        if (sensor.IsSingleValue())
+                        {
+                            var abstractSensor = ConvertConfiguredToAbstractSingleValue(sensor);
+                            if (abstractSensor != null) Variables.SingleValueSensors.Add(abstractSensor);
+                        }
+                        else
+                        {
+                            var abstractSensor = ConvertConfiguredToAbstractMultiValue(sensor);
+                            if (abstractSensor != null) Variables.MultiValueSensors.Add(abstractSensor);
+                        }
                     }
                 });
 

--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/Variables.cs
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/Variables.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using GrpcDotNetNamedPipes;
 using HASS.Agent.Shared.Models.Config.Service;
 using HASS.Agent.Shared.Models.HomeAssistant;
@@ -45,7 +45,9 @@ namespace HASS.Agent.Satellite.Service
         internal static string ServiceSettingsFile { get; } = Path.Combine(ConfigPath, "servicesettings.json");
         internal static string ServiceMqttSettingsFile { get; } = Path.Combine(ConfigPath, "servicemqttsettings.json");
         internal static string CommandsFile { get; } = Path.Combine(ConfigPath, "commands.json");
+        internal static string ServiceCommandsFile { get; } = Path.Combine(ConfigPath, "servicecommands.json");
         internal static string SensorsFile { get; } = Path.Combine(ConfigPath, "sensors.json");
+        internal static string ServiceSensorsFile { get; } = Path.Combine(ConfigPath, "servicesensors.json");
 
         /// <summary>
         /// Internal state
@@ -67,7 +69,9 @@ namespace HASS.Agent.Satellite.Service
         internal static ServiceSettings? ServiceSettings { get; set; } = new();
         internal static ServiceMqttSettings? ServiceMqttSettings { get; set; } = new();
         internal static List<AbstractCommand> Commands { get; set; } = new();
+        internal static string LoadedCommandsFile { get; set; } = string.Empty;
         internal static List<AbstractSingleValueSensor> SingleValueSensors { get; set; } = new();
         internal static List<AbstractMultiValueSensor> MultiValueSensors { get; set; } = new();
+        internal static string LoadedSensorsFile { get; set; } = string.Empty;
     }
 }


### PR DESCRIPTION
This PR introduces support for service-specific configuration files (servicecommands.json and servicesensors.json) in the Satellite Service. If these files exist in the config directory, the service will prioritize them over the standard global configuration files. This allows for dedicated service configurations without impacting the main HASS.Agent UI-managed entities.

Additionally, this PR includes the NullReferenceException fixes for unknown entity types (previously submitted in #441), ensuring the service remains stable when skipping unsupported entities.