### PR TITLE
Fix microphone and webcam activity detection on current Windows builds

### DIFF
--- a/src/HASS.Agent.sln
+++ b/src/HASS.Agent.sln
@@ -12,6 +12,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HASS.Agent.Shared", "HASS.A
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HASS.Agent.Satellite.Service", "HASS.Agent\HASS.Agent.Satellite.Service\HASS.Agent.Satellite.Service.csproj", "{C4138592-B05C-4B3D-B55C-A1337E97CDDD}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HASS.Agent.Shared.Tests", "..\tests\HASS.Agent.Shared.Tests\HASS.Agent.Shared.Tests.csproj", "{A4B3178C-C0F9-47C1-9CC3-8B65B26756F0}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8807B76C-04C9-408D-9ED7-BD1FEC59D0F8}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
@@ -63,6 +65,18 @@ Global
 		{C4138592-B05C-4B3D-B55C-A1337E97CDDD}.Release|x64.Build.0 = Release|Any CPU
 		{C4138592-B05C-4B3D-B55C-A1337E97CDDD}.Release|x86.ActiveCfg = Release|x86
 		{C4138592-B05C-4B3D-B55C-A1337E97CDDD}.Release|x86.Build.0 = Release|x86
+		{A4B3178C-C0F9-47C1-9CC3-8B65B26756F0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A4B3178C-C0F9-47C1-9CC3-8B65B26756F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A4B3178C-C0F9-47C1-9CC3-8B65B26756F0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A4B3178C-C0F9-47C1-9CC3-8B65B26756F0}.Debug|x64.Build.0 = Debug|Any CPU
+		{A4B3178C-C0F9-47C1-9CC3-8B65B26756F0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A4B3178C-C0F9-47C1-9CC3-8B65B26756F0}.Debug|x86.Build.0 = Debug|Any CPU
+		{A4B3178C-C0F9-47C1-9CC3-8B65B26756F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A4B3178C-C0F9-47C1-9CC3-8B65B26756F0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A4B3178C-C0F9-47C1-9CC3-8B65B26756F0}.Release|x64.ActiveCfg = Release|Any CPU
+		{A4B3178C-C0F9-47C1-9CC3-8B65B26756F0}.Release|x64.Build.0 = Release|Any CPU
+		{A4B3178C-C0F9-47C1-9CC3-8B65B26756F0}.Release|x86.ActiveCfg = Release|Any CPU
+		{A4B3178C-C0F9-47C1-9CC3-8B65B26756F0}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/MicrophoneActiveSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/MicrophoneActiveSensor.cs
@@ -1,6 +1,5 @@
-﻿using System.Linq;
+using HASS.Agent.Shared.HomeAssistant.Sensors.MediaActivity;
 using HASS.Agent.Shared.Models.HomeAssistant;
