### PR TITLE
Fix: Virtual Desktop issues with missing dependency

### DIFF
--- a/src/HASS.Agent/HASS.Agent/HASS.Agent.csproj
+++ b/src/HASS.Agent/HASS.Agent/HASS.Agent.csproj
@@ -68,6 +68,7 @@
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3296.44">
       <Aliases></Aliases>
     </PackageReference>
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.250606001" />
     <PackageReference Include="MQTTnet" Version="4.3.3.952" />
     <PackageReference Include="MQTTnet.Extensions.ManagedClient" Version="4.3.3.952" />


### PR DESCRIPTION
This PR fixes issue reported by @madface303 via https://github.com/hass-agent/HASS.Agent/issues/419
It adds Microsoft.Windows.CsWinRT nuget dependency to satisfy the 2.2.0 requirement for WinRT.Runtime.dll

Huge thanks to @AstralBlader for their investigation and hints!