### PR TITLE
Feature: single instance handling

### DIFF
--- a/src/HASS.Agent/HASS.Agent.Shared/HASS.Agent.Shared.csproj
+++ b/src/HASS.Agent/HASS.Agent.Shared/HASS.Agent.Shared.csproj
@@ -46,7 +46,7 @@
     <PackageReference Include="System.Reactive" Version="6.0.1" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="9.0.6" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="9.0.6" />
-    <PackageReference Include="Vanara.PInvoke.PowrProf" Version="4.2.1" />
+    <PackageReference Include="Vanara.PInvoke.PowrProf" Version="5.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/HASS.Agent/HASS.Agent/HASS.Agent.csproj
+++ b/src/HASS.Agent/HASS.Agent/HASS.Agent.csproj
@@ -86,6 +86,8 @@
     <PackageReference Include="Syncfusion.Shared.Base" Version="20.3.0.50" />
     <PackageReference Include="Syncfusion.Tools.Windows" Version="20.3.0.50" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="9.0.6" />
+    <PackageReference Include="Vanara.PInvoke.Ole" Version="5.0.7" />
+    <PackageReference Include="Vanara.PInvoke.User32" Version="5.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/HASS.Agent/HASS.Agent/Program.cs
+++ b/src/HASS.Agent/HASS.Agent/Program.cs
@@ -17,6 +17,7 @@ using HASS.Agent.Shared.Managers;
 using Microsoft.Windows.AppLifecycle;
 using Serilog;
 using Serilog.Events;
+using Vanara.PInvoke;
 
 namespace HASS.Agent
 {
@@ -39,11 +40,18 @@ namespace HASS.Agent
         [STAThread]
         private static void Main(string[] args)
         {
+            WinRT.ComWrappersSupport.InitializeComWrappers();
+            var redirectRequired = CheckRedirection();
+
+            if (redirectRequired)
+            {
+                return;
+            }
+
             using var appMutex = new Mutex(false, "HASS.Agent.App.Mutex");
 
             try
             {
-
                 Syncfusion.Licensing.SyncfusionLicenseProvider.RegisterLicense(Variables.SyncfusionLicense);
 
                 LoggingManager.PrepareLogging(args);
@@ -85,7 +93,7 @@ namespace HASS.Agent
                 }
 
                 LocalizationManager.Initialize();
-                                                                                               
+
                 Application.SetDefaultFont(Variables.DefaultFont);
 
                 Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
@@ -119,12 +127,51 @@ namespace HASS.Agent
             }
         }
 
+        private static bool CheckRedirection()
+        {
+            var redirectRequired = false;
+            var args = AppInstance.GetCurrent().GetActivatedEventArgs();
+            var keyInstance = AppInstance.FindOrRegisterForKey("HASS.Agent.App.Instance.Key");
+
+            if (keyInstance.IsCurrent)
+            {
+                keyInstance.Activated += OnActivated;
+            }
+            else
+            {
+                redirectRequired = true;
+                RedirectActivationTo(args, keyInstance);
+            }
+
+            return redirectRequired;
+        }
+
+        private static void RedirectActivationTo(AppActivationArguments args, AppInstance keyInstance)
+        {
+            using var redirectEventHandle = Kernel32.CreateEvent(null, true);
+            Task.Run(() =>
+            {
+                keyInstance.RedirectActivationToAsync(args).AsTask().Wait();
+                Kernel32.SetEvent(redirectEventHandle);
+            });
+
+            _ = Ole32.CoWaitForMultipleObjects(Ole32.CWMO_FLAGS.CWMO_DEFAULT, 0xFFFFFFFF, [redirectEventHandle.DangerousGetHandle()], out _);
+
+            var process = Process.GetProcessById((int)keyInstance.ProcessId);
+            User32.SetForegroundWindow(process.MainWindowHandle);
+        }
+
+        private static void OnActivated(object sender, AppActivationArguments args)
+        {
+            Variables.MainForm.Invoke(new MethodInvoker(Variables.MainForm.Show)); //NOTE(Amadeo): potential place to handle any advanced activation
+        }
+
         /// <summary>
         /// Checks whether we're asked to launch as a child application
         /// </summary>
         /// <param name="args"></param>
         /// <returns></returns>
-        internal static bool LaunchAsChildApplication(string[] args)
+        private static bool LaunchAsChildApplication(string[] args)
         {
             return args.Any(x => x == LaunchParamUpdate)
                    || args.Any(x => x == LaunchPortReservation)

--- a/src/HASS.Agent/HASS.Agent/Program.cs
+++ b/src/HASS.Agent/HASS.Agent/Program.cs
@@ -163,7 +163,7 @@ namespace HASS.Agent
 
         private static void OnActivated(object sender, AppActivationArguments args)
         {
-            Variables.MainForm.Invoke(new MethodInvoker(Variables.MainForm.Show)); //NOTE(Amadeo): potential place to handle any advanced activation
+            Variables.MainForm.Invoke(new MethodInvoker(Variables.MainForm.Show)); //NOTE(Amadeo): potential place to handle any advanced or third-party activation
         }
 
         /// <summary>


### PR DESCRIPTION
This PR adds feature requested via https://github.com/hass-agent/HASS.Agent/issues/463 that makes HASS.Agent a "single instance app".
Running .exe file again after HASS.Agent is already running, will cause it to be put into focus (and maximised  if main window is currently closed)