-using Microsoft.Win32;
 
 namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
 {
@@ -10,13 +9,21 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
     public class MicrophoneActiveSensor : AbstractSingleValueSensor
     {
         private const string DefaultName = "microphoneactive";
+        private readonly IMediaActivityProvider _mediaActivityProvider;
 
-        public MicrophoneActiveSensor(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default, string advancedSettings = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 10, id, advancedSettings: advancedSettings)
+        public MicrophoneActiveSensor(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default, string advancedSettings = default)
+            : this(MediaActivityProvider.Instance, updateInterval, entityName, name, id, advancedSettings)
         {
+        }
+
+        internal MicrophoneActiveSensor(IMediaActivityProvider mediaActivityProvider, int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default, string advancedSettings = default)
+            : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 10, id, advancedSettings: advancedSettings)
+        {
+            _mediaActivityProvider = mediaActivityProvider;
             Domain = "binary_sensor";
         }
 
-        public override string GetState() => IsMicrophoneInUse() ? "ON" : "OFF";
+        public override string GetState() => _mediaActivityProvider.GetActivity(MediaActivityKind.Microphone).IsActive ? "ON" : "OFF";
 
         public override DiscoveryConfigModel GetAutoDiscoveryConfig()
         {
@@ -39,64 +46,5 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
 
         public override string GetAttributes() => string.Empty;
 
-        private static bool IsMicrophoneInUse()
-        {
-            const string regKey = @"SOFTWARE\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\microphone";
-            bool inUse;
-
-            // first local machine
-            using (var key = Registry.LocalMachine.OpenSubKey(regKey))
-            {
-                inUse = CheckRegForMicrophoneInUse(key);
-                if (inUse) return true;
-            }
-
-            // then current user
-            using (var key = Registry.CurrentUser.OpenSubKey(regKey))
-            {
-                inUse = CheckRegForMicrophoneInUse(key);
-                if (inUse) return true;
-            }
-
-            // nope
-            return false;
-        }
-
-        private static bool CheckRegForMicrophoneInUse(RegistryKey key)
-        {
-            if (key == null) return false;
-
-            foreach (var subKeyName in key.GetSubKeyNames())
-            {
-                // NonPackaged has multiple subkeys
-                if (subKeyName == "NonPackaged")
-                {
-                    using var nonpackagedkey = key.OpenSubKey(subKeyName);
-                    if (nonpackagedkey == null) continue;
-
-                    foreach (var nonpackagedSubKeyName in nonpackagedkey.GetSubKeyNames())
-                    {
-                        using var subKey = nonpackagedkey.OpenSubKey(nonpackagedSubKeyName);
-                        if (subKey == null || !subKey.GetValueNames().Contains("LastUsedTimeStop")) continue;
-
-                        var endTime = subKey.GetValue("LastUsedTimeStop") is long
-                            ? (long)(subKey.GetValue("LastUsedTimeStop") ?? -1)
-                            : -1;
-
-                        if (endTime <= 0) return true;
-                    }
-                }
-                else
-                {
-                    using var subKey = key.OpenSubKey(subKeyName);
-                    if (subKey == null || !subKey.GetValueNames().Contains("LastUsedTimeStop")) continue;
-
-                    var endTime = subKey.GetValue("LastUsedTimeStop") is long ? (long)(subKey.GetValue("LastUsedTimeStop") ?? -1) : -1;
-                    if (endTime <= 0) return true;
-                }
-            }
-
-            return false;
-        }
     }
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/MicrophoneProcessSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/MicrophoneProcessSensor.cs
@@ -1,8 +1,6 @@
 using System.Collections.Generic;
-using System.Linq;
-using HASS.Agent.Shared.Functions;
+using HASS.Agent.Shared.HomeAssistant.Sensors.MediaActivity;
 using HASS.Agent.Shared.Models.HomeAssistant;
-using Microsoft.Win32;
 using Newtonsoft.Json;
 
 namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue;
@@ -14,12 +12,17 @@ public class MicrophoneProcessSensor : AbstractSingleValueSensor
 {
     private const string DefaultName = "microphoneprocess";
 
-    private const string _lastUsedTimeStop = "LastUsedTimeStop";
-    private const string _regKey = @"SOFTWARE\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\microphone";
+    private readonly IMediaActivityProvider _mediaActivityProvider;
     
-    public MicrophoneProcessSensor(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default, string advancedSettings = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 10, id, true, advancedSettings: advancedSettings)
+    public MicrophoneProcessSensor(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default, string advancedSettings = default)
+        : this(MediaActivityProvider.Instance, updateInterval, entityName, name, id, advancedSettings)
     {
-        //
+    }
+
+    internal MicrophoneProcessSensor(IMediaActivityProvider mediaActivityProvider, int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default, string advancedSettings = default)
+        : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 10, id, true, advancedSettings: advancedSettings)
+    {
+        _mediaActivityProvider = mediaActivityProvider;
     }
 
     private readonly Dictionary<string, string> _processes = new();
@@ -57,79 +60,20 @@ public class MicrophoneProcessSensor : AbstractSingleValueSensor
 
     private string MicrophoneProcess()
     {
+        var snapshot = _mediaActivityProvider.GetActivity(MediaActivityKind.Microphone);
         _processes.Clear();
 
-        // first local machine
-        using (var key = Registry.LocalMachine.OpenSubKey(_regKey))
+        foreach (var process in snapshot.Processes)
         {
-            CheckRegForMicrophoneInUse(key);
+            _processes[process.Name] = "on";
         }
 
-        // then current user
-        using (var key = Registry.CurrentUser.OpenSubKey(_regKey))
-        {
-            CheckRegForMicrophoneInUse(key);
-        }
-
-        // add processes as attributes
-        _attributes = _processes.Count > 0 ? JsonConvert.SerializeObject(_processes, Formatting.Indented) : "{}";
-
-        // return the count
+        _attributes = _processes.Count > 0
+            ? JsonConvert.SerializeObject(_processes, Formatting.Indented)
+            : "{}";
         return _processes.Count.ToString();
     }
 
-    private void CheckRegForMicrophoneInUse(RegistryKey key)
-    {
-        if (key == null)
-        {
-            return;
-        }
-
-        foreach (var subKeyName in key.GetSubKeyNames())
-        {
-            // NonPackaged has multiple subkeys
-            if (subKeyName == "NonPackaged")
-            {
-                using var nonpackagedkey = key.OpenSubKey(subKeyName);
-                if (nonpackagedkey == null)
-                {
-                    continue;
-                }
-
-                foreach (var nonpackagedSubKeyName in nonpackagedkey.GetSubKeyNames())
-                {
-                    using var subKey = nonpackagedkey.OpenSubKey(nonpackagedSubKeyName);
-                    if (subKey == null || !subKey.GetValueNames().Contains(_lastUsedTimeStop))
-                    {
-                        continue;
-                    }
-
-                    var endTime = subKey.GetValue(_lastUsedTimeStop) is long
-                        ? (long)(subKey.GetValue(_lastUsedTimeStop) ?? -1)
-                        : -1;
-
-                    if (endTime <= 0)
-                    {
-                        _processes[SharedHelperFunctions.ParseRegWebcamMicApplicationName(subKey.Name)] = "on";
-                    }
-                }
-            }
-            else
-            {
-                using var subKey = key.OpenSubKey(subKeyName);
-                if (subKey == null || !subKey.GetValueNames().Contains(_lastUsedTimeStop))
-                {
-                    continue;
-                }
-
-                var endTime = subKey.GetValue(_lastUsedTimeStop) is long ? (long)(subKey.GetValue(_lastUsedTimeStop) ?? -1) : -1;
-                if (endTime <= 0)
-                {
-                    _processes[SharedHelperFunctions.ParseRegWebcamMicApplicationName(subKey.Name)] = "on";
-                }
-            }
-        }
-    }
 
     public override string GetState() => MicrophoneProcess();
     public override string GetAttributes() => _attributes;

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/WebcamActiveSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/WebcamActiveSensor.cs
@@ -1,6 +1,5 @@
-﻿using System.Linq;
+using HASS.Agent.Shared.HomeAssistant.Sensors.MediaActivity;
 using HASS.Agent.Shared.Models.HomeAssistant;
-using Microsoft.Win32;
 
 namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
 {
@@ -10,16 +9,21 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
     public class WebcamActiveSensor : AbstractSingleValueSensor
     {
         private const string DefaultName = "webcamactive";
+        private readonly IMediaActivityProvider _mediaActivityProvider;
 
-        public WebcamActiveSensor(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default, string advancedSettings = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 10, id, advancedSettings: advancedSettings)
+        public WebcamActiveSensor(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default, string advancedSettings = default)
+            : this(MediaActivityProvider.Instance, updateInterval, entityName, name, id, advancedSettings)
         {
+        }
+
+        internal WebcamActiveSensor(IMediaActivityProvider mediaActivityProvider, int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default, string advancedSettings = default)
+            : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 10, id, advancedSettings: advancedSettings)
+        {
+            _mediaActivityProvider = mediaActivityProvider;
             Domain = "binary_sensor";
         }
 
-        public override string GetState()
-        {
-            return IsWebcamInUse() ? "ON" : "OFF";
-        }
+        public override string GetState() => _mediaActivityProvider.GetActivity(MediaActivityKind.Webcam).IsActive ? "ON" : "OFF";
 
         public override string GetAttributes() => string.Empty;
 
@@ -42,67 +46,5 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
             });
         }
         
