### PR TITLE
Fix: decimal sensor value separator (invariant culture)

### DIFF
--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/DataTypes/DataTypeBoolSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/DataTypes/DataTypeBoolSensor.cs
@@ -66,7 +66,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.Data
         public void SetState(bool value) => _value = value;
         public void SetAttributes(string value) => _attributes = string.IsNullOrWhiteSpace(value) ? "{}" : value;
 
-        public override string GetState() => _value.ToString(CultureInfo.CurrentCulture);
+        public override string GetState() => _value.ToString(CultureInfo.InvariantCulture);
         public override string GetAttributes() => _attributes;
     }
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/DataTypes/DataTypeDoubleSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/DataTypes/DataTypeDoubleSensor.cs
@@ -77,7 +77,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.Data
         public void SetState(double value) => _value = value;
         public void SetAttributes(string value) => _attributes = string.IsNullOrWhiteSpace(value) ? "{}" : value;
 
-        public override string GetState() => _value.ToString(CultureInfo.CurrentCulture);
+        public override string GetState() => _value.ToString(CultureInfo.InvariantCulture);
         public override string GetAttributes() => _attributes;
     }
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/PerformanceCounterSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/PerformanceCounterSensor.cs
@@ -64,13 +64,13 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors
             var nextVal = Counter.NextValue();
 
             // optionally apply rounding
-            if (ApplyRounding && Round != null && double.TryParse(nextVal.ToString(CultureInfo.CurrentCulture), out var dblValue))
+            if (ApplyRounding && Round != null && double.TryParse(nextVal.ToString(CultureInfo.InvariantCulture), out var dblValue))
             {
-                return Math.Round(dblValue, (int)Round).ToString(CultureInfo.CurrentCulture);
+                return Math.Round(dblValue, (int)Round).ToString(CultureInfo.InvariantCulture);
             }
 
             // done
-            return Math.Round(nextVal).ToString(CultureInfo.CurrentCulture);
+            return Math.Round(nextVal).ToString(CultureInfo.InvariantCulture);
         }
 
         public override string GetAttributes() => string.Empty;

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/PowershellSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/PowershellSensor.cs
@@ -57,7 +57,7 @@ public class PowershellSensor : AbstractSingleValueSensor
             return errors.Trim();
 
         // optionally apply rounding
-        if (ApplyRounding && Round != null && double.TryParse(output, out var dblValue)) { output = Math.Round(dblValue, (int)Round).ToString(CultureInfo.CurrentCulture); }
+        if (ApplyRounding && Round != null && double.TryParse(output, out var dblValue)) { output = Math.Round(dblValue, (int)Round).ToString(CultureInfo.InvariantCulture); }
 
         // done
         return string.IsNullOrWhiteSpace(errors) ? output : $"{output} | {errors}";

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/WmiQuerySensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/WmiQuerySensor.cs
@@ -99,7 +99,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors
                 // optionally apply rounding
                 if (ApplyRounding && Round != null && double.TryParse(retValue, out var dblValue))
                 {
-                    retValue = Math.Round(dblValue, (int)Round).ToString(CultureInfo.CurrentCulture);
+                    retValue = Math.Round(dblValue, (int)Round).ToString(CultureInfo.InvariantCulture);
                 }
 
                 // done


### PR DESCRIPTION
This PR fixes a bug/s reported via https://github.com/hass-agent/HASS.Agent/issues/457 where due to local culture, decimal point separator used by windows would not be accepted by Home Assistant (which accepts only ".")