-        private static bool IsWebcamInUse()
-        {
-            const string regKey = @"SOFTWARE\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\webcam";
-            bool inUse;
-
-            // first local machine
-            using (var key = Registry.LocalMachine.OpenSubKey(regKey))
-            {
-                inUse = CheckRegForWebcamInUse(key);
-                if (inUse) return true;
-            }
-
-            // then current user
-            using (var key = Registry.CurrentUser.OpenSubKey(regKey))
-            {
-                inUse = CheckRegForWebcamInUse(key);
-                if (inUse) return true;
-            }
-
-            // nope
-            return false;
-        }
-
-        private static bool CheckRegForWebcamInUse(RegistryKey key)
-        {
-            if (key == null) return false;
-
-            foreach (var subKeyName in key.GetSubKeyNames())
-            {
-                // NonPackaged has multiple subkeys
-                if (subKeyName == "NonPackaged")
-                {
-                    using var nonpackagedkey = key.OpenSubKey(subKeyName);
-                    if (nonpackagedkey == null) continue;
-
-                    foreach (var nonpackagedSubKeyName in nonpackagedkey.GetSubKeyNames())
-                    {
-                        using var subKey = nonpackagedkey.OpenSubKey(nonpackagedSubKeyName);
-                        if (subKey == null || !subKey.GetValueNames().Contains("LastUsedTimeStop")) continue;
-
-                        var endTime = subKey.GetValue("LastUsedTimeStop") is long
-                            ? (long)(subKey.GetValue("LastUsedTimeStop") ?? -1)
-                            : -1;
-
-                        if (endTime <= 0) return true;
-                    }
-                }
-                else
-                {
-                    using var subKey = key.OpenSubKey(subKeyName);
-                    if (subKey == null || !subKey.GetValueNames().Contains("LastUsedTimeStop")) continue;
-
-                    var endTime = subKey.GetValue("LastUsedTimeStop") is long
-                        ? (long)(subKey.GetValue("LastUsedTimeStop") ?? -1)
-                        : -1;
-
-                    if (endTime <= 0) return true;
-                }
-            }
-
-            return false;
-        }
     }
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/WebcamProcessSensor.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/WebcamProcessSensor.cs
@@ -1,8 +1,6 @@
 using System.Collections.Generic;
-using System.Linq;
-using HASS.Agent.Shared.Functions;
+using HASS.Agent.Shared.HomeAssistant.Sensors.MediaActivity;
 using HASS.Agent.Shared.Models.HomeAssistant;
-using Microsoft.Win32;
 using Newtonsoft.Json;
 
 namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
@@ -13,10 +11,17 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
     public class WebcamProcessSensor : AbstractSingleValueSensor
     {
         private const string DefaultName = "webcamprocess";
+        private readonly IMediaActivityProvider _mediaActivityProvider;
 
-        public WebcamProcessSensor(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default, string advancedSettings = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 10, id, true, advancedSettings: advancedSettings)
+        public WebcamProcessSensor(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default, string advancedSettings = default)
+            : this(MediaActivityProvider.Instance, updateInterval, entityName, name, id, advancedSettings)
         {
-            //
+        }
+
+        internal WebcamProcessSensor(IMediaActivityProvider mediaActivityProvider, int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string id = default, string advancedSettings = default)
+            : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 10, id, true, advancedSettings: advancedSettings)
+        {
+            _mediaActivityProvider = mediaActivityProvider;
         }
 
         private readonly Dictionary<string, string> _processes = new Dictionary<string, string>();
@@ -56,68 +61,19 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
 
         private string WebcamProcess()
         {
-            const string regKey = @"SOFTWARE\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\webcam";
-
+            var snapshot = _mediaActivityProvider.GetActivity(MediaActivityKind.Webcam);
             _processes.Clear();
 
-            // first local machine
-            using (var key = Registry.LocalMachine.OpenSubKey(regKey))
+            foreach (var process in snapshot.Processes)
             {
-                CheckRegForWebcamInUse(key);
+                _processes[process.Name] = "on";
             }
 
-            // then current user
-            using (var key = Registry.CurrentUser.OpenSubKey(regKey))
-            {
-                CheckRegForWebcamInUse(key);
-            }
-
-            // add processes as attributes
-            if (_processes.Count > 0) _attributes = JsonConvert.SerializeObject(_processes, Formatting.Indented);
-
-            // return the count
+            _attributes = _processes.Count > 0
+                ? JsonConvert.SerializeObject(_processes, Formatting.Indented)
+                : "{}";
             return _processes.Count.ToString();
         }
 
-        private void CheckRegForWebcamInUse(RegistryKey key)
-        {
-            if (key == null) return;
-
-            foreach (var subKeyName in key.GetSubKeyNames())
-            {
-                // NonPackaged has multiple subkeys
-                if (subKeyName == "NonPackaged")
-                {
-                    using var nonpackagedkey = key.OpenSubKey(subKeyName);
-                    if (nonpackagedkey == null) continue;
-
-                    foreach (var nonpackagedSubKeyName in nonpackagedkey.GetSubKeyNames())
-                    {
-                        using var subKey = nonpackagedkey.OpenSubKey(nonpackagedSubKeyName);
-                        if (subKey == null || !subKey.GetValueNames().Contains("LastUsedTimeStop")) continue;
-
-                        var endTime = subKey.GetValue("LastUsedTimeStop") is long
-                            ? (long)(subKey.GetValue("LastUsedTimeStop") ?? -1)
-                            : -1;
-
-                        if (endTime <= 0)
-                        {
-                            _processes.Add(SharedHelperFunctions.ParseRegWebcamMicApplicationName(subKey.Name), "on");
-                        }
-                    }
-                }
-                else
-                {
-                    using var subKey = key.OpenSubKey(subKeyName);
-                    if (subKey == null || !subKey.GetValueNames().Contains("LastUsedTimeStop")) continue;
-
-                    var endTime = subKey.GetValue("LastUsedTimeStop") is long ? (long)(subKey.GetValue("LastUsedTimeStop") ?? -1) : -1;
-                    if (endTime <= 0)
-                    {
-                        _processes.Add(SharedHelperFunctions.ParseRegWebcamMicApplicationName(subKey.Name), "on");
-                    }
-                }
-            }
-        }
     }
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/MediaActivity/MediaActivityProvider.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/MediaActivity/MediaActivityProvider.cs
@@ -1,0 +1,263 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using HASS.Agent.Shared.Functions;
+using Microsoft.Win32;
+using NAudio.CoreAudioApi;
+using NAudio.CoreAudioApi.Interfaces;
+
+namespace HASS.Agent.Shared.HomeAssistant.Sensors.MediaActivity;
+
+public enum MediaActivityKind
+{
+    Microphone,
+    Webcam
+}
+
+public sealed class MediaActivityProcess
+{
+    public MediaActivityProcess(int processId, string name)
+    {
+        ProcessId = processId;
+        Name = name;
+    }
+
+    public int ProcessId { get; }
+    public string Name { get; }
+}
+
+public sealed class MediaActivitySnapshot
+{
+    private MediaActivitySnapshot(bool isAvailable, IReadOnlyCollection<MediaActivityProcess> processes)
+    {
+        IsAvailable = isAvailable;
+        Processes = processes;
+    }
+
+    public bool IsAvailable { get; }
+    public IReadOnlyCollection<MediaActivityProcess> Processes { get; }
+    public bool IsActive => Processes.Count > 0;
+
+    public static MediaActivitySnapshot Available(IEnumerable<MediaActivityProcess> processes)
+    {
+        var uniqueProcesses = processes
+            .Where(process => process != null && !string.IsNullOrWhiteSpace(process.Name))
+            .GroupBy(process => process.ProcessId > 0 ? $"pid:{process.ProcessId}" : $"name:{process.Name}", StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.First())
+            .ToArray();
+
+        return new MediaActivitySnapshot(true, uniqueProcesses);
+    }
+
+    public static MediaActivitySnapshot Unavailable { get; } =
+        new(false, Array.Empty<MediaActivityProcess>());
+}
+
+public interface IMediaActivityProvider
+{
+    MediaActivitySnapshot GetActivity(MediaActivityKind kind);
+}
+
+internal interface IMediaActivitySource
+{
+    MediaActivitySnapshot GetActivity(MediaActivityKind kind);
+}
+
+internal sealed class MediaActivityProvider : IMediaActivityProvider
+{
+    private static readonly TimeSpan CacheDuration = TimeSpan.FromSeconds(1);
+    private readonly object _syncRoot = new();
+    private readonly IMediaActivitySource _primary;
+    private readonly IMediaActivitySource _fallback;
+    private readonly Dictionary<MediaActivityKind, CacheEntry> _cache = new();
+
+    internal static IMediaActivityProvider Instance { get; } =
+        new MediaActivityProvider(new WindowsMediaActivitySource(), new RegistryMediaActivitySource());
+
+    internal MediaActivityProvider(IMediaActivitySource primary, IMediaActivitySource fallback)
+    {
+        _primary = primary;
+        _fallback = fallback;
+    }
+
+    public MediaActivitySnapshot GetActivity(MediaActivityKind kind)
+    {
+        lock (_syncRoot)
+        {
+            if (_cache.TryGetValue(kind, out var cached) &&
+                DateTimeOffset.UtcNow - cached.CreatedAt < CacheDuration)
+            {
+                return cached.Snapshot;
+            }
+
+            var snapshot = _primary.GetActivity(kind);
+            if (!snapshot.IsAvailable)
+            {
+                snapshot = _fallback.GetActivity(kind);
+            }
+
+            _cache[kind] = new CacheEntry(DateTimeOffset.UtcNow, snapshot);
+            return snapshot;
+        }
+    }
+
+    private sealed class CacheEntry
+    {
+        internal CacheEntry(DateTimeOffset createdAt, MediaActivitySnapshot snapshot)
+        {
+            CreatedAt = createdAt;
+            Snapshot = snapshot;
+        }
+
+        internal DateTimeOffset CreatedAt { get; }
+        internal MediaActivitySnapshot Snapshot { get; }
+    }
+}
+
+internal sealed class WindowsMediaActivitySource : IMediaActivitySource
+{
+    private readonly WindowsCameraActivitySource _cameraSource = new();
+
+    public MediaActivitySnapshot GetActivity(MediaActivityKind kind)
+    {
+        return kind == MediaActivityKind.Microphone
+            ? GetMicrophoneActivity()
+            : _cameraSource.GetActivity();
+    }
+
+    private static MediaActivitySnapshot GetMicrophoneActivity()
+    {
+        try
+        {
+            var processes = new List<MediaActivityProcess>();
+            using var deviceEnumerator = new MMDeviceEnumerator();
+            var devices = deviceEnumerator.EnumerateAudioEndPoints(DataFlow.Capture, DeviceState.Active);
+
+            foreach (var device in devices)
+            {
+                using (device)
+                {
+                    var sessions = device.AudioSessionManager.Sessions;
+                    for (var index = 0; index < sessions.Count; index++)
+                    {
+                        using var session = sessions[index];
+                        if (session.State != AudioSessionState.AudioSessionStateActive)
+                        {
+                            continue;
+                        }
+
+                        var processId = unchecked((int)session.GetProcessID);
+                        if (processId <= 0)
+                        {
+                            continue;
+                        }
+
+                        processes.Add(new MediaActivityProcess(processId, GetProcessName(processId)));
+                    }
+                }
+            }
+
+            return MediaActivitySnapshot.Available(processes);
+        }
+        catch (Exception exception) when (
+            exception is COMException ||
+            exception is InvalidOperationException ||
+            exception is PlatformNotSupportedException)
+        {
+            return MediaActivitySnapshot.Unavailable;
+        }
+    }
+
+    internal static string GetProcessName(int processId)
+    {
+        try
+        {
+            using var process = Process.GetProcessById(processId);
+            return process.ProcessName;
+        }
+        catch
+        {
+            return $"process_{processId}";
+        }
+    }
+}
+
+internal sealed class RegistryMediaActivitySource : IMediaActivitySource
+{
+    private const string LastUsedTimeStop = "LastUsedTimeStop";
+    private const string ConsentStorePath =
+        @"SOFTWARE\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore";
+
+    public MediaActivitySnapshot GetActivity(MediaActivityKind kind)
+    {
+        var capability = kind == MediaActivityKind.Microphone ? "microphone" : "webcam";
+        var processes = new List<MediaActivityProcess>();
+
+        try
+        {
+            ReadHive(Registry.LocalMachine, capability, processes);
+            ReadHive(Registry.CurrentUser, capability, processes);
+            return MediaActivitySnapshot.Available(processes);
+        }
+        catch (Exception exception) when (
+            exception is UnauthorizedAccessException ||
+            exception is System.IO.IOException ||
+            exception is System.Security.SecurityException)
+        {
+            return MediaActivitySnapshot.Unavailable;
+        }
+    }
+
+    private static void ReadHive(
+        RegistryKey hive,
+        string capability,
+        ICollection<MediaActivityProcess> processes)
+    {
+        using var key = hive.OpenSubKey($@"{ConsentStorePath}\{capability}");
+        if (key == null)
+        {
+            return;
+        }
+
+        foreach (var subKeyName in key.GetSubKeyNames())
+        {
+            if (string.Equals(subKeyName, "NonPackaged", StringComparison.OrdinalIgnoreCase))
+            {
+                using var nonPackagedKey = key.OpenSubKey(subKeyName);
+                if (nonPackagedKey == null)
+                {
+                    continue;
+                }
+
+                foreach (var applicationKeyName in nonPackagedKey.GetSubKeyNames())
+                {
+                    using var applicationKey = nonPackagedKey.OpenSubKey(applicationKeyName);
+                    AddIfActive(applicationKey, processes);
+                }
+            }
+            else
+            {
+                using var applicationKey = key.OpenSubKey(subKeyName);
+                AddIfActive(applicationKey, processes);
+            }
+        }
+    }
+
+    private static void AddIfActive(
+        RegistryKey applicationKey,
+        ICollection<MediaActivityProcess> processes)
+    {
+        if (applicationKey?.GetValue(LastUsedTimeStop) is not long stopTime ||
+            stopTime > 0)
+        {
+            return;
+        }
+
+        var applicationName =
+            SharedHelperFunctions.ParseRegWebcamMicApplicationName(
+                applicationKey.Name);
+        processes.Add(new MediaActivityProcess(0, applicationName));
+    }
+}

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/MediaActivity/WindowsCameraActivitySource.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/MediaActivity/WindowsCameraActivitySource.cs
@@ -1,0 +1,228 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace HASS.Agent.Shared.HomeAssistant.Sensors.MediaActivity;
+
+internal sealed class WindowsCameraActivitySource
+{
+    private const int ReportTimeoutMilliseconds = 500;
+    private const int MediaFoundationVersion = 0x00020070;
+    private const int MediaFoundationStartupNoSocket = 0x1;
+
+    internal MediaActivitySnapshot GetActivity()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return MediaActivitySnapshot.Unavailable;
+        }
+
+        SensorActivitiesCallback callback = null;
+        IMFSensorActivityMonitor monitor = null;
+        var mediaFoundationStarted = false;
+
+        try
+        {
+            Marshal.ThrowExceptionForHR(
+                MFStartup(MediaFoundationVersion, MediaFoundationStartupNoSocket));
+            mediaFoundationStarted = true;
+            callback = new SensorActivitiesCallback();
+            Marshal.ThrowExceptionForHR(
+                MFCreateSensorActivityMonitor(callback, out monitor));
+            Marshal.ThrowExceptionForHR(monitor.Start());
+
+            if (!callback.Wait(ReportTimeoutMilliseconds) || callback.Failed)
+            {
+                return MediaActivitySnapshot.Unavailable;
+            }
+
+            return MediaActivitySnapshot.Available(callback.Processes);
+        }
+        catch (Exception exception) when (
+            exception is COMException ||
+            exception is DllNotFoundException ||
+            exception is EntryPointNotFoundException ||
+            exception is PlatformNotSupportedException)
+        {
+            return MediaActivitySnapshot.Unavailable;
+        }
+        finally
+        {
+            if (monitor != null)
+            {
+                monitor.Stop();
+                if (monitor is IMFShutdown shutdown)
+                {
+                    shutdown.Shutdown();
+                }
+            }
+
+            callback?.Dispose();
+
+            if (mediaFoundationStarted)
+            {
+                MFShutdown();
+            }
+        }
+    }
+
+    [DllImport("mfplat.dll", ExactSpelling = true)]
+    private static extern int MFStartup(int version, int flags);
+
+    [DllImport("mfplat.dll", ExactSpelling = true)]
+    private static extern int MFShutdown();
+
+    [DllImport("mfsensorgroup.dll", ExactSpelling = true)]
+    private static extern int MFCreateSensorActivityMonitor(
+        IMFSensorActivitiesReportCallback callback,
+        out IMFSensorActivityMonitor monitor);
+
+    [ComVisible(true)]
+    [ClassInterface(ClassInterfaceType.None)]
+    private sealed class SensorActivitiesCallback :
+        IMFSensorActivitiesReportCallback,
+        IDisposable
+    {
+        private readonly ManualResetEventSlim _activityDetectedOrFailed = new();
+        private IReadOnlyCollection<MediaActivityProcess> _processes =
+            Array.Empty<MediaActivityProcess>();
+        private volatile bool _reportReceived;
+
+        internal IReadOnlyCollection<MediaActivityProcess> Processes => _processes;
+        internal bool Failed { get; private set; }
+
+        internal bool Wait(int milliseconds)
+        {
+            if (_activityDetectedOrFailed.Wait(milliseconds))
+            {
+                return !Failed;
+            }
+
+            return _reportReceived;
+        }
+
+        public int OnActivitiesReport(IMFSensorActivitiesReport reports)
+        {
+            try
+            {
+                var processes = new List<MediaActivityProcess>();
+                Marshal.ThrowExceptionForHR(reports.GetCount(out var reportCount));
+
+                for (uint reportIndex = 0; reportIndex < reportCount; reportIndex++)
+                {
+                    Marshal.ThrowExceptionForHR(
+                        reports.GetActivityReport(reportIndex, out var report));
+                    Marshal.ThrowExceptionForHR(
+                        report.GetProcessCount(out var processCount));
+
+                    for (uint processIndex = 0; processIndex < processCount; processIndex++)
+                    {
+                        Marshal.ThrowExceptionForHR(
+                            report.GetProcessActivity(processIndex, out var activity));
+                        Marshal.ThrowExceptionForHR(
+                            activity.GetStreamingState(out var isStreaming));
+                        if (!isStreaming)
+                        {
+                            continue;
+                        }
+
+                        Marshal.ThrowExceptionForHR(
+                            activity.GetProcessId(out var processId));
+                        if (processId > 0)
+                        {
+                            var id = unchecked((int)processId);
+                            processes.Add(new MediaActivityProcess(
+                                id,
+                                WindowsMediaActivitySource.GetProcessName(id)));
+                        }
+                    }
+                }
+
+                _processes = MediaActivitySnapshot.Available(processes).Processes;
+                _reportReceived = true;
+                if (_processes.Count > 0)
+                {
+                    _activityDetectedOrFailed.Set();
+                }
+            }
+            catch
+            {
+                Failed = true;
+                _activityDetectedOrFailed.Set();
+            }
+
+            return 0;
+        }
+
+        public void Dispose()
+        {
+            _activityDetectedOrFailed.Dispose();
+        }
+    }
+
+    [ComImport]
+    [Guid("683F7A5E-4A19-43CD-B1A9-DBF4AB3F7777")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IMFSensorActivitiesReport
+    {
+        [PreserveSig] int GetCount(out uint count);
+        [PreserveSig] int GetActivityReport(
+            uint index,
+            out IMFSensorActivityReport report);
+        [PreserveSig] int GetActivityReportByDeviceName(
+            [MarshalAs(UnmanagedType.LPWStr)] string symbolicName,
+            out IMFSensorActivityReport report);
+    }
+
+    [ComImport]
+    [Guid("3E8C4BE1-A8C2-4528-90DE-2851BDE5FEAD")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IMFSensorActivityReport
+    {
+        [PreserveSig] int GetFriendlyName(IntPtr name, uint capacity, out uint written);
+        [PreserveSig] int GetSymbolicLink(IntPtr link, uint capacity, out uint written);
+        [PreserveSig] int GetProcessCount(out uint count);
+        [PreserveSig] int GetProcessActivity(
+            uint index,
+            out IMFSensorProcessActivity activity);
+    }
+
+    [ComImport]
+    [Guid("39DC7F4A-B141-4719-813C-A7F46162A2B8")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IMFSensorProcessActivity
+    {
+        [PreserveSig] int GetProcessId(out uint processId);
+        [PreserveSig] int GetStreamingState(
+            [MarshalAs(UnmanagedType.Bool)] out bool streaming);
+        [PreserveSig] int GetStreamingMode(out int mode);
+        [PreserveSig] int GetReportTime(out long fileTime);
+    }
+
+    [ComVisible(true)]
+    [Guid("DE5072EE-DBE3-46DC-8A87-B6F631194751")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IMFSensorActivitiesReportCallback
+    {
+        [PreserveSig] int OnActivitiesReport(IMFSensorActivitiesReport reports);
+    }
+
+    [ComImport]
+    [Guid("D0CEF145-B3F4-4340-A2E5-7A5080CA05CB")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IMFSensorActivityMonitor
+    {
+        [PreserveSig] int Start();
+        [PreserveSig] int Stop();
+    }
+
+    [ComImport]
+    [Guid("97EC2EA4-0E42-4937-97AC-9D6D328824E1")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IMFShutdown
+    {
+        [PreserveSig] int Shutdown();
+        [PreserveSig] int GetShutdownStatus(out int status);
+    }
+}

--- a/src/HASS.Agent/HASS.Agent.Shared/Properties/AssemblyInfo.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("HASS.Agent.Shared.Tests")]

--- a/tests/HASS.Agent.Shared.Tests/HASS.Agent.Shared.Tests.csproj
+++ b/tests/HASS.Agent.Shared.Tests/HASS.Agent.Shared.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\HASS.Agent\HASS.Agent.Shared\HASS.Agent.Shared.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/HASS.Agent.Shared.Tests/MediaActivitySensorTests.cs
+++ b/tests/HASS.Agent.Shared.Tests/MediaActivitySensorTests.cs
@@ -1,0 +1,128 @@
+using System;
+using HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue;
+using HASS.Agent.Shared.HomeAssistant.Sensors.MediaActivity;
+using Xunit;
+
+namespace HASS.Agent.Shared.Tests;
+
+public class MediaActivitySensorTests
+{
+    [Fact]
+    public void ProviderUsesFallbackWhenWindowsApiIsUnavailable()
+    {
+        var primary = new StubSource(MediaActivitySnapshot.Unavailable);
+        var fallback = new StubSource(Snapshot("Elgato.WaveLink", 42));
+        var provider = new MediaActivityProvider(primary, fallback);
+
+        var result = provider.GetActivity(MediaActivityKind.Microphone);
+
+        Assert.True(result.IsActive);
+        Assert.Equal(1, primary.CallCount);
+        Assert.Equal(1, fallback.CallCount);
+    }
+
+    [Fact]
+    public void ProviderDoesNotUseLegacyRegistryAfterSuccessfulEmptyWindowsApiResult()
+    {
+        var primary = new StubSource(MediaActivitySnapshot.Available(Array.Empty<MediaActivityProcess>()));
+        var fallback = new StubSource(Snapshot("stale-registry-entry", 0));
+        var provider = new MediaActivityProvider(primary, fallback);
+
+        var result = provider.GetActivity(MediaActivityKind.Microphone);
+
+        Assert.False(result.IsActive);
+        Assert.Equal(0, fallback.CallCount);
+    }
+
+    [Fact]
+    public void MicrophoneSensorsUseTheSameProviderSnapshot()
+    {
+        var provider = new StubProvider(Snapshot("Elgato.WaveLink", 26220));
+        var activeSensor = new MicrophoneActiveSensor(provider);
+        var processSensor = new MicrophoneProcessSensor(provider);
+
+        Assert.Equal("ON", activeSensor.GetState());
+        Assert.Equal(MediaActivityKind.Microphone, provider.LastKind);
+        Assert.Equal("1", processSensor.GetState());
+        Assert.Contains("Elgato.WaveLink", processSensor.GetAttributes());
+    }
+
+    [Fact]
+    public void WebcamSensorsUseTheSameProviderSnapshot()
+    {
+        var provider = new StubProvider(Snapshot("WindowsCamera", 123));
+        var activeSensor = new WebcamActiveSensor(provider);
+        var processSensor = new WebcamProcessSensor(provider);
+
+        Assert.Equal("ON", activeSensor.GetState());
+        Assert.Equal(MediaActivityKind.Webcam, provider.LastKind);
+        Assert.Equal("1", processSensor.GetState());
+        Assert.Contains("WindowsCamera", processSensor.GetAttributes());
+    }
+
+    [Fact]
+    public void ProcessSensorClearsAttributesWhenCaptureStops()
+    {
+        var provider = new StubProvider(Snapshot("Elgato.WaveLink", 42));
+        var sensor = new MicrophoneProcessSensor(provider);
+
+        Assert.Equal("1", sensor.GetState());
+        provider.Snapshot = MediaActivitySnapshot.Available(Array.Empty<MediaActivityProcess>());
+
+        Assert.Equal("0", sensor.GetState());
+        Assert.Equal("{}", sensor.GetAttributes());
+    }
+
+    [Fact]
+    public void SnapshotDeduplicatesSessionsFromTheSameProcess()
+    {
+        var snapshot = MediaActivitySnapshot.Available(new[]
+        {
+            new MediaActivityProcess(42, "Elgato.WaveLink"),
+            new MediaActivityProcess(42, "Elgato.WaveLink")
+        });
+
+        Assert.Single(snapshot.Processes);
+    }
+
+    private static MediaActivitySnapshot Snapshot(string name, int processId) =>
+        MediaActivitySnapshot.Available(new[]
+        {
+            new MediaActivityProcess(processId, name)
+        });
+
+    private sealed class StubProvider : IMediaActivityProvider
+    {
+        internal StubProvider(MediaActivitySnapshot snapshot)
+        {
+            Snapshot = snapshot;
+        }
+
+        internal MediaActivitySnapshot Snapshot { get; set; }
+        internal MediaActivityKind LastKind { get; private set; }
+
+        public MediaActivitySnapshot GetActivity(MediaActivityKind kind)
+        {
+            LastKind = kind;
+            return Snapshot;
+        }
+    }
+
+    private sealed class StubSource : IMediaActivitySource
+    {
+        private readonly MediaActivitySnapshot _snapshot;
+
+        internal StubSource(MediaActivitySnapshot snapshot)
+        {
+            _snapshot = snapshot;
+        }
+
+        internal int CallCount { get; private set; }
+
+        public MediaActivitySnapshot GetActivity(MediaActivityKind kind)
+        {
+            CallCount++;
+            return _snapshot;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- refactor the four microphone/webcam sensors around a shared media-activity provider
- detect active microphone consumers through Core Audio capture sessions
- detect active camera consumers through `IMFSensorActivityMonitor`
- retain `CapabilityAccessManager\ConsentStore` as a fallback only when the modern API is unavailable or fails
- add focused tests for provider selection, sensor behavior, stale attributes, and process deduplication

## Reproduction

- Windows build: 26220
- failure appeared immediately after an August 20 reboot
- affected sensors: `MicrophoneProcess`, `MicrophoneActive`, `WebcamProcess`, and `WebcamActive`
- ordinary sensors and MQTT/Home Assistant transport remained healthy
- Elgato Wave Link continuously used the microphone and Windows displayed it as active, while HASS.Agent reported `MicrophoneProcess = 0`
- the ConsentStore entry for `Elgato.WaveLink_g54w8ztgkx496` retained positive, unchanged `LastUsedTimeStart` and `LastUsedTimeStop` values while capture continued, so `LastUsedTimeStop <= 0` no longer represented live activity

## Implementation notes

The shared provider treats a successful empty result from the current Windows APIs as authoritative. It consults the registry only when an API is unavailable, errors, or times out, preventing stale ConsentStore data from overriding a valid inactive state.

Microphone activity is collected from active Core Audio sessions across active capture endpoints. Camera activity is collected from Media Foundation sensor activity reports, including the required `MFStartup`/`MFShutdown` lifecycle and a short observation window so an initial empty callback does not hide a subsequent active-stream report.

## Validation

- `dotnet test tests/HASS.Agent.Shared.Tests/HASS.Agent.Shared.Tests.csproj --configuration Release`: 6 passed
- live Windows 11 build 26220 microphone probe: `active=True`, `21024:Elgato.WaveLink`
- live Windows 11 build 26220 webcam probe: `active=True`, `43928:Airtime`
- x64 client and satellite service publish succeeded
- locally built installer completed successfully and the installed `HASS.Agent.Shared.dll` matched the published artifact