### PR TITLE
Feature: add Simplified Chinese (zh-CN) localization

### DIFF
--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.zh-CN.resx
@@ -1,0 +1,3289 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ConfigExternalTools_LblInfo1" xml:space="preserve">
+    <value>This page allows you to configure bindings with external tools.</value>
+  </data>
+  <data name="ConfigExternalTools_LblBrowserName" xml:space="preserve">
+    <value>Browser Name</value>
+  </data>
+  <data name="ConfigExternalTools_LblInfo2" xml:space="preserve">
+	  <value>By default HASS.Agent will launch URLs using your default browser. You can also configure
+a specific browser to be used instead along with launch arguments to run in private mode.</value>
+  </data>
+  <data name="ConfigExternalTools_LblBrowserBinary" xml:space="preserve">
+    <value>Browser Binary</value>
+  </data>
+  <data name="ConfigExternalTools_LblLaunchIncogArg" xml:space="preserve">
+    <value>Additional Launch Arguments</value>
+  </data>
+  <data name="ConfigExternalTools_LblCustomExecutorBinary" xml:space="preserve">
+    <value>Custom Executor Binary</value>
+  </data>
+  <data name="ConfigExternalTools_LblInfo3" xml:space="preserve">
+	  <value>You can configure the HASS.Agent to use a specific interpreter such as Perl or Python.
+Use the 'custom executor' command to launch this executor.</value>
+  </data>
+  <data name="ConfigExternalTools_LblCustomExecutorName" xml:space="preserve">
+    <value>Custom Executor Name</value>
+  </data>
+  <data name="ConfigExternalTools_LblTip1" xml:space="preserve">
+    <value>Tip: Double-click to Browse</value>
+  </data>
+  <data name="ConfigExternalTools_BtnExternalBrowserIncognitoTest" xml:space="preserve">
+    <value>&amp;Test</value>
+  </data>
+  <data name="ConfigGeneral_LblInfo4" xml:space="preserve">
+	  <value>HASS.Agent will wait a grace period before notifying you of disconnects from MQTT or HA's API.
+You can set the amount of seconds to wait in this grace period below.</value>
+  </data>
+  <data name="ConfigGeneral_LblDisconGraceSeconds" xml:space="preserve">
+    <value>Seconds</value>
+  </data>
+  <data name="ConfigGeneral_LblDisconGracePeriod" xml:space="preserve">
+    <value>Disconnected Grace &amp;Period</value>
+  </data>
+  <data name="ConfigGeneral_LblInfo3" xml:space="preserve">
+	  <value>IMPORTANT: if you change this value, HASS.Agent will unpublish all your sensors, commands and force a restart of itself so they can be republished under the new device name.
+Your automations and scripts will keep working.</value>
+  </data>
+  <data name="ConfigGeneral_LblInfo2" xml:space="preserve">
+	  <value>The device name is used to identify your machine on Home Assistant.
+It is also used as a prefix for your command/sensor names (this can be changed per entity).</value>
+  </data>
+  <data name="ConfigGeneral_LblInfo1" xml:space="preserve">
+    <value>This page contains general configuration settings, for more settings you can browse the tabs on the left.</value>
+  </data>
+  <data name="ConfigGeneral_LblDeviceName" xml:space="preserve">
+    <value>Device &amp;Name</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_LblTip1" xml:space="preserve">
+    <value>Tip: Double-click this field to browse</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_LblClientCertificate" xml:space="preserve">
+    <value>Client &amp;Certificate</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_CbHassAutoClientCertificate" xml:space="preserve">
+    <value>Use &amp;automatic client certificate selection</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_BtnTestApi" xml:space="preserve">
+    <value>&amp;Test Connection</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_LblInfo1" xml:space="preserve">
+	  <value>To learn which entities you have configured and to send quick actions, HASS.Agent uses
+Home Assistant's API.
+
+Please provide a long-lived access token and the address of your Home Assistant instance.
+You can get a token in Home Assistant by clicking your profile picture at the bottom-left
+and navigating to the bottom of the page until you see the 'CREATE TOKEN' button.</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_LblApiToken" xml:space="preserve">
+    <value>&amp;API Token</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_LblServerUri" xml:space="preserve">
+    <value>Server &amp;URI</value>
+  </data>
+  <data name="ConfigHotKey_BtnClearHotKey" xml:space="preserve">
+    <value>&amp;Clear</value>
+  </data>
+  <data name="ConfigHotKey_LblInfo1" xml:space="preserve">
+	  <value>An easy way to pull up your quick actions is to use a global hotkey.
+
+This way, whatever you're doing on your machine, you can always interact with Home Assistant.</value>
+  </data>
+  <data name="ConfigHotKey_CbEnableQuickActionsHotkey" xml:space="preserve">
+    <value>&amp;Enable Quick Actions Hotkey</value>
+  </data>
+  <data name="ConfigHotKey_LblHotkeyCombo" xml:space="preserve">
+    <value>&amp;Hotkey Combination</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearImageCache" xml:space="preserve">
+    <value>Clear Image Cache</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnOpenImageCache" xml:space="preserve">
+    <value>Open Folder</value>
+  </data>
+  <data name="ConfigLocalStorage_LblCacheLocations" xml:space="preserve">
+    <value>Image Cache Location</value>
+  </data>
+  <data name="ConfigLocalStorage_LblCacheDays" xml:space="preserve">
+    <value>days</value>
+  </data>
+  <data name="ConfigLocalStorage_LblInfo1" xml:space="preserve">
+	  <value>Some items like images shown in notifications have to be temporarily stored locally. You can
+configure the amount of days they should be kept before HASS.Agent deletes them.
+
+Enter '0' to keep them permanently.</value>
+  </data>
+  <data name="ConfigLogging_LblInfo1" xml:space="preserve">
+	  <value>Extended logging provides more verbose and in-depth logging, in case the default logging isn't
+sufficient. Please note that enabling this can cause the logfiles to grow large, and should only be
+used when you suspect something's wrong with HASS.Agent itself or when asked by the
+developers.</value>
+  </data>
+  <data name="ConfigLogging_CbExtendedLogging" xml:space="preserve">
+    <value>&amp;Enable Extended Logging</value>
+  </data>
+  <data name="ConfigLogging_BtnShowLogs" xml:space="preserve">
+    <value>&amp;Open Logs Folder</value>
+  </data>
+  <data name="ConfigMqtt_LblTip3" xml:space="preserve">
+    <value>Tip: Double-click these fields to browse</value>
+  </data>
+  <data name="ConfigMqtt_LblClientCert" xml:space="preserve">
+    <value>Client Certificate</value>
+  </data>
+  <data name="ConfigMqtt_LblRootCert" xml:space="preserve">
+    <value>Root Certificate</value>
+  </data>
+  <data name="ConfigMqtt_CbUseRetainFlag" xml:space="preserve">
+    <value>Use &amp;Retain Flag</value>
+  </data>
+  <data name="ConfigMqtt_CbAllowUntrustedCertificates" xml:space="preserve">
+    <value>&amp;Allow Untrusted Certificates</value>
+  </data>
+  <data name="ConfigMqtt_BtnMqttClearConfig" xml:space="preserve">
+    <value>&amp;Clear Configuration</value>
+  </data>
+  <data name="ConfigMqtt_LblTip1" xml:space="preserve">
+    <value>(leave default if unsure)</value>
+  </data>
+  <data name="ConfigMqtt_LblInfo1" xml:space="preserve">
+	  <value>Commands and sensors use MQTT, as well as notifications and media player functions when using the new integration. 
+
+Please provide credentials for your broker, if you're using the HA Mosquitto addon, you can probably use the preset address.
+
+Note: these settings (excluding the Client ID) will also be applied to the satellite service.</value>
+  </data>
+  <data name="ConfigMqtt_LblDiscoPrefix" xml:space="preserve">
+    <value>Discovery Prefix</value>
+  </data>
+  <data name="ConfigMqtt_LblBrokerPassword" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="ConfigMqtt_LblBrokerUsername" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="ConfigMqtt_LblBrokerPort" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="ConfigMqtt_LblBrokerIp" xml:space="preserve">
+    <value>Broker IP Address or Hostname</value>
+  </data>
+  <data name="ConfigMqtt_LblTip2" xml:space="preserve">
+    <value>(leave empty to auto generate)</value>
+  </data>
+  <data name="ConfigMqtt_LblClientId" xml:space="preserve">
+    <value>Client ID</value>
+  </data>
+  <data name="ConfigNotifications_LblInfo2" xml:space="preserve">
+	  <value>If something is not working, make sure you try the following steps:
+
+- Install the HASS.Agent integration
+- Restart Home Assistant
+- Make sure HASS.Agent is active with MQTT enabled!
+- Your device should get detected and added as an entity automatically
+- Optionally: manually add it using the local API</value>
+  </data>
+  <data name="ConfigNotifications_LblInfo1" xml:space="preserve">
+    <value>HASS.Agent can receive notifications from Home Assistant, using text, images and actions. If you have MQTT enabled, your device will automatically get added. Otherwise, manually configure the integration to use the local API.</value>
+  </data>
+  <data name="ConfigNotifications_BtnNotificationsReadme" xml:space="preserve">
+    <value>Notifications &amp;Documentation</value>
+  </data>
+  <data name="ConfigNotifications_LblPort" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="ConfigNotifications_CbAcceptNotifications" xml:space="preserve">
+    <value>&amp;Accept Notifications</value>
+  </data>
+  <data name="ConfigNotifications_BtnSendTestNotification" xml:space="preserve">
+    <value>Show Test Notification</value>
+  </data>
+  <data name="ConfigNotifications_BtnExecutePortReservation" xml:space="preserve">
+    <value>Execute Port Reservation</value>
+  </data>
+  <data name="ConfigNotifications_CbNotificationsIgnoreImageCertErrors" xml:space="preserve">
+    <value>&amp;Ignore certificate errors for images</value>
+  </data>
+  <data name="ConfigService_LblInfo1" xml:space="preserve">
+	  <value>The satellite service allows you to run sensors and commands even when no user's logged in. 
+Use the 'satellite service' button on the main window to manage it.</value>
+  </data>
+  <data name="ConfigService_LblServiceStatusInfo" xml:space="preserve">
+    <value>Service Status:</value>
+  </data>
+  <data name="ConfigService_BtnStartService" xml:space="preserve">
+    <value>S&amp;tart Service</value>
+  </data>
+  <data name="ConfigService_BtnDisableService" xml:space="preserve">
+    <value>&amp;Disable Service</value>
+  </data>
+  <data name="ConfigService_BtnStopService" xml:space="preserve">
+    <value>&amp;Stop Service</value>
+  </data>
+  <data name="ConfigService_BtnEnableService" xml:space="preserve">
+    <value>&amp;Enable Service</value>
+  </data>
+  <data name="ConfigService_BtnReinstallService" xml:space="preserve">
+    <value>&amp;Reinstall Service</value>
+  </data>
+  <data name="ConfigService_LblInfo2" xml:space="preserve">
+	  <value>If you do not configure the service, it won't do anything. However, you can still decide to disable it as well.
+The installer will leave the disabled service alone(if you remove the service, the installer will reinstall it).</value>
+  </data>
+  <data name="ConfigService_LblInfo3" xml:space="preserve">
+	  <value>You can try reinstalling the service if it's not working correctly.
+Your configuration and entities won't be removed.</value>
+  </data>
+  <data name="ConfigService_BtnShowLogs" xml:space="preserve">
+    <value>Open Service &amp;Logs Folder</value>
+  </data>
+  <data name="ConfigService_LblInfo4" xml:space="preserve">
+    <value>If the service still fails after reinstalling, please open a ticket and send the content of the latest log.</value>
+  </data>
+  <data name="ConfigStartup_LblInfo1" xml:space="preserve">
+	  <value>HASS.Agent can start when you login by creating an entry in your user profile's registry.
+
+Since HASS.Agent is user based, if you want to launch for another user, just install and config
+HASS.Agent there.</value>
+  </data>
+  <data name="ConfigStartup_BtnSetStartOnLogin" xml:space="preserve">
+    <value>&amp;Enable Start-on-Login</value>
+  </data>
+  <data name="ConfigStartup_LblStartOnLoginStatusInfo" xml:space="preserve">
+    <value>Start-on-Login Status:</value>
+  </data>
+  <data name="ConfigUpdates_CbBetaUpdates" xml:space="preserve">
+    <value>Notify me of &amp;beta releases</value>
+  </data>
+  <data name="ConfigUpdates_LblInfo2" xml:space="preserve">
+	  <value>When a new update is available, HASS.Agent can download the installer and launch it for you.
+
+The certificate of the downloaded file will get checked before running,you will still get to review the release notes and manually approve the update.</value>
+  </data>
+  <data name="ConfigUpdates_CbExecuteUpdater" xml:space="preserve">
+    <value>Automatically &amp;download future updates</value>
+  </data>
+  <data name="ConfigUpdates_LblInfo1" xml:space="preserve">
+	  <value>HASS.Agent checks for updates in the background if enabled.
+
+You will be sent a push notification if a new update is discovered, letting you know a
+new version is ready to be installed.</value>
+  </data>
+  <data name="ConfigUpdates_CbUpdates" xml:space="preserve">
+    <value>Notify me when a new &amp;release is available</value>
+  </data>
+  <data name="OnboardingWelcome_LblInfo1" xml:space="preserve">
+	  <value>Welcome to the HASS.Agent! It looks like this is the first time you are launching the agent.
+
+To assist you with a first time setup, proceed with the configuration steps below
+or alternatively, click 'Close'.</value>
+  </data>
+  <data name="OnboardingWelcome_LblInfo2" xml:space="preserve">
+    <value>The device name is used to identify your machine on Home Assistant, it is also used as a suggested prefix for your commands and sensors.</value>
+  </data>
+  <data name="OnboardingWelcome_LblDeviceName" xml:space="preserve">
+    <value>Device &amp;Name</value>
+  </data>
+  <data name="OnboardingStartup_BtnSetLaunchOnLogin" xml:space="preserve">
+    <value>Yes, &amp;start HASS.Agent on System Login</value>
+  </data>
+  <data name="OnboardingStartup_LblInfo1" xml:space="preserve">
+	  <value>HASS.Agent can start with your system, this allows for any sensors and data transmission between your device and Home Assistant to begin as soon as you login.
+
+This setting can be changed any time later in the HASS.Agent configuration window.</value>
+  </data>
+  <data name="OnboardingStartup_LblCreateInfo" xml:space="preserve">
+    <value>Fetching current state, please wait..</value>
+  </data>
+  <data name="OnboardingNotifications_LblTip1" xml:space="preserve">
+    <value>Note: 5115 is the default port, only change it if you changed it in Home Assistant.</value>
+  </data>
+  <data name="OnboardingNotifications_CbAcceptNotifications" xml:space="preserve">
+    <value>Yes, accept notifications on port</value>
+  </data>
+  <data name="OnboardingNotifications_LblInfo1" xml:space="preserve">
+	  <value>HASS.Agent can receive notifications from Home Assistant, using text and/or images.
+
+Do you want to enable this function?</value>
+  </data>
+  <data name="OnboardingIntegration_LblIntegration" xml:space="preserve">
+    <value>HASS.Agent-Notifier GitHub Page</value>
+  </data>
+  <data name="OnboardingIntegration_LblInfo2" xml:space="preserve">
+	  <value>Make sure you follow these steps:
+
+- Install HASS.Agent-Notifier integration
+- Restart Home Assistant
+- Configure a notifier entity
+- Restart Home Assistant</value>
+  </data>
+  <data name="OnboardingIntegration_LblInfo1" xml:space="preserve">
+	  <value>To use notifications, you need to install and configure the HASS.Agent-notifier integration in
+Home Assistant.
+
+This is very easy using HACS but may also be installed manually, visit the link below for more
+information.</value>
+  </data>
+  <data name="OnboardingApi_LblApiToken" xml:space="preserve">
+    <value>API &amp;Token</value>
+  </data>
+  <data name="OnboardingApi_LblServerUri" xml:space="preserve">
+    <value>Server &amp;URI (should be ok like this)</value>
+  </data>
+  <data name="OnboardingApi_LblInfo1" xml:space="preserve">
+	  <value>To learn which entities you have configured and to send quick actions, HASS.Agent uses
+Home Assistant's API.
+
+Please provide a long-lived access token and the address of your Home Assistant instance.
+You can get a token in Home Assistant by clicking your profile picture at the bottom-left
+and navigating to the bottom of the page until you see the 'CREATE TOKEN' button.</value>
+  </data>
+  <data name="OnboardingApi_BtnTest" xml:space="preserve">
+    <value>Test &amp;Connection</value>
+  </data>
+  <data name="OnboardingApi_LblTip1" xml:space="preserve">
+    <value>Tip: Specialized settings can be found in the Configuration Window.</value>
+  </data>
+  <data name="OnboardingMqtt_LblPassword" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="OnboardingMqtt_LblUsername" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="OnboardingMqtt_LblPort" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="OnboardingMqtt_LblIpAdress" xml:space="preserve">
+    <value>IP Address or Hostname</value>
+  </data>
+  <data name="OnboardingMqtt_LblInfo1" xml:space="preserve">
+	  <value>Commands and sensors are sent through MQTT. The notifications- and media player integration also make use of them.
+
+Tip: if you're using the HA addon, you can probably use the preset address - just provide credentials.
+</value>
+  </data>
+  <data name="OnboardingMqtt_LblDiscoveryPrefix" xml:space="preserve">
+    <value>Discovery Prefix</value>
+  </data>
+  <data name="OnboardingMqtt_LblTip1" xml:space="preserve">
+    <value>(leave default if not sure)</value>
+  </data>
+  <data name="OnboardingMqtt_LblTip2" xml:space="preserve">
+    <value>Tip: Specialized settings can be found in the Configuration Window.</value>
+  </data>
+  <data name="OnboardingHotKey_LblHotkeyCombo" xml:space="preserve">
+    <value>&amp;Hotkey Combination</value>
+  </data>
+  <data name="OnboardingHotKey_LblInfo1" xml:space="preserve">
+	  <value>An easy way to pull up your quick actions is to use a global hotkey.
+
+This way, whatever you're doing on your machine, you can always interact with Home Assistant.
+</value>
+  </data>
+  <data name="OnboardingHotKey_BtnClear" xml:space="preserve">
+    <value>&amp;Clear</value>
+  </data>
+  <data name="OnboardingUpdates_LblInfo1" xml:space="preserve">
+	  <value>HASS.Agent checks for updates in the background if enabled.
+
+You will be sent a push notification if a new update is discovered, letting you know a
+new version is ready to be installed.
+
+Do you want to enable this automatic update checks?</value>
+  </data>
+  <data name="OnboardingUpdates_CbNofityOnUpdate" xml:space="preserve">
+    <value>Yes, notify me on new &amp;updates</value>
+  </data>
+  <data name="OnboardingUpdates_CbExecuteUpdater" xml:space="preserve">
+    <value>Yes, &amp;download and launch the installer for me</value>
+  </data>
+  <data name="OnboardingUpdates_LblInfo2" xml:space="preserve">
+	  <value>When a new update is available, HASS.Agent can download the installer and launch it for you.
+
+The certificate of the downloaded file will get checked before running,you will still get to review the release notes and manually approve the update.</value>
+  </data>
+  <data name="OnboardingDone_LblGitHub" xml:space="preserve">
+    <value>HASS.Agent GitHub page</value>
+  </data>
+  <data name="OnboardingDone_LblInfo3" xml:space="preserve">
+	  <value>There's a lot more to tinker with, so make sure you take a look at the Configuration Window!
+
+
+Thank you for using HASS.Agent, hopefully it'll be useful for you :-)
+</value>
+  </data>
+  <data name="OnboardingDone_LblInfo2" xml:space="preserve">
+    <value>HASS.Agent will now restart to apply your configuration changes.</value>
+  </data>
+  <data name="OnboardingDone_LblInfo1" xml:space="preserve">
+    <value>Yay, done!</value>
+  </data>
+  <data name="ServiceCommands_LblLowIntegrity" xml:space="preserve">
+    <value>Low Integrity</value>
+  </data>
+  <data name="ServiceCommands_ClmName" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="ServiceCommands_ClmType" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="ServiceCommands_BtnRemove" xml:space="preserve">
+    <value>&amp;Remove</value>
+  </data>
+  <data name="ServiceCommands_BtnModify" xml:space="preserve">
+    <value>&amp;Modify</value>
+  </data>
+  <data name="ServiceCommands_BtnAdd" xml:space="preserve">
+    <value>&amp;Add New</value>
+  </data>
+  <data name="ServiceCommands_BtnStore" xml:space="preserve">
+    <value>&amp;Send &amp;&amp; Activate Commands</value>
+  </data>
+  <data name="ServiceCommands_LblStored" xml:space="preserve">
+    <value>commands stored!</value>
+  </data>
+  <data name="ServiceConnect_BtnRetryAuthId" xml:space="preserve">
+    <value>&amp;Apply</value>
+  </data>
+  <data name="ServiceConnect_LblRetryAuthId" xml:space="preserve">
+    <value>Auth &amp;ID</value>
+  </data>
+  <data name="ServiceConnect_LblAuthenticate" xml:space="preserve">
+    <value>Authenticate</value>
+  </data>
+  <data name="ServiceConnect_LblConnect" xml:space="preserve">
+    <value>Connect with service</value>
+  </data>
+  <data name="ServiceConnect_LblLoading" xml:space="preserve">
+    <value>Connecting satellite service, please wait..</value>
+  </data>
+  <data name="ServiceConnect_LblFetchConfig" xml:space="preserve">
+    <value>Fetch Configuration</value>
+  </data>
+  <data name="ServiceGeneral_LblInfo1" xml:space="preserve">
+    <value>This page contains general configuration settings, for MQTT settings, commands, and sensors, browse the different tabs above.</value>
+  </data>
+  <data name="ServiceGeneral_LblAuthId" xml:space="preserve">
+    <value>Auth &amp;ID</value>
+  </data>
+  <data name="ServiceGeneral_LblDeviceName" xml:space="preserve">
+    <value>Device &amp;Name</value>
+  </data>
+  <data name="ServiceGeneral_LblTip1" xml:space="preserve">
+    <value>Tip: Double-click these fields to browse</value>
+  </data>
+  <data name="ServiceGeneral_LblCustomExecBinary" xml:space="preserve">
+    <value>Custom Executor &amp;Binary</value>
+  </data>
+  <data name="ServiceGeneral_LblCustomExecName" xml:space="preserve">
+    <value>Custom &amp;Executor Name</value>
+  </data>
+  <data name="ServiceGeneral_LblSeconds" xml:space="preserve">
+    <value>seconds</value>
+  </data>
+  <data name="ServiceGeneral_LblDisconGrace" xml:space="preserve">
+    <value>Disconnected Grace &amp;Period</value>
+  </data>
+  <data name="ServiceGeneral_Apply" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="ServiceGeneral_LblVersionInfo" xml:space="preserve">
+    <value>Version</value>
+  </data>
+  <data name="ServiceGeneral_LblTip2" xml:space="preserve">
+    <value>Tip: Double-click to generate random</value>
+  </data>
+  <data name="ServiceGeneral_Stored" xml:space="preserve">
+    <value>Stored!</value>
+  </data>
+  <data name="ServiceMqtt_LblTip2" xml:space="preserve">
+    <value>(leave empty to auto generate)</value>
+  </data>
+  <data name="ServiceMqtt_LblClientId" xml:space="preserve">
+    <value>Client ID</value>
+  </data>
+  <data name="ServiceMqtt_LblTip3" xml:space="preserve">
+    <value>Tip: Double-click these fields to browse</value>
+  </data>
+  <data name="ServiceMqtt_LblClientCert" xml:space="preserve">
+    <value>Client Certificate</value>
+  </data>
+  <data name="ServiceMqtt_LblRootCert" xml:space="preserve">
+    <value>Root Certificate</value>
+  </data>
+  <data name="ServiceMqtt_CbUseRetainFlag" xml:space="preserve">
+    <value>Use &amp;Retain Flag</value>
+  </data>
+  <data name="ServiceMqtt_CbAllowUntrustedCertificates" xml:space="preserve">
+    <value>&amp;Allow Untrusted Certificates</value>
+  </data>
+  <data name="ServiceMqtt_BtnMqttClearConfig" xml:space="preserve">
+    <value>&amp;Clear Configuration</value>
+  </data>
+  <data name="ServiceMqtt_LblTip1" xml:space="preserve">
+    <value>(leave default if not sure)</value>
+  </data>
+  <data name="ServiceMqtt_LblInfo1" xml:space="preserve">
+	  <value>Commands and sensors are sent through MQTT. Please provide credentials for your server. If you're using the HA addon,
+you can probably use the preset address.</value>
+  </data>
+  <data name="ServiceMqtt_LblDiscoPrefix" xml:space="preserve">
+    <value>Discovery Prefix</value>
+  </data>
+  <data name="ServiceMqtt_LblBrokerPassword" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="ServiceMqtt_LblBrokerUsername" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="ServiceMqtt_LblBrokerPort" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="ServiceMqtt_LblBrokerIp" xml:space="preserve">
+    <value>Broker IP Address or Hostname</value>
+  </data>
+  <data name="ServiceMqtt_BtnStore" xml:space="preserve">
+    <value>&amp;Send &amp;&amp; Activate Configuration</value>
+  </data>
+  <data name="ServiceMqtt_BtnCopy" xml:space="preserve">
+    <value>Copy from &amp;HASS.Agent</value>
+  </data>
+  <data name="ServiceMqtt_LblStored" xml:space="preserve">
+    <value>Configuration stored!</value>
+  </data>
+  <data name="ServiceMqtt_LblStatusInfo" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="ServiceMqtt_LblStatus" xml:space="preserve">
+    <value>Querying..</value>
+  </data>
+  <data name="ServiceSensors_ClmName" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="ServiceSensors_ClmType" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="ServiceSensors_LblRefresh" xml:space="preserve">
+    <value>Refresh</value>
+  </data>
+  <data name="ServiceSensors_BtnRemove" xml:space="preserve">
+    <value>&amp;Remove</value>
+  </data>
+  <data name="ServiceSensors_BtnAdd" xml:space="preserve">
+    <value>&amp;Add New</value>
+  </data>
+  <data name="ServiceSensors_BtnModify" xml:space="preserve">
+    <value>&amp;Modify</value>
+  </data>
+  <data name="ServiceSensors_BtnStore" xml:space="preserve">
+    <value>&amp;Send &amp;&amp; Activate Sensors</value>
+  </data>
+  <data name="ServiceSensors_LblStored" xml:space="preserve">
+    <value>Sensors stored!</value>
+  </data>
+  <data name="PortReservation_LblInfo1" xml:space="preserve">
+    <value>Please wait a bit while the task is performed ..</value>
+  </data>
+  <data name="PortReservation_LblTask1" xml:space="preserve">
+    <value>Create API Port Binding</value>
+  </data>
+  <data name="PortReservation_LblTask2" xml:space="preserve">
+    <value>Set Firewall Rule</value>
+  </data>
+  <data name="PortReservation_Title" xml:space="preserve">
+    <value>HASS.Agent Port Reservation</value>
+  </data>
+  <data name="PostUpdate_LblInfo1" xml:space="preserve">
+    <value>Please wait a bit while some post-update tasks are performed ..</value>
+  </data>
+  <data name="PostUpdate_LblTask1" xml:space="preserve">
+    <value>Configuring Satellite Service</value>
+  </data>
+  <data name="PostUpdate_LblTask2" xml:space="preserve">
+    <value>Create API Port Binding</value>
+  </data>
+  <data name="PostUpdate_Title" xml:space="preserve">
+    <value>HASS.Agent Post Update</value>
+  </data>
+  <data name="Restart_LblInfo1" xml:space="preserve">
+    <value>Please wait while HASS.Agent restarts..</value>
+  </data>
+  <data name="Restart_LblTask1" xml:space="preserve">
+    <value>Waiting for previous instance to close..</value>
+  </data>
+  <data name="Restart_LblTask2" xml:space="preserve">
+    <value>Relaunch HASS.Agent</value>
+  </data>
+  <data name="Restart_Title" xml:space="preserve">
+    <value>HASS.Agent Restarter</value>
+  </data>
+  <data name="ServiceReinstall_LblInfo1" xml:space="preserve">
+    <value>Please wait while the satellite service is re-installed..</value>
+  </data>
+  <data name="ServiceReinstall_LblTask1" xml:space="preserve">
+    <value>Remove Satellite Service</value>
+  </data>
+  <data name="ServiceReinstall_LblTask2" xml:space="preserve">
+    <value>Install Satellite Service</value>
+  </data>
+  <data name="ServiceReinstall_Title" xml:space="preserve">
+    <value>HASS.Agent Reinstall Satellite Service</value>
+  </data>
+  <data name="ServiceSetState_LblInfo1" xml:space="preserve">
+    <value>Please wait while the satellite service is configured..</value>
+  </data>
+  <data name="ServiceSetState_LblTask1" xml:space="preserve">
+    <value>Enable Satellite Service</value>
+  </data>
+  <data name="ServiceSetState_Title" xml:space="preserve">
+    <value>HASS.Agent Configure Satellite Service</value>
+  </data>
+  <data name="CommandMqttTopic_BtnClose" xml:space="preserve">
+    <value>&amp;Close</value>
+  </data>
+  <data name="CommandMqttTopic_LblInfo1" xml:space="preserve">
+    <value>This is the MQTT topic on which you can publish action commands:</value>
+  </data>
+  <data name="CommandMqttTopic_BtnCopyClipboard" xml:space="preserve">
+    <value>Copy &amp;to Clipboard</value>
+  </data>
+  <data name="CommandMqttTopic_LblHelp" xml:space="preserve">
+    <value>help and examples</value>
+  </data>
+  <data name="CommandMqttTopic_Title" xml:space="preserve">
+    <value>MQTT Action Topic</value>
+  </data>
+  <data name="CommandsConfig_BtnRemove" xml:space="preserve">
+    <value>&amp;Remove</value>
+  </data>
+  <data name="CommandsConfig_BtnModify" xml:space="preserve">
+    <value>&amp;Modify</value>
+  </data>
+  <data name="CommandsConfig_BtnAdd" xml:space="preserve">
+    <value>&amp;Add New</value>
+  </data>
+  <data name="CommandsConfig_BtnStore" xml:space="preserve">
+    <value>&amp;Store and Activate Commands</value>
+  </data>
+  <data name="CommandsConfig_ClmName" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="CommandsConfig_ClmType" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="CommandsConfig_LblLowIntegrity" xml:space="preserve">
+    <value>Low Integrity</value>
+  </data>
+  <data name="CommandsConfig_LblActionInfo" xml:space="preserve">
+    <value>Action</value>
+  </data>
+  <data name="CommandsConfig_Title" xml:space="preserve">
+    <value>Commands Config</value>
+  </data>
+  <data name="CommandsMod_BtnStore" xml:space="preserve">
+    <value>&amp;Store Command</value>
+  </data>
+  <data name="CommandsMod_LblSetting" xml:space="preserve">
+    <value>&amp;Configuration</value>
+  </data>
+  <data name="CommandsMod_LblName" xml:space="preserve">
+    <value>&amp;Name</value>
+  </data>
+  <data name="CommandsMod_LblDescription" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="CommandsMod_CbRunAsLowIntegrity" xml:space="preserve">
+    <value>&amp;Run as 'Low Integrity'</value>
+  </data>
+  <data name="CommandsMod_LblIntegrityInfo" xml:space="preserve">
+    <value>What's this?</value>
+  </data>
+  <data name="CommandsMod_ClmSensorName" xml:space="preserve">
+    <value>  Type</value>
+  </data>
+  <data name="CommandsMod_LblSelectedType" xml:space="preserve">
+    <value>Selected Type</value>
+  </data>
+  <data name="CommandsMod_LblService" xml:space="preserve">
+    <value>Service</value>
+  </data>
+  <data name="CommandsMod_LblAgent" xml:space="preserve">
+    <value>agent</value>
+  </data>
+  <data name="CommandsMod_LblSpecificClient" xml:space="preserve">
+    <value>HASS.Agent only!</value>
+  </data>
+  <data name="CommandsMod_LblEntityType" xml:space="preserve">
+    <value>&amp;Entity Type</value>
+  </data>
+  <data name="CommandsMod_LblMqttTopic" xml:space="preserve">
+    <value>Show MQTT Action Topic</value>
+  </data>
+  <data name="CommandsMod_LblActionInfo" xml:space="preserve">
+    <value>Action</value>
+  </data>
+  <data name="CommandsMod_Title" xml:space="preserve">
+    <value>Command</value>
+  </data>
+  <data name="QuickActions_LblLoading" xml:space="preserve">
+    <value>Retrieving entities, please wait..</value>
+  </data>
+  <data name="QuickActions_Title" xml:space="preserve">
+    <value>Quick Actions</value>
+  </data>
+  <data name="QuickActionsConfig_BtnStore" xml:space="preserve">
+    <value>&amp;Store Quick Actions</value>
+  </data>
+  <data name="QuickActionsConfig_BtnAdd" xml:space="preserve">
+    <value>&amp;Add New</value>
+  </data>
+  <data name="QuickActionsConfig_BtnModify" xml:space="preserve">
+    <value>&amp;Modify</value>
+  </data>
+  <data name="QuickActionsConfig_BtnRemove" xml:space="preserve">
+    <value>&amp;Remove</value>
+  </data>
+  <data name="QuickActionsConfig_BtnPreview" xml:space="preserve">
+    <value>&amp;Preview</value>
+  </data>
+  <data name="QuickActionsConfig_ClmDomain" xml:space="preserve">
+    <value>Domain</value>
+  </data>
+  <data name="QuickActionsConfig_ClmEntity" xml:space="preserve">
+    <value>Entity</value>
+  </data>
+  <data name="QuickActionsConfig_ClmAction" xml:space="preserve">
+    <value>Action</value>
+  </data>
+  <data name="QuickActionsConfig_ClmHotKey" xml:space="preserve">
+    <value>Hotkey</value>
+  </data>
+  <data name="QuickActionsConfig_ClmDescription" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="QuickActionsConfig_LblHotkey" xml:space="preserve">
+	  <value>Hotkey Enabled</value>
+  </data>
+  <data name="QuickActionsConfig_Title" xml:space="preserve">
+    <value>Quick Actions Configuration</value>
+  </data>
+  <data name="QuickActionsMod_BtnStore" xml:space="preserve">
+    <value>&amp;Store Quick Action</value>
+  </data>
+  <data name="QuickActionsMod_LblDomain" xml:space="preserve">
+    <value>Domain</value>
+  </data>
+  <data name="QuickActionsMod_LblEntityInfo" xml:space="preserve">
+    <value>&amp;Entity</value>
+  </data>
+  <data name="QuickActionsMod_LblAction" xml:space="preserve">
+    <value>Desired &amp;Action</value>
+  </data>
+  <data name="QuickActionsMod_LblDescription" xml:space="preserve">
+    <value>&amp;Description</value>
+  </data>
+  <data name="QuickActionsMod_LblLoading" xml:space="preserve">
+    <value>Retrieving entities, please wait..</value>
+  </data>
+  <data name="QuickActionsMod_CbEnableHotkey" xml:space="preserve">
+    <value>enable hotkey</value>
+  </data>
+  <data name="QuickActionsMod_LblHotkey" xml:space="preserve">
+    <value>&amp;hotkey combination</value>
+  </data>
+  <data name="QuickActionsMod_LblTip1" xml:space="preserve">
+    <value>(optional, will be used instead of entity name)</value>
+  </data>
+  <data name="QuickActionsMod_Title" xml:space="preserve">
+    <value>Quick Action</value>
+  </data>
+  <data name="SensorsConfig_BtnRemove" xml:space="preserve">
+    <value>&amp;Remove</value>
+  </data>
+  <data name="SensorsConfig_BtnModify" xml:space="preserve">
+    <value>&amp;Modify</value>
+  </data>
+  <data name="SensorsConfig_BtnAdd" xml:space="preserve">
+    <value>&amp;Add New</value>
+  </data>
+  <data name="SensorsConfig_BtnStore" xml:space="preserve">
+    <value>&amp;Store &amp;&amp; Activate Sensors</value>
+  </data>
+  <data name="SensorsConfig_ClmName" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="SensorsConfig_ClmType" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="SensorsConfig_LblRefresh" xml:space="preserve">
+    <value>Refresh</value>
+  </data>
+  <data name="SensorsConfig_Title" xml:space="preserve">
+    <value>Sensors Configuration</value>
+  </data>
+  <data name="SensorsMod_BtnStore" xml:space="preserve">
+    <value>&amp;Store Sensor</value>
+  </data>
+  <data name="SensorsMod_LblSetting1" xml:space="preserve">
+    <value>setting 1</value>
+  </data>
+  <data name="SensorsMod_LblType" xml:space="preserve">
+    <value>Selected Type</value>
+  </data>
+  <data name="SensorsMod_LblName" xml:space="preserve">
+    <value>&amp;Name</value>
+  </data>
+  <data name="SensorsMod_LblUpdate" xml:space="preserve">
+    <value>&amp;Update every</value>
+  </data>
+  <data name="SensorsMod_LblSeconds" xml:space="preserve">
+    <value>seconds</value>
+  </data>
+  <data name="SensorsMod_LblDescription" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="SensorsMod_LblSetting2" xml:space="preserve">
+    <value>Setting 2</value>
+  </data>
+  <data name="SensorsMod_LblSetting3" xml:space="preserve">
+    <value>Setting 3</value>
+  </data>
+  <data name="SensorsMod_ClmSensorName" xml:space="preserve">
+    <value>  Type</value>
+  </data>
+  <data name="SensorsMod_LblMultiValue" xml:space="preserve">
+	  <value>Multivalue</value>
+  </data>
+  <data name="SensorsMod_LblAgent" xml:space="preserve">
+    <value>Agent</value>
+  </data>
+  <data name="SensorsMod_LblService" xml:space="preserve">
+    <value>Service</value>
+  </data>
+  <data name="SensorsMod_LblSpecificClient" xml:space="preserve">
+    <value>HASS.Agent only!</value>
+  </data>
+  <data name="SensorsMod_Title" xml:space="preserve">
+    <value>Sensor</value>
+  </data>
+  <data name="ServiceConfig_TabGeneral" xml:space="preserve">
+    <value>     General     </value>
+  </data>
+  <data name="ServiceConfig_TabMqtt" xml:space="preserve">
+    <value>     MQTT     </value>
+  </data>
+  <data name="ServiceConfig_TabCommands" xml:space="preserve">
+    <value>     Commands     </value>
+  </data>
+  <data name="ServiceConfig_TabSensors" xml:space="preserve">
+    <value>     Sensors     </value>
+  </data>
+  <data name="ServiceConfig_Title" xml:space="preserve">
+    <value>Satellite Service Configuration</value>
+  </data>
+  <data name="About_BtnClose" xml:space="preserve">
+    <value>&amp;Close</value>
+  </data>
+  <data name="About_LblInfo1" xml:space="preserve">
+    <value>A Windows-based client for the Home Assistant platform.</value>
+  </data>
+  <data name="About_LblInfo3" xml:space="preserve">
+	  <value>This application is open source and completely free, please check the project pages of 
+the used components for their individual licenses:</value>
+  </data>
+  <data name="About_LblInfo4" xml:space="preserve">
+	  <value>A big 'thank you' to the developers of these projects, who were kind enough to share
+their hard work with the rest of us mere mortals. </value>
+  </data>
+  <data name="About_LblInfo5" xml:space="preserve">
+	  <value>And of course; thanks to Paulus Shoutsen and the entire team of developers that 
+created and maintain Home Assistant :-)</value>
+  </data>
+  <data name="About_LblInfo2" xml:space="preserve">
+    <value>Created with love by</value>
+  </data>
+  <data name="About_LblInfo6" xml:space="preserve">
+    <value>Like this tool? Support us (read: keep us awake) by buying a cup of coffee:</value>
+  </data>
+  <data name="About_Title" xml:space="preserve">
+    <value>About</value>
+  </data>
+  <data name="Configuration_TabGeneral" xml:space="preserve">
+    <value>General</value>
+  </data>
+  <data name="Configuration_TabExternalTools" xml:space="preserve">
+    <value>External Tools</value>
+  </data>
+  <data name="Configuration_TabHassApi" xml:space="preserve">
+    <value>Home Assistant API</value>
+  </data>
+  <data name="Configuration_TabHotKey" xml:space="preserve">
+    <value>Hotkey</value>
+  </data>
+  <data name="Configuration_TabLocalStorage" xml:space="preserve">
+    <value>Local Storage</value>
+  </data>
+  <data name="Configuration_TabLogging" xml:space="preserve">
+    <value>Logging</value>
+  </data>
+  <data name="Configuration_TabMQTT" xml:space="preserve">
+    <value>MQTT</value>
+  </data>
+  <data name="Configuration_TabNotifications" xml:space="preserve">
+    <value>Notifications</value>
+  </data>
+  <data name="Configuration_TabService" xml:space="preserve">
+    <value>Satellite Service</value>
+  </data>
+  <data name="Configuration_TabStartup" xml:space="preserve">
+    <value>Startup</value>
+  </data>
+  <data name="Configuration_TabUpdates" xml:space="preserve">
+    <value>Updates</value>
+  </data>
+  <data name="Configuration_BtnAbout" xml:space="preserve">
+    <value>&amp;About</value>
+  </data>
+  <data name="Configuration_BtnHelp" xml:space="preserve">
+    <value>&amp;Help &amp;&amp; Contact</value>
+  </data>
+  <data name="Configuration_BtnStore" xml:space="preserve">
+    <value>&amp;Save Configuration</value>
+  </data>
+  <data name="Configuration_BtnClose" xml:space="preserve">
+    <value>Close &amp;Without Saving</value>
+  </data>
+  <data name="Configuration_Title" xml:space="preserve">
+    <value>Configuration</value>
+  </data>
+  <data name="ExitDialog_LblInfo1" xml:space="preserve">
+    <value>What would you like to do?</value>
+  </data>
+  <data name="ExitDialog_BtnRestart" xml:space="preserve">
+    <value>&amp;Restart</value>
+  </data>
+  <data name="ExitDialog_BtnHide" xml:space="preserve">
+    <value>&amp;Hide</value>
+  </data>
+  <data name="ExitDialog_BtnExit" xml:space="preserve">
+    <value>&amp;Exit</value>
+  </data>
+  <data name="ExitDialog_Title" xml:space="preserve">
+    <value>Exit Dialog</value>
+  </data>
+  <data name="Help_BtnClose" xml:space="preserve">
+    <value>&amp;Close</value>
+  </data>
+  <data name="Help_LblInfo1" xml:space="preserve">
+	  <value>If you are having trouble with HASS.Agent and require support
+with any sensors, commands, or for general support and feedback,
+there are few ways you can reach us:</value>
+  </data>
+  <data name="Help_LblAbout" xml:space="preserve">
+    <value>About</value>
+  </data>
+  <data name="Help_LblHAForum" xml:space="preserve">
+    <value>Home Assistant Forum</value>
+  </data>
+  <data name="Help_LblGitHub" xml:space="preserve">
+    <value>GitHub Issues</value>
+  </data>
+  <data name="Help_LblHAInfo" xml:space="preserve">
+	  <value>Bit of everything, with the addition that other
+HA users can help you out too!</value>
+  </data>
+  <data name="Help_LblGitHubInfo" xml:space="preserve">
+    <value>Report bugs, post feature requests, see latest changes, etc.</value>
+  </data>
+  <data name="Help_LblDiscordInfo" xml:space="preserve">
+	  <value>Get help with setting up and using HASS.Agent, 
+report bugs or get involved in general chit-chat!</value>
+  </data>
+  <data name="Help_LblWikiInfo" xml:space="preserve">
+    <value>Browse HASS.Agent documentation and usage examples.</value>
+  </data>
+  <data name="Help_Title" xml:space="preserve">
+    <value>Help</value>
+  </data>
+  <data name="Main_TsShow" xml:space="preserve">
+    <value>Show HASS.Agent</value>
+  </data>
+  <data name="Main_TsShowQuickActions" xml:space="preserve">
+    <value>Show Quick Actions</value>
+  </data>
+  <data name="Main_TsConfig" xml:space="preserve">
+    <value>Configuration</value>
+  </data>
+  <data name="Main_TsQuickItemsConfig" xml:space="preserve">
+    <value>Manage Quick Actions</value>
+  </data>
+  <data name="Main_TsLocalSensors" xml:space="preserve">
+    <value>Manage Local Sensors</value>
+  </data>
+  <data name="Main_TsCommands" xml:space="preserve">
+    <value>Manage Commands</value>
+  </data>
+  <data name="Main_CheckForUpdates" xml:space="preserve">
+    <value>Check for Updates</value>
+  </data>
+  <data name="Main_TsDonate" xml:space="preserve">
+    <value>Donate</value>
+  </data>
+  <data name="Main_TsHelp" xml:space="preserve">
+    <value>Help &amp;&amp; Contact</value>
+  </data>
+  <data name="Main_TsAbout" xml:space="preserve">
+    <value>About</value>
+  </data>
+  <data name="Main_TsExit" xml:space="preserve">
+    <value>Exit HASS.Agent</value>
+  </data>
+  <data name="Main_BtnHide" xml:space="preserve">
+    <value>&amp;Hide</value>
+  </data>
+  <data name="Main_GpControls" xml:space="preserve">
+    <value>Controls</value>
+  </data>
+  <data name="Main_BtnServiceManager" xml:space="preserve">
+    <value>S&amp;atellite Service</value>
+  </data>
+  <data name="Main_BtnAppSettings" xml:space="preserve">
+    <value>C&amp;onfiguration</value>
+  </data>
+  <data name="Main_BtnActionsManager" xml:space="preserve">
+    <value>&amp;Quick Actions</value>
+  </data>
+  <data name="Main_BtnCommandsManager" xml:space="preserve">
+    <value>Loading..</value>
+  </data>
+  <data name="Main_BtnSensorsManager" xml:space="preserve">
+    <value>Loading..</value>
+  </data>
+  <data name="Main_GpStatus" xml:space="preserve">
+    <value>System Status</value>
+  </data>
+  <data name="Main_LblService" xml:space="preserve">
+    <value>Satellite Service:</value>
+  </data>
+  <data name="Main_LblCommands" xml:space="preserve">
+    <value>Commands:</value>
+  </data>
+  <data name="Main_LblSensors" xml:space="preserve">
+    <value>Sensors:</value>
+  </data>
+  <data name="Main_LblQuickActions" xml:space="preserve">
+    <value>Quick Actions:</value>
+  </data>
+  <data name="Main_LblHomeAssistantApi" xml:space="preserve">
+    <value>Home Assistant API:</value>
+  </data>
+  <data name="Main_LblNotificationApi" xml:space="preserve">
+    <value>notification api:</value>
+  </data>
+  <data name="Onboarding_BtnNext" xml:space="preserve">
+    <value>&amp;Next</value>
+  </data>
+  <data name="Onboarding_BtnClose" xml:space="preserve">
+    <value>&amp;Close</value>
+  </data>
+  <data name="Onboarding_BtnPrevious" xml:space="preserve">
+    <value>&amp;Previous</value>
+  </data>
+  <data name="Onboarding_Onboarding" xml:space="preserve">
+    <value>HASS.Agent Onboarding</value>
+  </data>
+  <data name="UpdatePending_BtnDownload" xml:space="preserve">
+    <value>Fetching info, please wait..</value>
+  </data>
+  <data name="UpdatePending_LblNewReleaseInfo" xml:space="preserve">
+    <value>There's a new release available:</value>
+  </data>
+  <data name="UpdatePending_LblInfo1" xml:space="preserve">
+    <value>Release notes</value>
+  </data>
+  <data name="UpdatePending_BtnIgnore" xml:space="preserve">
+    <value>&amp;Ignore Update</value>
+  </data>
+  <data name="UpdatePending_LblRelease" xml:space="preserve">
+    <value>Release Page</value>
+  </data>
+  <data name="UpdatePending_Title" xml:space="preserve">
+    <value>HASS.Agent Update</value>
+  </data>
+  <data name="CommandsManager_CustomCommandDescription" xml:space="preserve">
+	  <value>Execute a custom command.
+
+These commands run without special elevation. To run elevated, create a Scheduled Task, and use 'schtasks /Run /TN "TaskName"' as the command to execute your task.
+
+Or enable 'run as low integrity' for even stricter execution.</value>
+  </data>
+  <data name="CommandsManager_CustomExecutorCommandDescription" xml:space="preserve">
+	  <value>Executes the command through the configured custom executor (in Configuration -&gt; External Tools).
+
+Your command is provided as an argument 'as is', so you have to supply your own quotes etc. if necessary.</value>
+  </data>
+  <data name="CommandsManager_HibernateCommandDescription" xml:space="preserve">
+    <value>Sets the machine in hibernation.</value>
+  </data>
+  <data name="CommandsManager_KeyCommandDescription" xml:space="preserve">
+	  <value>Simulates a single keypress.
+
+Click on the 'keycode' textbox and press the key you want simulated. The corresponding keycode will be entered for you.
+
+If you need more keys and/or modifiers like CTRL, use the MultipleKeys command.</value>
+  </data>
+  <data name="CommandsManager_LaunchUrlCommandDescription" xml:space="preserve">
+	  <value>Launches the provided URL, by default in your default browser.
+
+To use 'incognito', provide a specific browser in Configuration -&gt; External Tools.
+
+If you just want a window with a specific URL (not an entire browser), use a 'WebView' command.</value>
+  </data>
+  <data name="CommandsManager_LockCommandDescription" xml:space="preserve">
+    <value>Locks the current session.</value>
+  </data>
+  <data name="CommandsManager_LogOffCommandDescription" xml:space="preserve">
+    <value>Logs off the current session.</value>
+  </data>
+  <data name="CommandsManager_MediaMuteCommandDescription" xml:space="preserve">
+    <value>Simulates 'Mute' key.</value>
+  </data>
+  <data name="CommandsManager_MediaNextCommandDescription" xml:space="preserve">
+    <value>Simulates 'Media Next' key.</value>
+  </data>
+  <data name="CommandsManager_MediaPlayPauseCommandDescription" xml:space="preserve">
+    <value>Simulates 'Media Pause/Play' key.</value>
+  </data>
+  <data name="CommandsManager_MediaPreviousCommandDescription" xml:space="preserve">
+    <value>Simulates 'Media Previous' key.</value>
+  </data>
+  <data name="CommandsManager_MediaVolumeDownCommandDescription" xml:space="preserve">
+    <value>Simulates 'Volume Down' key.</value>
+  </data>
+  <data name="CommandsManager_MediaVolumeUpCommandDescription" xml:space="preserve">
+    <value>Simulates 'Volume Up' key.</value>
+  </data>
+  <data name="CommandsManager_MultipleKeysCommandDescription" xml:space="preserve">
+	  <value>Simulates pressing mulitple keys.
+
+You need to put [ ] between every key, otherwise HASS.Agent can't tell them apart. So say you want to press X TAB Y SHIFT-Z, it'd be [X] [{TAB}] [Y] [+Z].
+
+There are a few tricks you can use:
+
+- If you want a bracket pressed, escape it, so [ is [\[] and ] is [\]] 
+
+- Special keys go between { }, like {TAB} or {UP}
+
+- Put a + in front of a key to add SHIFT, ^ for CTRL and % for ALT. So, +C is SHIFT-C. Or, +(CD) is SHIFT-C and SHIFT-D, while +CD is SHIFT-C and D
+
+- For multiple presses, use {z 15}, which means Z will get pressed 15 times.
+
+More info: https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.sendkeys</value>
+  </data>
+  <data name="CommandsManager_PowershellCommandDescription" xml:space="preserve">
+	  <value>Execute a Powershell command or script.
+
+You can either provide the location of a script (*.ps1), or a single-line command.
+
+This will run without special elevation.</value>
+  </data>
+  <data name="CommandsManager_PublishAllSensorsCommandDescription" xml:space="preserve">
+	  <value>Resets all sensor checks, forcing all sensors to process and send their value.
+
+Useful for example if you want to force HASS.Agent to update all your sensors after a HA reboot.</value>
+  </data>
+  <data name="CommandsManager_RestartCommandDescription" xml:space="preserve">
+	  <value>Restarts the machine after one minute.
+
+Tip: Accidentally triggered? Run 'shutdown /a' to abort shutdown.</value>
+  </data>
+  <data name="CommandsManager_ShutdownCommandDescription" xml:space="preserve">
+	  <value>Shuts down the machine after one minute.
+
+Tip: Accidentally triggered? Run 'shutdown /a' to abort shutdown.</value>
+  </data>
+  <data name="CommandsManager_SleepCommandDescription" xml:space="preserve">
+	  <value>Puts the machine to sleep.
+
+Note: due to a limitation in Windows, this only works if hibernation is disabled, otherwise it will just hibernate.
+
+You can use something like NirCmd (http://www.nirsoft.net/utils/nircmd.html) to circumvent this.</value>
+  </data>
+  <data name="ConfigExternalTools_BtnExternalBrowserIncognitoTest_MessageBox1" xml:space="preserve">
+    <value>Please enter the location of your browser's binary! (.exe file)</value>
+  </data>
+  <data name="ConfigExternalTools_ConfigExternalTools_BtnExternalBrowserIncognitoTest_MessageBox2" xml:space="preserve">
+    <value>The browser binary provided could not be found, please ensure the path is correct and try again.</value>
+  </data>
+  <data name="ConfigExternalTools_BtnExternalBrowserIncognitoTest_MessageBox3" xml:space="preserve">
+	  <value>No incognito arguments were provided so the browser will likely launch normally.
+
+Do you want to continue?</value>
+  </data>
+  <data name="ConfigExternalTools_BtnExternalBrowserIncognitoTest_MessageBox4" xml:space="preserve">
+	  <value>Something went wrong while launching your browser in incognito mode!
+
+Please check the logs for more information.</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox1" xml:space="preserve">
+    <value>Please enter a valid API key!</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox2" xml:space="preserve">
+    <value>Please enter a value for your Home Assistant's URI.</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox3" xml:space="preserve">
+	  <value>Unable to connect, the following error was returned:
+
+{0}</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox4" xml:space="preserve">
+	  <value>Connection OK!
+
+Home Assistant version: {0}</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearImageCache_MessageBox1" xml:space="preserve">
+    <value>Image cache has been cleared!</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearImageCache_InfoText1" xml:space="preserve">
+    <value>Cleaning..</value>
+  </data>
+  <data name="ConfigNotifications_BtnSendTestNotification_MessageBox1" xml:space="preserve">
+    <value>Notifications are currently disabled, please enable them and restart the HASS.Agent, then try again.</value>
+  </data>
+  <data name="ConfigNotifications_BtnSendTestNotification_MessageBox2" xml:space="preserve">
+	  <value>The test notification should have appeared, if you did not receive it please check the logs or consult the documentation for troubleshooting tips.
+
+Note: This only tests locally whether notifications can be shown!</value>
+  </data>
+  <data name="ConfigNotifications_TestNotification" xml:space="preserve">
+    <value>This is a test notification!</value>
+  </data>
+  <data name="ConfigNotifications_BtnExecutePortReservation_Busy" xml:space="preserve">
+    <value>Executing, please wait..</value>
+  </data>
+  <data name="ConfigNotifications_BtnExecutePortReservation_MessageBox1" xml:space="preserve">
+	  <value>Something went wrong whilst reserving the port!
+
+Manual execution is required and a command has been copied to your clipboard, please open an elevated terminal and paste the command.
+
+Additionally, remember to change your Firewall Rules port!</value>
+  </data>
+  <data name="ConfigService_NotInstalled" xml:space="preserve">
+    <value>Not Installed</value>
+  </data>
+  <data name="ConfigService_Disabled" xml:space="preserve">
+    <value>Disabled</value>
+  </data>
+  <data name="ConfigService_Running" xml:space="preserve">
+    <value>Running</value>
+  </data>
+  <data name="ConfigService_Stopped" xml:space="preserve">
+    <value>Stopped</value>
+  </data>
+  <data name="ConfigService_Failed" xml:space="preserve">
+    <value>Failed</value>
+  </data>
+  <data name="ConfigService_BtnStopService_MessageBox1" xml:space="preserve">
+	  <value>Something went wrong whilst stopping the service, did you allow the UAC prompt?
+
+Check the HASS.Agent (not the service) logs for more information.</value>
+  </data>
+  <data name="ConfigService_BtnStartService_MessageBox1" xml:space="preserve">
+	  <value>The service is set to 'disabled', so it cannot be started.
+
+Please enable the service first and try again.</value>
+  </data>
+  <data name="ConfigService_BtnStartService_MessageBox2" xml:space="preserve">
+	  <value>Something went wrong whilst starting the service, did you allow the UAC prompt?
+
+Check the HASS.Agent (not the service) logs for more information.</value>
+  </data>
+  <data name="ConfigService_BtnDisableService_MessageBox1" xml:space="preserve">
+	  <value>Something went wrong whilst disabling the service, did you allow the UAC prompt?
+
+Check the HASS.Agent (not the service) logs for more information.</value>
+  </data>
+  <data name="ConfigService_BtnEnableService_MessageBox1" xml:space="preserve">
+	  <value>Something went wrong whilst enabling the service, did you allow the UAC prompt?
+
+Check the HASS.Agent (not the service) logs for more information.</value>
+  </data>
+  <data name="ConfigService_BtnShowLogs_MessageBox1" xml:space="preserve">
+	  <value>Something went wrong whilst reinstalling the service, did you allow the UAC prompt?
+
+Check the HASS.Agent (not the service) logs for more information.</value>
+  </data>
+  <data name="ConfigStartup_BtnSetStartOnLogin_MessageBox1" xml:space="preserve">
+    <value>Something went wrong whilst disabling Start-on-Login, please check the logs for more information.</value>
+  </data>
+  <data name="ConfigStartup_BtnSetStartOnLogin_MessageBox2" xml:space="preserve">
+    <value>Something went wrong whilst disabling Start-on-Login, please check the logs for more information.</value>
+  </data>
+  <data name="ConfigStartup_Enabled" xml:space="preserve">
+    <value>Enabled</value>
+  </data>
+  <data name="ConfigStartup_Disable" xml:space="preserve">
+    <value>Disable Start-on-Login</value>
+  </data>
+  <data name="ConfigStartup_Disabled" xml:space="preserve">
+    <value>Disabled</value>
+  </data>
+  <data name="ConfigStartup_Enable" xml:space="preserve">
+    <value>Enable Start-on-Login</value>
+  </data>
+  <data name="OnboardingStartup_Activated" xml:space="preserve">
+    <value>Start-on-Login has been activated!</value>
+  </data>
+  <data name="OnboardingStartup_EnableNow" xml:space="preserve">
+    <value>Do you want to enable Start-on-Login now?</value>
+  </data>
+  <data name="OnboardingStartup_AlreadyActivated" xml:space="preserve">
+    <value>Start-on-Login is already activated, all set!</value>
+  </data>
+  <data name="OnboardingStartup_Activating" xml:space="preserve">
+    <value>Activating Start-on-Login..</value>
+  </data>
+  <data name="OnboardingStartup_Failed" xml:space="preserve">
+    <value>Something went wrong. You can try again, or skip to the next page and retry after HASS.Agent's restart.</value>
+  </data>
+  <data name="OnboardingStartup_BtnSetLaunchOnLogin_2" xml:space="preserve">
+    <value>Enable Start-on-Login</value>
+  </data>
+  <data name="OnboardingApi_BtnTest_MessageBox1" xml:space="preserve">
+    <value>Please provide a valid API key.</value>
+  </data>
+  <data name="OnboardingApi_BtnTest_MessageBox2" xml:space="preserve">
+    <value>Please enter your Home Assistant's URI.</value>
+  </data>
+  <data name="OnboardingApi_BtnTest_MessageBox3" xml:space="preserve">
+	  <value>Unable to connect, the following error was returned:
+
+{0}</value>
+  </data>
+  <data name="OnboardingApi_BtnTest_MessageBox4" xml:space="preserve">
+	  <value>Connection OK!
+
+Home Assistant version: {0}</value>
+  </data>
+  <data name="OnboardingApi_BtnTest_Testing" xml:space="preserve">
+    <value>Testing..</value>
+  </data>
+  <data name="ServiceCommands_BtnStore_MessageBox1" xml:space="preserve">
+    <value>An error occurred whilst saving your commands, please check the logs for more information.</value>
+  </data>
+  <data name="ServiceCommands_BtnStore_Storing" xml:space="preserve">
+    <value>Storing and registering, please wait..</value>
+  </data>
+  <data name="ServiceConnect_Connecting" xml:space="preserve">
+    <value>Connecting with satellite service, please wait..</value>
+  </data>
+  <data name="ServiceConnect_Failed" xml:space="preserve">
+    <value>Connecting to the service has failed!</value>
+  </data>
+  <data name="ServiceConnect_FailedMessage" xml:space="preserve">
+	  <value>The service hasn't been found! You can install and manage it from the configuration panel.
+
+When it's up and running, come back here to configure the commands and sensors.</value>
+  </data>
+  <data name="ServiceConnect_CommunicationFailed" xml:space="preserve">
+    <value>Communicating with the service has failed!</value>
+  </data>
+  <data name="ServiceConnect_CommunicationFailedMessage" xml:space="preserve">
+	  <value>Unable to communicate with the service. Check the logs for more info.
+
+You can open the logs and manage the service from the configuration panel.</value>
+  </data>
+  <data name="ServiceConnect_Unauthorized" xml:space="preserve">
+    <value>Unauthorized</value>
+  </data>
+  <data name="ServiceConnect_UnauthorizedMessage" xml:space="preserve">
+	  <value>You are not authorized to contact the service.
+
+If you have the correct auth ID, you can set it now and try again.</value>
+  </data>
+  <data name="ServiceConnect_SettingsFailed" xml:space="preserve">
+    <value>Fetching settings failed!</value>
+  </data>
+  <data name="ServiceConnect_SettingsFailedMessage" xml:space="preserve">
+	  <value>The service returned an error while requesting its settings. Check the logs for more info.
+
+You can open the logs and manage the service from the configuration panel.</value>
+  </data>
+  <data name="ServiceConnect_MqttFailed" xml:space="preserve">
+    <value>Fetching MQTT settings failed!</value>
+  </data>
+  <data name="ServiceConnect_MqttFailedMessage" xml:space="preserve">
+	  <value>The service returned an error while requesting its MQTT settings. Check the logs for more info.
+
+You can open the logs and manage the service from the configuration panel.</value>
+  </data>
+  <data name="ServiceConnect_CommandsFailed" xml:space="preserve">
+    <value>Fetching configured commands failed!</value>
+  </data>
+  <data name="ServiceConnect_CommandsFailedMessage" xml:space="preserve">
+	  <value>The service returned an error while requesting its configured commands. Check the logs for more info.
+
+You can open the logs and manage the service from the configuration panel.</value>
+  </data>
+  <data name="ServiceConnect_SensorsFailed" xml:space="preserve">
+    <value>Fetching configured sensors failed!</value>
+  </data>
+  <data name="ServiceConnect_SensorsFailedMessage" xml:space="preserve">
+	  <value>The service returned an error while requesting its configured sensors. Check the logs for more info.
+
+You can open the logs and manage the service from the configuration panel.</value>
+  </data>
+  <data name="ServiceGeneral_TbAuthId_MessageBox1" xml:space="preserve">
+	  <value>Storing an empty auth ID will allow all HASS.Agent to access the service.
+
+Are you sure you want this?</value>
+  </data>
+  <data name="ServiceGeneral_SavingFailedMessageBox" xml:space="preserve">
+    <value>An error occurred whilst saving, check the logs for more information.</value>
+  </data>
+  <data name="ServiceGeneral_BtnStoreDeviceName_MessageBox1" xml:space="preserve">
+    <value>Please provide a device name!</value>
+  </data>
+  <data name="ServiceGeneral_BtnStoreCustomExecutor_MessageBox1" xml:space="preserve">
+    <value>Please select an executor first. (Tip: Double click to Browse)</value>
+  </data>
+  <data name="ServiceGeneral_BtnStoreCustomExecutor_MessageBox2" xml:space="preserve">
+    <value>The selected executor could not be found, please ensure the path provided is correct and try again.</value>
+  </data>
+  <data name="ServiceGeneral_LblAuthIdInfo_MessageBox1" xml:space="preserve">
+	  <value>Set an auth ID if you don't want every instance of HASS.Agent on this PC to connect with the satellite service.
+
+Only the instances that have the correct ID, can connect.
+
+Leave empty to allow all to connect.</value>
+  </data>
+  <data name="ServiceGeneral_LblDeviceNameInfo_MessageBox1" xml:space="preserve">
+	  <value>This is the name with which the satellite service registers itself on Home Assistant.
+
+By default, it's your PC's name plus '-satellite'.</value>
+  </data>
+  <data name="ServiceGeneral_LblDisconGraceInfo_MessageBox1" xml:space="preserve">
+    <value>The amount of time the satellite service will wait before reporting a lost connection to the MQTT broker.</value>
+  </data>
+  <data name="ServiceMqtt_StatusError" xml:space="preserve">
+    <value>Error fetching status, please check logs for information.</value>
+  </data>
+  <data name="ServiceMqtt_BtnStore_MessageBox1" xml:space="preserve">
+    <value>An error occurred whilst saving the configuration, please check the logs for more information.</value>
+  </data>
+  <data name="ServiceMqtt_BtnStore_Storing" xml:space="preserve">
+    <value>Storing and registering, please wait..</value>
+  </data>
+  <data name="ServiceSensors_BtnStore_MessageBox1" xml:space="preserve">
+    <value>An error occurred whilst saving the sensors, please check the logs for more information.</value>
+  </data>
+  <data name="ServiceSensors_BtnStore_Storing" xml:space="preserve">
+    <value>Storing and registering, please wait..</value>
+  </data>
+  <data name="PortReservation_ProcessPostUpdate_MessageBox1" xml:space="preserve">
+    <value>Not all steps completed succesfully. Please consult the logs for more information.</value>
+  </data>
+  <data name="PostUpdate_ProcessPostUpdate_MessageBox1" xml:space="preserve">
+    <value>Not all steps completed succesfully. Please consult the logs for more information.</value>
+  </data>
+  <data name="Restart_ProcessRestart_MessageBox1" xml:space="preserve">
+	  <value>HASS.Agent is still active after {0} seconds. Please close all instances and restart manually.
+
+Check the logs for more info, and optionally inform the developers.</value>
+  </data>
+  <data name="ServiceReinstall_ProcessReinstall_MessageBox1" xml:space="preserve">
+    <value>Not all steps completed successfully, please check the logs for more information.</value>
+  </data>
+  <data name="ServiceSetState_Enabled" xml:space="preserve">
+    <value>Enable Satellite Service</value>
+  </data>
+  <data name="ServiceSetState_Disabled" xml:space="preserve">
+    <value>Disable Satellite Service</value>
+  </data>
+  <data name="ServiceSetState_Started" xml:space="preserve">
+    <value>Start Satellite Service</value>
+  </data>
+  <data name="ServiceSetState_Stopped" xml:space="preserve">
+    <value>Stop Satellite Service</value>
+  </data>
+  <data name="ServiceSetState_ProcessState_MessageBox1" xml:space="preserve">
+	  <value>Something went wrong while processing the desired service state.
+
+Please consult the logs for more information.</value>
+  </data>
+  <data name="CommandMqttTopic_BtnCopyClipboard_Copied" xml:space="preserve">
+    <value>Topic copied to clipboard!</value>
+  </data>
+  <data name="CommandsConfig_BtnStore_Storing" xml:space="preserve">
+    <value>Storing and registering, please wait..</value>
+  </data>
+  <data name="CommandsConfig_BtnStore_MessageBox1" xml:space="preserve">
+    <value>An error occurred whilst saving commands, please check the logs for more information.</value>
+  </data>
+  <data name="CommandsMod_Title_NewCommand" xml:space="preserve">
+    <value>New Command</value>
+  </data>
+  <data name="CommandsMod_Title_ModCommand" xml:space="preserve">
+    <value>Mod Command</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox1" xml:space="preserve">
+    <value>Please select a command type!</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox2" xml:space="preserve">
+    <value>Please select a valid command type!</value>
+  </data>
+  <data name="CommandsMod_MessageBox_EntityType" xml:space="preserve">
+    <value>Select a valid entity type first.</value>
+  </data>
+  <data name="CommandsMod_MessageBox_Name" xml:space="preserve">
+    <value>Please provide a name!</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox3" xml:space="preserve">
+    <value>A command with that name already exists, are you sure you want to continue?</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox4" xml:space="preserve">
+	  <value>If a command is not provided, you may only use this entity with an 'action' value via Home Assistant, running it as-is will have no action.
+
+Are you sure you want to proceed?</value>
+  </data>
+  <data name="CommandsMod_MessageBox_Action" xml:space="preserve">
+	  <value>If you don't enter a command or script, you can only use this entity with an 'action' value through Home Assistant. Running it as-is won't do anything.
+
+Are you sure you want this?</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox5" xml:space="preserve">
+    <value>Please enter a key code!</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox6" xml:space="preserve">
+    <value>Checking keys failed: {0}</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox7" xml:space="preserve">
+	  <value>If a URL is not provided, you may only use this entity with an 'action' value via Home Assistant, running it as-is will have no action.
+
+Are you sure you want to proceed?</value>
+  </data>
+  <data name="CommandsMod_LblSetting_Command" xml:space="preserve">
+    <value>Command</value>
+  </data>
+  <data name="CommandsMod_LblSetting_CommandScript" xml:space="preserve">
+    <value>Command or Script</value>
+  </data>
+  <data name="CommandsMod_LblSetting_KeyCode" xml:space="preserve">
+    <value>Keycode</value>
+  </data>
+  <data name="CommandsMod_LblSetting_KeyCodes" xml:space="preserve">
+    <value>Keycodes</value>
+  </data>
+  <data name="CommandsMod_CbCommandSpecific_Incognito" xml:space="preserve">
+    <value>Launch in Incognito Mode</value>
+  </data>
+  <data name="CommandsMod_LblInfo_Browser" xml:space="preserve">
+	  <value>Browser: Default
+
+Please configure a custom browser to enable incognito mode.</value>
+  </data>
+  <data name="CommandsMod_LblSetting_Url" xml:space="preserve">
+    <value>URL</value>
+  </data>
+  <data name="CommandsMod_LblInfo_BrowserSpecific" xml:space="preserve">
+    <value>Browser: {0}</value>
+  </data>
+  <data name="CommandsMod_LblInfo_Executor" xml:space="preserve">
+	  <value>Executor: None
+
+Please configure an executor or your command will not run.</value>
+  </data>
+  <data name="CommandsMod_LblInfo_ExecutorSpecific" xml:space="preserve">
+    <value>Executor: {0}</value>
+  </data>
+  <data name="CommandsMod_LblIntegrityInfo_InfoMsg1" xml:space="preserve">
+    <value>Low integrity means your command will be executed with restricted privileges.</value>
+  </data>
+  <data name="CommandsMod_LblIntegrityInfo_InfoMsg2" xml:space="preserve">
+    <value>This means it will only be able to save and modify files in certain locations,</value>
+  </data>
+  <data name="CommandsMod_LblIntegrityInfo_InfoMsg3" xml:space="preserve">
+    <value>such as the '%USERPROFILE%\AppData\LocalLow' folder or</value>
+  </data>
+  <data name="CommandsMod_LblIntegrityInfo_InfoMsg4" xml:space="preserve">
+    <value>the 'HKEY_CURRENT_USER\Software\AppDataLow' registry key.</value>
+  </data>
+  <data name="CommandsMod_LblIntegrityInfo_InfoMsg5" xml:space="preserve">
+    <value>You should test your command to make sure it's not influenced by this!</value>
+  </data>
+  <data name="CommandsMod_SpecificClient" xml:space="preserve">
+    <value>{0} only!</value>
+  </data>
+  <data name="CommandsMod_LblMqttTopic_MessageBox1" xml:space="preserve">
+    <value>The MQTT manager hasn't been configured properly, or hasn't yet completed its startup.</value>
+  </data>
+  <data name="QuickActions_CheckHassManager_MessageBox1" xml:space="preserve">
+    <value>Unable to fetch your entities because of missing config, please enter the required values in the config screen.</value>
+  </data>
+  <data name="QuickActions_MessageBox_EntityFailed" xml:space="preserve">
+    <value>There was an error trying to fetch your entities!</value>
+  </data>
+  <data name="QuickActionsMod_Title_New" xml:space="preserve">
+    <value>New Quick Action</value>
+  </data>
+  <data name="QuickActionsMod_Title_Mod" xml:space="preserve">
+    <value>Mod Quick Action</value>
+  </data>
+  <data name="QuickActionsMod_CheckHassManager_MessageBox1" xml:space="preserve">
+    <value>Unable to fetch your entities because of missing config, please enter the required values in the config screen.</value>
+  </data>
+  <data name="QuickActionsMod_MessageBox_Entities" xml:space="preserve">
+    <value>There was an error trying to fetch your entities.</value>
+  </data>
+  <data name="QuickActionsMod_BtnStore_MessageBox1" xml:space="preserve">
+    <value>Please select an entity!</value>
+  </data>
+  <data name="QuickActionsMod_BtnStore_MessageBox2" xml:space="preserve">
+    <value>Please select an domain!</value>
+  </data>
+  <data name="QuickActionsMod_BtnStore_MessageBox3" xml:space="preserve">
+    <value>Unknown action, please select a valid one.</value>
+  </data>
+  <data name="SensorsConfig_BtnStore_Storing" xml:space="preserve">
+    <value>Storing and registering, please wait..</value>
+  </data>
+  <data name="SensorsConfig_BtnStore_MessageBox1" xml:space="preserve">
+    <value>An error occurred whilst saving the sensors, please check the logs for more information.</value>
+  </data>
+  <data name="SensorsMod_Title_New" xml:space="preserve">
+    <value>New Sensor</value>
+  </data>
+  <data name="SensorsMod_Title_Mod" xml:space="preserve">
+    <value>Mod Sensor</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_WindowName" xml:space="preserve">
+    <value>Window Name</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_Wmi" xml:space="preserve">
+    <value>WMI Query</value>
+  </data>
+  <data name="SensorsMod_LblSetting2_Wmi" xml:space="preserve">
+    <value>WMI Scope (optional)</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_Category" xml:space="preserve">
+    <value>Category</value>
+  </data>
+  <data name="SensorsMod_LblSetting2_Counter" xml:space="preserve">
+    <value>Counter</value>
+  </data>
+  <data name="SensorsMod_LblSetting3_Instance" xml:space="preserve">
+    <value>Instance (optional)</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_Process" xml:space="preserve">
+    <value>Process</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_Service" xml:space="preserve">
+    <value>Service</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox1" xml:space="preserve">
+    <value>Please select a sensor type!</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox2" xml:space="preserve">
+    <value>Please select a valid sensor type!</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox3" xml:space="preserve">
+    <value>Please provide a name!</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox4" xml:space="preserve">
+    <value>A single-value sensor already exists with that name, are you sure you want to proceed?</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox5" xml:space="preserve">
+    <value>A multi-value sensor already exists with that name, are you sure you want to proceed?</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox6" xml:space="preserve">
+    <value>Please provide an interval between 1 and 43200 (12 hours)!</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox7" xml:space="preserve">
+    <value>Please enter a window name!</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox8" xml:space="preserve">
+    <value>Please enter a query!</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox9" xml:space="preserve">
+    <value>Please enter a category and instance!</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox10" xml:space="preserve">
+    <value>Please enter the name of a process!</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox11" xml:space="preserve">
+    <value>Please enter the name of a service!</value>
+  </data>
+  <data name="SensorsMod_SpecificClient" xml:space="preserve">
+    <value>{0} only!</value>
+  </data>
+  <data name="Configuration_ProcessChanges_MessageBox1" xml:space="preserve">
+	  <value>You've changed your device's name.
+
+All your sensors and commands will now be unpublished, and HASS.Agent will restart afterwards to republish them.
+
+Don't worry, they'll keep their current names, so your automations or scripts will keep working.
+
+Note: the name will get 'sanitized', which means everything except letters, digits and whitespace get replaced by an underscore. This is required by HA.</value>
+  </data>
+  <data name="Configuration_ProcessChanges_MessageBox2" xml:space="preserve">
+	  <value>You've changed the local API's port. This new port needs to be reserved.
+
+You'll get an UAC request to do so, please approve.</value>
+  </data>
+  <data name="Configuration_ProcessChanges_MessageBox3" xml:space="preserve">
+	  <value>Something went wrong!
+
+Please manually execute the required command. It has been copied onto your clipboard, you just need to paste it into an elevated command prompt.
+
+Remember to change your firewall rule's port as well.</value>
+  </data>
+  <data name="Configuration_ProcessChanges_MessageBox4" xml:space="preserve">
+	  <value>The port has succesfully been reserved!
+
+HASS.Agent will now restart to activate the new configuration.</value>
+  </data>
+  <data name="Configuration_MessageBox_RestartManually" xml:space="preserve">
+	  <value>Something went wrong while preparing to restart.
+Please restart manually.</value>
+  </data>
+  <data name="Configuration_ProcessChanges_MessageBox5" xml:space="preserve">
+	  <value>Your configuration has been saved. Most changes require HASS.Agent to restart before they take effect.
+
+Do you want to restart now?</value>
+  </data>
+  <data name="Main_Load_MessageBox1" xml:space="preserve">
+	  <value>Something went wrong while loading your settings.
+
+Check appsettings.json in the 'config' subfolder, or just delete it to start fresh.</value>
+  </data>
+  <data name="Main_Load_MessageBox2" xml:space="preserve">
+	  <value>There was an error launching HASS.Agent.
+Please check the logs and make a bug report on GitHub.</value>
+  </data>
+  <data name="Main_BtnSensorsManage_Ready" xml:space="preserve">
+	  <value>&amp;Sensors</value>
+  </data>
+  <data name="Main_BtnCommandsManager_Ready" xml:space="preserve">
+    <value>&amp;Commands</value>
+  </data>
+  <data name="Main_Checking" xml:space="preserve">
+    <value>Checking..</value>
+  </data>
+  <data name="Main_CheckForUpdate_MessageBox1" xml:space="preserve">
+    <value>You're running the latest version: {0}{1}</value>
+  </data>
+  <data name="UpdatePending_NewBetaRelease" xml:space="preserve">
+    <value>There's a new BETA release available:</value>
+  </data>
+  <data name="UpdatePending_Title_Beta" xml:space="preserve">
+    <value>HASS.Agent BETA Update</value>
+  </data>
+  <data name="UpdatePending_LblUpdateQuestion_Download" xml:space="preserve">
+    <value>Do you want to &amp;download and launch the installer?</value>
+  </data>
+  <data name="UpdatePending_LblUpdateQuestion_Navigate" xml:space="preserve">
+    <value>Do you want to &amp;navigate to the release page?</value>
+  </data>
+  <data name="UpdatePending_InstallUpdate" xml:space="preserve">
+    <value>Install Update</value>
+  </data>
+  <data name="UpdatePending_InstallBetaRelease" xml:space="preserve">
+    <value>Install Beta Release</value>
+  </data>
+  <data name="UpdatePending_OpenReleasePage" xml:space="preserve">
+    <value>Open Release Page</value>
+  </data>
+  <data name="UpdatePending_OpenBetaReleasePage" xml:space="preserve">
+    <value>Open Beta Release Page</value>
+  </data>
+  <data name="UpdatePending_LblUpdateQuestion_Processing" xml:space="preserve">
+    <value>Processing request, please wait..</value>
+  </data>
+  <data name="UpdatePending_BtnDownload_Processing" xml:space="preserve">
+    <value>Processing..</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_Start" xml:space="preserve">
+    <value>HASS.Agent Onboarding: Start [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_Startup" xml:space="preserve">
+    <value>HASS.Agent Onboarding: Startup [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_Notifications" xml:space="preserve">
+    <value>HASS.Agent Onboarding: Notifications [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_Integration" xml:space="preserve">
+    <value>HASS.Agent Onboarding: Integration [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_Api" xml:space="preserve">
+    <value>HASS.Agent Onboarding: API [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_Mqtt" xml:space="preserve">
+    <value>HASS.Agent Onboarding: MQTT [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_HotKey" xml:space="preserve">
+    <value>HASS.Agent Onboarding: HotKey [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_Updates" xml:space="preserve">
+    <value>HASS.Agent Onboarding: Updates [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_Completed" xml:space="preserve">
+    <value>HASS.Agent Onboarding: Completed [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_ConfirmBeforeClose_MessageBox1" xml:space="preserve">
+	  <value>Are you sure you want to abort the onboarding process?
+
+Your progress will not be saved, and it will not be shown again on next launch.</value>
+  </data>
+  <data name="UpdateManager_GetLatestVersionInfo_Error" xml:space="preserve">
+    <value>Error fetching info, please check logs for more information.</value>
+  </data>
+  <data name="UpdateManager_DownloadAndExecuteUpdate_MessageBox1" xml:space="preserve">
+	  <value>Unable to prepare downloading the update, check the logs for more info.
+
+The release page will now open instead.</value>
+  </data>
+  <data name="UpdateManager_DownloadAndExecuteUpdate_MessageBox2" xml:space="preserve">
+	  <value>Unable to download the update, check the logs for more info.
+
+The release page will now open instead.</value>
+  </data>
+  <data name="UpdateManager_DownloadAndExecuteUpdate_MessageBox3" xml:space="preserve">
+	  <value>The downloaded file FAILED the certificate check.
+
+This could be a technical error, but also a tampered file!
+
+Please check the logs, and post a ticket with the findings.</value>
+  </data>
+  <data name="UpdateManager_DownloadAndExecuteUpdate_MessageBox4" xml:space="preserve">
+	  <value>Unable to launch the installer (did you approve the UAC prompt?), check the logs for more info.
+
+The release page will now open instead.</value>
+  </data>
+  <data name="HassApiManager_ToolTip_ConnectionSetupFailed" xml:space="preserve">
+    <value>HASS API: Connection setup failed.</value>
+  </data>
+  <data name="HassApiManager_ToolTip_InitialConnectionFailed" xml:space="preserve">
+    <value>HASS API: Initial connection failed.</value>
+  </data>
+  <data name="HassApiManager_ToolTip_ConnectionFailed" xml:space="preserve">
+    <value>HASS API: Connection failed.</value>
+  </data>
+  <data name="HassApiManager_CheckHassConfig_CertNotFound" xml:space="preserve">
+    <value>Client certificate file not found.</value>
+  </data>
+  <data name="HassApiManager_CheckHassConfig_UnableToConnect" xml:space="preserve">
+    <value>Unable to connect, check URI.</value>
+  </data>
+  <data name="HassApiManager_CheckHassConfig_ConfigFailed" xml:space="preserve">
+    <value>Unable to fetch configuration, please check API key.</value>
+  </data>
+  <data name="HassApiManager_ConnectionFailed" xml:space="preserve">
+    <value>Unable to connect, please check URI and configuration.</value>
+  </data>
+  <data name="HassApiManager_ToolTip_QuickActionFailed" xml:space="preserve">
+    <value>quick action: action failed, check the logs for info</value>
+  </data>
+  <data name="HassApiManager_ToolTip_QuickActionFailedOnEntity" xml:space="preserve">
+    <value>quick action: action failed, entity not found</value>
+  </data>
+  <data name="MqttManager_ToolTip_ConnectionError" xml:space="preserve">
+    <value>MQTT: Error while connecting</value>
+  </data>
+  <data name="MqttManager_ToolTip_ConnectionFailed" xml:space="preserve">
+    <value>MQTT: Failed to connect</value>
+  </data>
+  <data name="MqttManager_ToolTip_Disconnected" xml:space="preserve">
+    <value>MQTT: Disconnected</value>
+  </data>
+  <data name="NotifierManager_Initialize_MessageBox1" xml:space="preserve">
+	  <value>Error trying to bind the API to port {0}.
+
+Make sure no other instance of HASS.Agent is running and the port is available and registered.</value>
+  </data>
+  <data name="SensorsManager_ActiveWindowSensorDescription" xml:space="preserve">
+    <value>Provides the title of the current active window.</value>
+  </data>
+  <data name="SensorsManager_AudioSensorsDescription" xml:space="preserve">
+	  <value>Provides information various aspects of your device's audio:
+
+Current peak volume level (can be used as a simple 'is something playing' value).
+
+Default audio device: name, state and volume.
+
+Summary of your audio sessions: application name, muted state, volume and current peak volume.</value>
+  </data>
+  <data name="SensorsManager_BatterySensorsDescription" xml:space="preserve">
+    <value>Provides a sensor with the current charging status, estimated amount of minutes on a full charge, remaining charge as a percentage, remaining charge in minutes and the powerline status.</value>
+  </data>
+  <data name="SensorsManager_CpuLoadSensorDescription" xml:space="preserve">
+    <value>Provides the current load of the first CPU as a percentage.</value>
+  </data>
+  <data name="SensorsManager_CurrentClockSpeedSensorDescription" xml:space="preserve">
+    <value>Provides the current clockspeed of the first CPU.</value>
+  </data>
+  <data name="SensorsManager_CurrentVolumeSensorDescription" xml:space="preserve">
+	  <value>Provides the current volume level as a percentage.
+
+Currently takes the volume of your default device.</value>
+  </data>
+  <data name="SensorsManager_DisplaySensorsDescription" xml:space="preserve">
+    <value>Provides a sensor with the amount of displays, name of the primary display, and per display its name, resolution and bits per pixel.</value>
+  </data>
+  <data name="SensorsManager_DummySensorDescription" xml:space="preserve">
+    <value>Dummy sensor for testing purposes, sends a random integer value between 0 and 100.</value>
+  </data>
+  <data name="SensorsManager_GpuLoadSensorDescription" xml:space="preserve">
+    <value>Provides the current load of the first GPU as a percentage.</value>
+  </data>
+  <data name="SensorsManager_GpuTemperatureSensorDescription" xml:space="preserve">
+    <value>NOTE: This is a non-functioning sensor.
+
+Due to the security concerns regarding Libre Hardware Monitor (library allowing HASS.Agent to access GPU temperature data) this sensor is left for backward compatibility reasons and will always return 0.
+Please see documentation for alternative options.</value>
+  </data>
+  <data name="SensorsManager_LastActiveSensorDescription" xml:space="preserve">
+    <value>Provides a datetime value containing the last moment the user provided any input.</value>
+  </data>
+  <data name="SensorsManager_LastBootSensorDescription" xml:space="preserve">
+	  <value>Provides a datetime value containing the last moment the system (re)booted.
+
+Important: Windows' FastBoot option can throw this value off, because that's a form of hibernation. You can disable it through Power Options -&gt; 'Choose what the power buttons do' -&gt; uncheck 'Turn on fast start-up'. It doesn't make much difference for modern machines with SSDs, but disabling makes sure you get a clean state after rebooting.</value>
+  </data>
+  <data name="SensorsManager_LastSystemStateChangeSensorDescription" xml:space="preserve">
+	  <value>Provides the last system state change:
+
+ApplicationStarted, Logoff, SystemShutdown, Resume, Suspend, ConsoleConnect, ConsoleDisconnect, RemoteConnect, RemoteDisconnect, SessionLock, SessionLogoff, SessionLogon, SessionRemoteControl and SessionUnlock.</value>
+  </data>
+  <data name="SensorsManager_LoggedUserSensorDescription" xml:space="preserve">
+	  <value>Returns the name of the currently logged user.
+
+This will only show active users, and falls back to 'Empty' if there are none. If there are multiple, the first will be used.</value>
+  </data>
+  <data name="SensorsManager_LoggedUsersSensorDescription" xml:space="preserve">
+	  <value>Returns a json-formatted list of currently logged users.
+
+This will also contain users that aren't active. If you only want the current active user, use the LoggedUser sensor instead.</value>
+  </data>
+  <data name="SensorsManager_MemoryUsageSensorDescription" xml:space="preserve">
+    <value>Provides the amount of used memory as a percentage.</value>
+  </data>
+  <data name="SensorsManager_MicrophoneActiveSensorDescription" xml:space="preserve">
+	  <value>Provides a bool value based on whether the microphone is currently being used.
+
+Note: if used in the satellite service, it won't detect userspace applications.</value>
+  </data>
+  <data name="SensorsManager_NamedWindowSensorDescription" xml:space="preserve">
+    <value>Provides an ON/OFF value based on whether the window is currently open (doesn't have to be active).</value>
+  </data>
+  <data name="SensorsManager_NetworkSensorsDescription" xml:space="preserve">
+	  <value>Provides card info, configuration, transfer- &amp; package statistics and addresses (ip, mac, dhcp, dns) of the selected network card(s).
+
+This is a multi-value sensor.</value>
+  </data>
+  <data name="SensorsManager_PerformanceCounterSensorDescription" xml:space="preserve">
+	  <value>Provides the values of a performance counter.
+
+For example, the built-in CPU load sensor uses these values:
+
+Category: Processor
+Counter: % Processor Time
+Instance: _Total
+
+You can explore the counters through Windows' 'perfmon.exe' tool.</value>
+  </data>
+  <data name="SensorsManager_ProcessActiveSensorDescription" xml:space="preserve">
+	  <value>Provides the number of active instances of the process.
+
+Note: don't add the extension (eg. notepad.exe becomes notepad).</value>
+  </data>
+  <data name="SensorsManager_ServiceStateSensorDescription" xml:space="preserve">
+	  <value>Returns the state of the provided service: NotFound, Stopped, StartPending, StopPending, Running, ContinuePending, PausePending or Paused.
+
+Make sure to provide the 'Service name', not the 'Display name'.</value>
+  </data>
+  <data name="SensorsManager_SessionStateSensorDescription" xml:space="preserve">
+	  <value>Provides the current session state:
+
+Locked, Unlocked or Unknown.
+
+Use a LastSystemStateChangeSensor to monitor session state changes.</value>
+  </data>
+  <data name="SensorsManager_StorageSensorsDescription" xml:space="preserve">
+    <value>Provides the labels, total size (MB), available space (MB), used space (MB) and file system of all present non-removable disks.</value>
+  </data>
+  <data name="SensorsManager_UserNotificationStateSensorDescription" xml:space="preserve">
+	  <value>Provides the current user state:
+
+NotPresent, Busy, RunningDirect3dFullScreen, PresentationMode, AcceptsNotifications, QuietTime or RunningWindowsStoreApp.
+
+Can for instance be used to determine whether to send notifications or TTS messages.</value>
+  </data>
+  <data name="SensorsManager_WebcamActiveSensorDescription" xml:space="preserve">
+	  <value>Provides a bool value based on whether the webcam is currently being used.
+
+Note: if used in the satellite service, it won't detect userspace applications.</value>
+  </data>
+  <data name="SensorsManager_WindowsUpdatesSensorsDescription" xml:space="preserve">
+	  <value>Provides a sensor with the amount of pending driver updates, a sensor with the amount of pending software updates, a sensor containing all pending driver updates information (title, kb article id's, hidden, type and categories) and a sensor containing the same for pending software updates.
+
+This is a costly request, so the recommended interval is 15 minutes (900 seconds). But it's capped at 10 minutes, if you provide a lower value, you'll get the last known list.</value>
+  </data>
+  <data name="SensorsManager_WmiQuerySensorDescription" xml:space="preserve">
+    <value>Provides the result of the WMI query.</value>
+  </data>
+  <data name="SettingsManager_LoadAppSettings_MessageBox1" xml:space="preserve">
+	  <value>Error loading settings:
+
+{0}</value>
+  </data>
+  <data name="SettingsManager_StoreInitialSettings_MessageBox1" xml:space="preserve">
+	  <value>Error storing initial settings:
+
+{0}</value>
+  </data>
+  <data name="SettingsManager_StoreAppSettings_MessageBox1" xml:space="preserve">
+	  <value>Error storing settings:
+
+{0}</value>
+  </data>
+  <data name="StoredCommands_Load_MessageBox1" xml:space="preserve">
+	  <value>Error loading commands:
+
+{0}</value>
+  </data>
+  <data name="StoredCommands_Store_MessageBox1" xml:space="preserve">
+	  <value>Error storing commands:
+
+{0}</value>
+  </data>
+  <data name="StoredQuickActions_Load_MessageBox1" xml:space="preserve">
+	  <value>Error loading quick actions:
+
+{0}</value>
+  </data>
+  <data name="StoredQuickActions_Store_MessageBox1" xml:space="preserve">
+	  <value>Error storing quick actions:
+
+{0}</value>
+  </data>
+  <data name="StoredSensors_Load_MessageBox1" xml:space="preserve">
+	  <value>Error loading sensors:
+
+{0}</value>
+  </data>
+  <data name="StoredSensors_Store_MessageBox1" xml:space="preserve">
+	  <value>Error storing sensors:
+
+{0}</value>
+  </data>
+  <data name="Main_LblMqtt" xml:space="preserve">
+    <value>MQTT:</value>
+  </data>
+  <data name="Help_LblWiki" xml:space="preserve">
+    <value>Wiki</value>
+  </data>
+  <data name="Configuration_BtnStore_Busy" xml:space="preserve">
+    <value>Busy, please wait..</value>
+  </data>
+  <data name="ConfigGeneral_LblInterfaceLangauge" xml:space="preserve">
+    <value>Interface &amp;Language</value>
+  </data>
+  <data name="About_LblOr" xml:space="preserve">
+    <value>or</value>
+  </data>
+  <data name="OnboardingManager_BtnNext_Finish" xml:space="preserve">
+    <value>Finish</value>
+  </data>
+  <data name="OnboardingWelcome_LblInterfaceLangauge" xml:space="preserve">
+    <value>Interface &amp;Language</value>
+  </data>
+  <data name="ServiceMqtt_SetMqttStatus_ConfigError" xml:space="preserve">
+    <value>Configuration missing</value>
+  </data>
+  <data name="ServiceMqtt_SetMqttStatus_Connected" xml:space="preserve">
+    <value>Connected</value>
+  </data>
+  <data name="ServiceMqtt_SetMqttStatus_Connecting" xml:space="preserve">
+    <value>Connecting..</value>
+  </data>
+  <data name="ServiceMqtt_SetMqttStatus_Disconnected" xml:space="preserve">
+    <value>Disconnected</value>
+  </data>
+  <data name="ServiceMqtt_SetMqttStatus_Error" xml:space="preserve">
+    <value>Error</value>
+  </data>
+  <data name="CommandType_CustomCommand" xml:space="preserve">
+    <value>Custom</value>
+  </data>
+  <data name="CommandType_CustomExecutorCommand" xml:space="preserve">
+    <value>CustomExecutor</value>
+  </data>
+  <data name="CommandType_HibernateCommand" xml:space="preserve">
+    <value>Hibernate</value>
+  </data>
+  <data name="CommandType_KeyCommand" xml:space="preserve">
+    <value>Key</value>
+  </data>
+  <data name="CommandType_LaunchUrlCommand" xml:space="preserve">
+    <value>LaunchUrl</value>
+  </data>
+  <data name="CommandType_LockCommand" xml:space="preserve">
+    <value>Lock</value>
+  </data>
+  <data name="CommandType_LogOffCommand" xml:space="preserve">
+    <value>LogOff</value>
+  </data>
+  <data name="CommandType_MediaMuteCommand" xml:space="preserve">
+    <value>MediaMute</value>
+  </data>
+  <data name="CommandType_MediaNextCommand" xml:space="preserve">
+    <value>MediaNext</value>
+  </data>
+  <data name="CommandType_MediaPlayPauseCommand" xml:space="preserve">
+    <value>MediaPlayPause</value>
+  </data>
+  <data name="CommandType_MediaPreviousCommand" xml:space="preserve">
+    <value>MediaPrevious</value>
+  </data>
+  <data name="CommandType_MediaVolumeDownCommand" xml:space="preserve">
+    <value>MediaVolumeDown</value>
+  </data>
+  <data name="CommandType_MediaVolumeUpCommand" xml:space="preserve">
+    <value>MediaVolumeUp</value>
+  </data>
+  <data name="CommandType_MultipleKeysCommand" xml:space="preserve">
+    <value>MultipleKeys</value>
+  </data>
+  <data name="CommandType_PowershellCommand" xml:space="preserve">
+    <value>Powershell</value>
+  </data>
+  <data name="CommandType_PublishAllSensorsCommand" xml:space="preserve">
+    <value>PublishAllSensors</value>
+  </data>
+  <data name="CommandType_RestartCommand" xml:space="preserve">
+    <value>Restart</value>
+  </data>
+  <data name="CommandType_ShutdownCommand" xml:space="preserve">
+    <value>Shutdown</value>
+  </data>
+  <data name="CommandType_SleepCommand" xml:space="preserve">
+    <value>Sleep</value>
+  </data>
+  <data name="UserNotificationState_AcceptsNotifications" xml:space="preserve">
+    <value>AcceptsNotifications</value>
+  </data>
+  <data name="UserNotificationState_Busy" xml:space="preserve">
+    <value>Busy</value>
+  </data>
+  <data name="UserNotificationState_NotPresent" xml:space="preserve">
+    <value>NotPresent</value>
+  </data>
+  <data name="UserNotificationState_PresentationMode" xml:space="preserve">
+    <value>PresentationMode</value>
+  </data>
+  <data name="UserNotificationState_QuietTime" xml:space="preserve">
+    <value>QuietTime</value>
+  </data>
+  <data name="UserNotificationState_RunningDirect3dFullScreen" xml:space="preserve">
+    <value>RunningDirect3dFullScreen</value>
+  </data>
+  <data name="UserNotificationState_RunningWindowsStoreApp" xml:space="preserve">
+    <value>RunningWindowsStoreApp</value>
+  </data>
+  <data name="SystemStateEvent_ConsoleConnect" xml:space="preserve">
+    <value>ConsoleConnect</value>
+  </data>
+  <data name="SystemStateEvent_ConsoleDisconnect" xml:space="preserve">
+    <value>ConsoleDisconnect</value>
+  </data>
+  <data name="SystemStateEvent_HassAgentSatelliteServiceStarted" xml:space="preserve">
+    <value>HassAgentSatelliteServiceStarted</value>
+  </data>
+  <data name="SystemStateEvent_HassAgentStarted" xml:space="preserve">
+    <value>HassAgentStarted</value>
+  </data>
+  <data name="SystemStateEvent_Logoff" xml:space="preserve">
+    <value>Logoff</value>
+  </data>
+  <data name="SystemStateEvent_RemoteConnect" xml:space="preserve">
+    <value>RemoteConnect</value>
+  </data>
+  <data name="SystemStateEvent_RemoteDisconnect" xml:space="preserve">
+    <value>RemoteDisconnect</value>
+  </data>
+  <data name="SystemStateEvent_Resume" xml:space="preserve">
+    <value>Resume</value>
+  </data>
+  <data name="SystemStateEvent_SessionLock" xml:space="preserve">
+    <value>SessionLock</value>
+  </data>
+  <data name="SystemStateEvent_SessionLogoff" xml:space="preserve">
+    <value>SessionLogoff</value>
+  </data>
+  <data name="SystemStateEvent_SessionLogon" xml:space="preserve">
+    <value>SessionLogon</value>
+  </data>
+  <data name="SystemStateEvent_SessionRemoteControl" xml:space="preserve">
+    <value>SessionRemoteControl</value>
+  </data>
+  <data name="SystemStateEvent_SessionUnlock" xml:space="preserve">
+    <value>SessionUnlock</value>
+  </data>
+  <data name="SystemStateEvent_Suspend" xml:space="preserve">
+    <value>Suspend</value>
+  </data>
+  <data name="SystemStateEvent_SystemShutdown" xml:space="preserve">
+    <value>SystemShutdown</value>
+  </data>
+  <data name="SensorType_ActiveWindowSensor" xml:space="preserve">
+    <value>ActiveWindow</value>
+  </data>
+  <data name="SensorType_AudioSensors" xml:space="preserve">
+    <value>Audio</value>
+  </data>
+  <data name="SensorType_BatterySensors" xml:space="preserve">
+    <value>Battery</value>
+  </data>
+  <data name="SensorType_CpuLoadSensor" xml:space="preserve">
+    <value>CpuLoad</value>
+  </data>
+  <data name="SensorType_CurrentClockSpeedSensor" xml:space="preserve">
+    <value>CurrentClockSpeed</value>
+  </data>
+  <data name="SensorType_CurrentVolumeSensor" xml:space="preserve">
+    <value>CurrentVolume</value>
+  </data>
+  <data name="SensorType_DisplaySensors" xml:space="preserve">
+    <value>Display</value>
+  </data>
+  <data name="SensorType_DummySensor" xml:space="preserve">
+    <value>Dummy</value>
+  </data>
+  <data name="SensorType_GpuLoadSensor" xml:space="preserve">
+    <value>GpuLoad</value>
+  </data>
+  <data name="SensorType_GpuTemperatureSensor" xml:space="preserve">
+    <value>GpuTemperature</value>
+  </data>
+  <data name="SensorType_LastActiveSensor" xml:space="preserve">
+    <value>LastActive</value>
+  </data>
+  <data name="SensorType_LastBootSensor" xml:space="preserve">
+    <value>LastBoot</value>
+  </data>
+  <data name="SensorType_LastSystemStateChangeSensor" xml:space="preserve">
+    <value>LastSystemStateChange</value>
+  </data>
+  <data name="SensorType_LoggedUserSensor" xml:space="preserve">
+    <value>LoggedUser</value>
+  </data>
+  <data name="SensorType_LoggedUsersSensor" xml:space="preserve">
+    <value>LoggedUsers</value>
+  </data>
+  <data name="SensorType_MemoryUsageSensor" xml:space="preserve">
+    <value>MemoryUsage</value>
+  </data>
+  <data name="SensorType_MicrophoneActiveSensor" xml:space="preserve">
+    <value>MicrophoneActive</value>
+  </data>
+  <data name="SensorType_NamedWindowSensor" xml:space="preserve">
+    <value>NamedWindow</value>
+  </data>
+  <data name="SensorType_NetworkSensors" xml:space="preserve">
+    <value>Network</value>
+  </data>
+  <data name="SensorType_PerformanceCounterSensor" xml:space="preserve">
+    <value>PerformanceCounter</value>
+  </data>
+  <data name="SensorType_ProcessActiveSensor" xml:space="preserve">
+    <value>ProcessActive</value>
+  </data>
+  <data name="SensorType_ServiceStateSensor" xml:space="preserve">
+    <value>ServiceState</value>
+  </data>
+  <data name="SensorType_SessionStateSensor" xml:space="preserve">
+    <value>SessionState</value>
+  </data>
+  <data name="SensorType_StorageSensors" xml:space="preserve">
+    <value>Storage</value>
+  </data>
+  <data name="SensorType_UserNotificationStateSensor" xml:space="preserve">
+    <value>UserNotification</value>
+  </data>
+  <data name="SensorType_WebcamActiveSensor" xml:space="preserve">
+    <value>WebcamActive</value>
+  </data>
+  <data name="SensorType_WindowsUpdatesSensors" xml:space="preserve">
+    <value>WindowsUpdates</value>
+  </data>
+  <data name="SensorType_WmiQuerySensor" xml:space="preserve">
+    <value>WmiQuery</value>
+  </data>
+  <data name="HassDomain_Automation" xml:space="preserve">
+    <value>Automation</value>
+  </data>
+  <data name="HassDomain_Climate" xml:space="preserve">
+    <value>Climate</value>
+  </data>
+  <data name="HassDomain_Cover" xml:space="preserve">
+    <value>Cover</value>
+  </data>
+  <data name="HassDomain_InputBoolean" xml:space="preserve">
+    <value>InputBoolean</value>
+  </data>
+  <data name="HassDomain_Light" xml:space="preserve">
+    <value>Light</value>
+  </data>
+  <data name="HassDomain_MediaPlayer" xml:space="preserve">
+    <value>MediaPlayer</value>
+  </data>
+  <data name="HassDomain_Scene" xml:space="preserve">
+    <value>Scene</value>
+  </data>
+  <data name="HassDomain_Script" xml:space="preserve">
+    <value>Script</value>
+  </data>
+  <data name="HassDomain_Switch" xml:space="preserve">
+    <value>Switch</value>
+  </data>
+  <data name="HassAction_Close" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="HassAction_Off" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="HassAction_On" xml:space="preserve">
+    <value>On</value>
+  </data>
+  <data name="HassAction_Open" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="HassAction_Pause" xml:space="preserve">
+    <value>Pause</value>
+  </data>
+  <data name="HassAction_Play" xml:space="preserve">
+    <value>Play</value>
+  </data>
+  <data name="HassAction_Stop" xml:space="preserve">
+    <value>Stop</value>
+  </data>
+  <data name="HassAction_Toggle" xml:space="preserve">
+    <value>Toggle</value>
+  </data>
+  <data name="CommandEntityType_Button" xml:space="preserve">
+    <value>Button</value>
+  </data>
+  <data name="CommandEntityType_Light" xml:space="preserve">
+    <value>Light</value>
+  </data>
+  <data name="CommandEntityType_Lock" xml:space="preserve">
+    <value>Lock</value>
+  </data>
+  <data name="CommandEntityType_Siren" xml:space="preserve">
+    <value>Siren</value>
+  </data>
+  <data name="CommandEntityType_Switch" xml:space="preserve">
+    <value>Switch</value>
+  </data>
+  <data name="ComponentStatus_Connecting" xml:space="preserve">
+    <value>Connecting..</value>
+  </data>
+  <data name="ComponentStatus_Disabled" xml:space="preserve">
+    <value>Disabled</value>
+  </data>
+  <data name="ComponentStatus_Failed" xml:space="preserve">
+    <value>Failed</value>
+  </data>
+  <data name="ComponentStatus_Loading" xml:space="preserve">
+    <value>Loading..</value>
+  </data>
+  <data name="ComponentStatus_Ok" xml:space="preserve">
+	  <value>Running</value>
+  </data>
+  <data name="ComponentStatus_Stopped" xml:space="preserve">
+    <value>Stopped</value>
+  </data>
+  <data name="LockState_Locked" xml:space="preserve">
+    <value>Locked</value>
+  </data>
+  <data name="LockState_Unknown" xml:space="preserve">
+    <value>Unknown</value>
+  </data>
+  <data name="LockState_Unlocked" xml:space="preserve">
+    <value>Unlocked</value>
+  </data>
+  <data name="SensorType_GeoLocationSensor" xml:space="preserve">
+    <value>GeoLocation</value>
+  </data>
+  <data name="SensorsMod_All" xml:space="preserve">
+    <value>All</value>
+  </data>
+  <data name="SensorsMod_BtnTest" xml:space="preserve">
+    <value>&amp;Test</value>
+  </data>
+  <data name="SensorsMod_BtnTest_PerformanceCounter" xml:space="preserve">
+    <value>Test Performance Counter</value>
+  </data>
+  <data name="SensorsMod_BtnTest_Wmi" xml:space="preserve">
+    <value>Test WMI Query</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_Network" xml:space="preserve">
+    <value>Network Card</value>
+  </data>
+  <data name="SensorsMod_TestPerformanceCounter_MessageBox1" xml:space="preserve">
+    <value>Enter a category and counter first.</value>
+  </data>
+  <data name="SensorsMod_TestPerformanceCounter_MessageBox2" xml:space="preserve">
+	  <value>Test succesfully executed, result value:
+
+{0}</value>
+  </data>
+  <data name="SensorsMod_TestPerformanceCounter_MessageBox3" xml:space="preserve">
+	  <value>The test failed to execute:
+
+{0}
+
+Do you want to open the logs folder?</value>
+  </data>
+  <data name="SensorsMod_TestWmi_MessageBox1" xml:space="preserve">
+    <value>Enter a WMI query first.</value>
+  </data>
+  <data name="SensorsMod_TestWmi_MessageBox2" xml:space="preserve">
+	  <value>Query succesfully executed, result value:
+
+{0}</value>
+  </data>
+  <data name="SensorsMod_TestWmi_MessageBox3" xml:space="preserve">
+	  <value>The query failed to execute:
+
+{0}
+
+Do you want to open the logs folder?</value>
+  </data>
+  <data name="SensorsMod_WmiTestFailed" xml:space="preserve">
+	  <value>It looks like your scope is malformed, it should probably start like this:
+
+\\.\ROOT\
+
+The scope you entered:
+
+{0}
+
+Tip: make sure you haven't switched the scope and query fields around.
+
+Do you still want to use the current values?</value>
+  </data>
+  <data name="SystemStateEvent_ApplicationStarted" xml:space="preserve">
+    <value>ApplicationStarted</value>
+  </data>
+  <data name="ServiceGeneral_LblInfo2" xml:space="preserve">
+    <value>You can use the satellite service to run sensors and commands without having to be logged in. Not all types are available, for instance the 'LaunchUrl' command can only be added as a regular command.</value>
+  </data>
+  <data name="SensorsConfig_ClmValue" xml:space="preserve">
+    <value>Last Known Value</value>
+  </data>
+  <data name="LocalApiManager_Initialize_MessageBox1" xml:space="preserve">
+	  <value>Error trying to bind the API to port {0}.
+
+Make sure no other instance of HASS.Agent is running and the port is available and registered.</value>
+  </data>
+  <data name="CommandType_SendWindowToFrontCommand" xml:space="preserve">
+    <value>SendWindowToFront</value>
+  </data>
+  <data name="CommandType_WebViewCommand" xml:space="preserve">
+    <value>WebView</value>
+  </data>
+  <data name="CommandsManager_WebViewCommandDescription" xml:space="preserve">
+	  <value>Shows a window with the provided URL.
+
+This differs from the 'LaunchUrl' command in that it doesn't load a full-fledged browser, just the provided URL in its own window.
+
+You can use this to for instance quickly show Home Assistant's dashboard.
+
+By default, it stores cookies indefinitely so you only have to log in once.</value>
+  </data>
+  <data name="HassDomain_HASSAgentCommands" xml:space="preserve">
+    <value>HASS.Agent Commands</value>
+  </data>
+  <data name="CommandsManager_CommandsManager_SendWindowToFrontCommandDescription" xml:space="preserve">
+	  <value>Looks for the specified process, and tries to send its main window to the front.
+
+If the application is minimized, it'll get restored.
+
+Example: if you want to send VLC to the foreground, use 'vlc'.</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox8" xml:space="preserve">
+	  <value>If you do not configure the command, you may only use this entity with an 'action' value via Home Assistant and it will appear using the default settings, running it as-is will have no action.
+
+Are you sure you want to do this?</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearAudioCache" xml:space="preserve">
+    <value>Clear Audio Cache</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearAudioCache_InfoText1" xml:space="preserve">
+    <value>Cleaning..</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearAudioCache_MessageBox1" xml:space="preserve">
+    <value>The audio cache has been cleared!</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearWebViewCache" xml:space="preserve">
+    <value>Clear WebView Cache</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearWebViewCache_InfoText1" xml:space="preserve">
+    <value>Cleaning..</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearWebViewCache_MessageBox1" xml:space="preserve">
+    <value>The WebView cache has been cleared!</value>
+  </data>
+  <data name="Main_CheckDpiScalingFactor_MessageBox1" xml:space="preserve">
+	  <value>It looks like you're using an alternative scaling. This may result in some parts of HASS.Agent not looking as intended.
+
+Please report any unusable aspects on GitHub. Thanks!
+
+Note: this message only shows once.</value>
+  </data>
+  <data name="WebViewCommandConfig_SetStoredVariables_MessageBox1" xml:space="preserve">
+    <value>Unable to load the stored command settings, resetting to default.</value>
+  </data>
+  <data name="CommandsMod_BtnConfigureCommand" xml:space="preserve">
+    <value>Configure Command &amp;Parameters</value>
+  </data>
+  <data name="ConfigLocalApi_BtnExecutePortReservation" xml:space="preserve">
+    <value>Execute Port &amp;Reservation</value>
+  </data>
+  <data name="ConfigLocalApi_CbLocalApiActive" xml:space="preserve">
+    <value>&amp;Enable Local API</value>
+  </data>
+  <data name="ConfigLocalApi_LblInfo1" xml:space="preserve">
+	  <value>HASS.Agent has its own local API, so Home Assistant can send requests (for instance to send a notification). You can configure it globally here, and afterwards you can configure the dependent sections (currently notifications and mediaplayer).
+
+Note: this is not required for the new integration to function. Only enable and use it if you don't use MQTT.</value>
+  </data>
+  <data name="ConfigLocalApi_LblInfo2" xml:space="preserve">
+    <value>To be able to listen to the requests, HASS.Agent needs to have its port reserved and opened in your firewall. You can use this button to have it done for you.</value>
+  </data>
+  <data name="ConfigLocalApi_LblPort" xml:space="preserve">
+    <value>&amp;Port</value>
+  </data>
+  <data name="ConfigLocalStorage_LblAudioCacheLocation" xml:space="preserve">
+    <value>Audio Cache Location</value>
+  </data>
+  <data name="ConfigLocalStorage_LblImageCacheDays" xml:space="preserve">
+    <value>days</value>
+  </data>
+  <data name="ConfigLocalStorage_LblImageCacheLocation" xml:space="preserve">
+    <value>Image Cache Location</value>
+  </data>
+  <data name="ConfigLocalStorage_LblKeepAudio" xml:space="preserve">
+    <value>Keep audio for</value>
+  </data>
+  <data name="ConfigLocalStorage_LblKeepImages" xml:space="preserve">
+    <value>Keep images for</value>
+  </data>
+  <data name="ConfigLocalStorage_LblKeepWebView" xml:space="preserve">
+    <value>Clear cache every</value>
+  </data>
+  <data name="ConfigLocalStorage_LblWebViewCacheLocation" xml:space="preserve">
+    <value>WebView Cache Location</value>
+  </data>
+  <data name="ConfigMediaPlayer_BtnMediaPlayerReadme" xml:space="preserve">
+    <value>Media Player &amp;Documentation</value>
+  </data>
+  <data name="ConfigMediaPlayer_CbEnableMediaPlayer" xml:space="preserve">
+    <value>&amp;Enable Media Player Functionality</value>
+  </data>
+  <data name="ConfigMediaPlayer_LblInfo1" xml:space="preserve">
+    <value>HASS.Agent can act as a media player for Home Assistant, so you'll be able to see and control any media that's playing, and send text-to-speech. If you have MQTT enabled, your device will automatically get added. Otherwise, manually configure the integration to use the local API.</value>
+  </data>
+  <data name="ConfigMediaPlayer_LblInfo2" xml:space="preserve">
+	  <value>If something is not working, make sure you try the following steps:
+
+- Install the HASS.Agent integration
+- Restart Home Assistant
+- Make sure HASS.Agent is active with MQTT enabled!
+- Your device should get detected and added as an entity automatically
+- Optionally: manually add it using the local API</value>
+  </data>
+  <data name="ConfigMediaPlayer_LblLocalApiDisabled" xml:space="preserve">
+    <value>The local API is disabled however the media player requires it in order to function.</value>
+  </data>
+  <data name="ConfigMqtt_CbMqttTls" xml:space="preserve">
+    <value>&amp;TLS</value>
+  </data>
+  <data name="ConfigNotifications_LblLocalApiDisabled" xml:space="preserve">
+    <value>The local API is disabled however the media player requires it in order to function.</value>
+  </data>
+  <data name="ConfigTrayIcon_BtnShowWebViewPreview" xml:space="preserve">
+    <value>Show &amp;Preview</value>
+  </data>
+  <data name="ConfigTrayIcon_CbDefaultMenu" xml:space="preserve">
+    <value>Show &amp;Default Menu</value>
+  </data>
+  <data name="ConfigTrayIcon_CbShowWebView" xml:space="preserve">
+    <value>Show &amp;WebView</value>
+  </data>
+  <data name="ConfigTrayIcon_CbWebViewKeepLoaded" xml:space="preserve">
+    <value>&amp;Keep page loaded in the background</value>
+  </data>
+  <data name="ConfigTrayIcon_LblInfo1" xml:space="preserve">
+    <value>Control the behaviour of the tray icon when it is right-clicked.</value>
+  </data>
+  <data name="ConfigTrayIcon_LblInfo2" xml:space="preserve">
+    <value>(This uses extra resources, but reduces loading time.)</value>
+  </data>
+  <data name="ConfigTrayIcon_LblWebViewSize" xml:space="preserve">
+    <value>Size (px)</value>
+  </data>
+  <data name="ConfigTrayIcon_LblWebViewUrl" xml:space="preserve">
+    <value>&amp;WebView URL (For instance, your Home Assistant Dashboard URL)</value>
+  </data>
+  <data name="Configuration_TablLocalApi" xml:space="preserve">
+    <value>Local API</value>
+  </data>
+  <data name="Configuration_TabMediaPlayer" xml:space="preserve">
+    <value>Media Player</value>
+  </data>
+  <data name="Configuration_TabTrayIcon" xml:space="preserve">
+    <value>Tray Icon</value>
+  </data>
+  <data name="HelperFunctions_InputLanguageCheckDiffers_ErrorMsg1" xml:space="preserve">
+    <value>Your input language '{0}' is known to collide with the default CTRL-ALT-Q hotkey. Please set your own.</value>
+  </data>
+  <data name="HelperFunctions_InputLanguageCheckDiffers_ErrorMsg2" xml:space="preserve">
+    <value>Your input language '{0}' is unknown, and might collide with the default CTRL-ALT-Q hotkey. Please check to be sure. If it does, consider opening a ticket on GitHub so it can be added to the list.</value>
+  </data>
+  <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg1" xml:space="preserve">
+    <value>No keys found</value>
+  </data>
+  <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg2" xml:space="preserve">
+    <value>brackets missing, start and close all keys with [ ]</value>
+  </data>
+  <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg3" xml:space="preserve">
+    <value>Error while parsing keys, please check the logs for more information.</value>
+  </data>
+  <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg4" xml:space="preserve">
+    <value>The number of open brackets ('[') does not correspond to the number of closed brackets. (']')! ({0} to {1})</value>
+  </data>
+  <data name="Help_LblDocumentation" xml:space="preserve">
+    <value>Documentation</value>
+  </data>
+  <data name="Help_LblDocumentationInfo" xml:space="preserve">
+    <value>Documentation and Usage Examples</value>
+  </data>
+  <data name="Main_BtnCheckForUpdate" xml:space="preserve">
+    <value>Check for &amp;Updates</value>
+  </data>
+  <data name="Main_LblLocalApi" xml:space="preserve">
+    <value>Local API:</value>
+  </data>
+  <data name="Main_TsSatelliteService" xml:space="preserve">
+    <value>Manage Satellite Service</value>
+  </data>
+  <data name="OnboardingIntegrations_LblInfo1" xml:space="preserve">
+	  <value>To use notifications, you need to install and configure the HASS.Agent-notifier integration in
+Home Assistant.
+
+This is very easy using HACS, but you can also install manually. Visit the link below for more
+information.</value>
+  </data>
+  <data name="OnboardingIntegrations_LblInfo2" xml:space="preserve">
+	  <value>Make sure you follow these steps:
+
+- Install the HASS.Agent-Notifier and / or HASS.Agent-MediaPlayer integration
+- Restart Home Assistant
+-Configure a notifier and / or media_player entity
+-Restart Home Assistant</value>
+  </data>
+  <data name="OnboardingIntegrations_LblInfo3" xml:space="preserve">
+    <value>The same goes for the media player, this integration allows you to control your device as a media_player entity, see what's playing and send text-to-speech.</value>
+  </data>
+  <data name="OnboardingIntegrations_LblMediaPlayerIntegration" xml:space="preserve">
+    <value>HASS.Agent-MediaPlayer GitHub Page</value>
+  </data>
+  <data name="OnboardingIntegrations_LblNotifierIntegration" xml:space="preserve">
+    <value>HASS.Agent-Integration GitHub Page</value>
+  </data>
+  <data name="OnboardingLocalApi_CbEnableLocalApi" xml:space="preserve">
+    <value>Yes, &amp;enable the local API on port</value>
+  </data>
+  <data name="OnboardingLocalApi_CbEnableMediaPlayer" xml:space="preserve">
+    <value>Enable &amp;Media Player and text-to-speech (TTS)</value>
+  </data>
+  <data name="OnboardingLocalApi_CbEnableNotifications" xml:space="preserve">
+    <value>Enable &amp;Notifications</value>
+  </data>
+  <data name="OnboardingLocalApi_LblInfo1" xml:space="preserve">
+	  <value>HASS.Agent has its own internal API, so Home Assistant can send requests (like notifications or text-to-speech).
+
+Do you want to enable it?</value>
+  </data>
+  <data name="OnboardingLocalApi_LblInfo2" xml:space="preserve">
+    <value>You can choose what modules you want to enable. They require HA integrations, but don't worry, the next page will give you more info on how to set them up.</value>
+  </data>
+  <data name="OnboardingLocalApi_LblTip1" xml:space="preserve">
+    <value>Note: 5115 is the default port, only change it if you changed it in Home Assistant.</value>
+  </data>
+  <data name="OnboardingMqtt_CbMqttTls" xml:space="preserve">
+    <value>&amp;TLS</value>
+  </data>
+  <data name="OnboardingWelcome_Store_MessageBox1" xml:space="preserve">
+	  <value>Your device name contained some characters that are not allowed by HA (only letters, digits and whitespace).
+
+The final name is: {0}
+
+Do you want to use that version?</value>
+  </data>
+  <data name="Onboarding_Title" xml:space="preserve">
+    <value>HASS.Agent Onboarding</value>
+  </data>
+  <data name="ServiceGeneral_LblAuthStored" xml:space="preserve">
+    <value>stored!</value>
+  </data>
+  <data name="ServiceMqtt_CbMqttTls" xml:space="preserve">
+    <value>&amp;TLS</value>
+  </data>
+  <data name="WebViewCommandConfig_BtnSave" xml:space="preserve">
+    <value>&amp;Save</value>
+  </data>
+  <data name="WebViewCommandConfig_CbCenterScreen" xml:space="preserve">
+    <value>&amp;Always show centered in screen</value>
+  </data>
+  <data name="WebViewCommandConfig_CbShowTitleBar" xml:space="preserve">
+    <value>Show the window's &amp;title bar</value>
+  </data>
+  <data name="WebViewCommandConfig_CbTopMost" xml:space="preserve">
+    <value>Set window as 'Always on &amp;Top'</value>
+  </data>
+  <data name="WebViewCommandConfig_LblInfo1" xml:space="preserve">
+    <value>Drag and resize this window to set the size and location of your webview command.</value>
+  </data>
+  <data name="WebViewCommandConfig_LblLocation" xml:space="preserve">
+    <value>Location</value>
+  </data>
+  <data name="WebViewCommandConfig_LblSize" xml:space="preserve">
+    <value>Size</value>
+  </data>
+  <data name="WebViewCommandConfig_LblTip1" xml:space="preserve">
+    <value>Tip: Press ESCAPE to close a WebView.</value>
+  </data>
+  <data name="WebViewCommandConfig_LblUrl" xml:space="preserve">
+    <value>&amp;URL</value>
+  </data>
+  <data name="WebViewCommandConfig_Title" xml:space="preserve">
+    <value>WebView Configuration</value>
+  </data>
+  <data name="WebView_Title" xml:space="preserve">
+    <value>WebView</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox9" xml:space="preserve">
+	  <value>The keycode you have provided is not a valid number!
+
+Please ensure the keycode field is in focus and press the key you want simulated, the keycode should then be generated for you.</value>
+  </data>
+  <data name="ConfigGeneral_CbEnableDeviceNameSanitation" xml:space="preserve">
+    <value>Enable Device Name &amp;Sanitation</value>
+  </data>
+  <data name="ConfigGeneral_CbEnableStateNotifications" xml:space="preserve">
+    <value>Enable State Notifications</value>
+  </data>
+  <data name="ConfigGeneral_LblInfo5" xml:space="preserve">
+    <value>HASS.Agent will sanitize your device name to make sure HA will accept it, you can overrule this rule below if you're sure that your name will be accepted as-is.</value>
+  </data>
+  <data name="ConfigGeneral_LblInfo6" xml:space="preserve">
+    <value>HASS.Agent sends notifications when the state of a module changes, you can adjust whether or not you want to receive these notifications below.</value>
+  </data>
+  <data name="Configuration_ProcessChanges_MessageBox6" xml:space="preserve">
+	  <value>You've changed your device's name.
+
+All your sensors and commands will now be unpublished and published again after the HASS.Agent restarts.
+
+Don't worry! they'll keep their current names so your automations and scripts will continue to work.
+
+Note: You disabled sanitation, so make sure your device name is accepted by Home Assistant.</value>
+  </data>
+  <data name="SensorType_PrintersSensors" xml:space="preserve">
+    <value>Printers</value>
+  </data>
+  <data name="CommandType_MonitorSleepCommand" xml:space="preserve">
+    <value>MonitorSleep</value>
+  </data>
+  <data name="CommandType_MonitorWakeCommand" xml:space="preserve">
+    <value>MonitorWake</value>
+  </data>
+  <data name="MonitorPowerEvent_PowerOn" xml:space="preserve">
+    <value>PowerOn</value>
+  </data>
+  <data name="MonitorPowerEvent_PowerOff" xml:space="preserve">
+    <value>PowerOff</value>
+  </data>
+  <data name="MonitorPowerEvent_Dimmed" xml:space="preserve">
+    <value>Dimmed</value>
+  </data>
+  <data name="MonitorPowerEvent_Unknown" xml:space="preserve">
+    <value>Unknown</value>
+  </data>
+  <data name="SensorType_MonitorPowerStateSensor" xml:space="preserve">
+    <value>MonitorPowerState</value>
+  </data>
+  <data name="SensorType_PowershellSensor" xml:space="preserve">
+    <value>PowershellSensor</value>
+  </data>
+  <data name="CommandType_SetVolumeCommand" xml:space="preserve">
+    <value>SetVolume</value>
+  </data>
+  <data name="WindowState_Maximized" xml:space="preserve">
+    <value>Maximized</value>
+  </data>
+  <data name="WindowState_Minimized" xml:space="preserve">
+    <value>Minimized</value>
+  </data>
+  <data name="WindowState_Normal" xml:space="preserve">
+    <value>Normal</value>
+  </data>
+  <data name="WindowState_Unknown" xml:space="preserve">
+    <value>Unknown</value>
+  </data>
+  <data name="WindowState_Hidden" xml:space="preserve">
+    <value>Hidden</value>
+  </data>
+  <data name="SensorType_WindowStateSensor" xml:space="preserve">
+    <value>WindowState</value>
+  </data>
+  <data name="SensorType_WebcamProcessSensor" xml:space="preserve">
+    <value>WebcamProcess</value>
+  </data>
+  <data name="SensorType_MicrophoneProcessSensor" xml:space="preserve">
+    <value>MicrophoneProcess</value>
+  </data>
+  <data name="CommandsManager_MonitorSleepCommandDescription" xml:space="preserve">
+    <value>Puts all monitors in sleep (low power) mode.</value>
+  </data>
+  <data name="CommandsManager_MonitorWakeCommandDescription" xml:space="preserve">
+    <value>Tries to wake up all monitors by simulating a 'arrow up' keypress.</value>
+  </data>
+  <data name="CommandsManager_SetVolumeCommandDescription" xml:space="preserve">
+    <value>Sets the volume of the current default audiodevice to the specified level.</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox10" xml:space="preserve">
+    <value>Please enter a value between 0-100 as the desired volume level!</value>
+  </data>
+  <data name="CommandsMod_CommandsMod" xml:space="preserve">
+    <value>Command</value>
+  </data>
+  <data name="CommandsMod_MessageBox_Action2" xml:space="preserve">
+	  <value>If you don't enter a volume value, you can only use this entity with an 'action' value through Home Assistant. Running it as-is won't do anything.
+
+Are you sure you want this?</value>
+  </data>
+  <data name="CommandsMod_MessageBox_Sanitize" xml:space="preserve">
+	  <value>The name you provided contains unsupported characters and won't work. The suggested version is:
+
+{0}
+
+Do you want to use this version?</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox5" xml:space="preserve">
+	  <value>The API token you have provided doesn't appear to be valid, please ensure you selected the entire token (Don't use CTRL + A or double-click). A valid API key contains three sections, separated by two dots.
+
+Are you sure you want to use this key anyway?</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox6" xml:space="preserve">
+	  <value>The URI you have provided does not appear to be valid, a valid URI may look like either of the following:
+- http://homeassistant.local:8123
+- http://192.168.0.1:8123
+
+Are you sure you want to use this URI anyway?</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_BtnTestApi_Testing" xml:space="preserve">
+    <value>Testing..</value>
+  </data>
+  <data name="ConfigMediaPlayer_LblConnectivityDisabled" xml:space="preserve">
+    <value>both the local API and MQTT are disabled, but the integration needs at least one for it to work</value>
+  </data>
+  <data name="ConfigMqtt_CbEnableMqtt" xml:space="preserve">
+    <value>Enable MQTT</value>
+  </data>
+  <data name="ConfigMqtt_LblMqttDisabledWarning" xml:space="preserve">
+    <value>If MQTT is not enabled, commands and sensors will not work!</value>
+  </data>
+  <data name="ConfigNotifications_LblConnectivityDisabled" xml:space="preserve">
+    <value>both the local API and MQTT are disabled, but the integration needs at least one for it to work</value>
+  </data>
+  <data name="ConfigService_BtnManageService" xml:space="preserve">
+    <value>&amp;Manage Service</value>
+  </data>
+  <data name="ConfigService_BtnManageService_MessageBox1" xml:space="preserve">
+	  <value>The service is currently stopped and cannot be configured.
+
+Please start the service first in order to configure it.</value>
+  </data>
+  <data name="ConfigService_LblInfo5" xml:space="preserve">
+    <value>If you want to manage the service (add commands and sensor, change settings) you can do so here, or by using the 'satellite service' button on the main window.</value>
+  </data>
+  <data name="ConfigTrayIcon_CbWebViewShowMenuOnLeftClick" xml:space="preserve">
+    <value>Show default menu on mouse left-click</value>
+  </data>
+  <data name="Configuration_CheckValues_MessageBox1" xml:space="preserve">
+	  <value>Your Home Assistant API token doesn't look right. Make sure you selected the entire token (don't use CTRL+A or doubleclick).
+It should contain three sections (seperated by two dots).
+
+Are you sure you want to use it like this?</value>
+  </data>
+  <data name="Configuration_CheckValues_MessageBox2" xml:space="preserve">
+	  <value>Your Home Assistant URI doesn't look right. It should look something like 'http://homeassistant.local:8123' or 'https://192.168.0.1:8123'.
+
+Are you sure you want to use it like this?</value>
+  </data>
+  <data name="Configuration_CheckValues_MessageBox3" xml:space="preserve">
+	  <value>Your MQTT broker URI doesn't look right. It should look something like 'homeassistant.local' or '192.168.0.1'.
+
+Are you sure you want to use it like this?</value>
+  </data>
+  <data name="Donate_BtnClose" xml:space="preserve">
+    <value>&amp;Close</value>
+  </data>
+  <data name="Donate_CbHideDonateButton" xml:space="preserve">
+    <value>I already donated, hide the button on the main window.</value>
+  </data>
+  <data name="Donate_LblInfo" xml:space="preserve">
+	  <value>HASS.Agent is completely free, and will always stay that way without restrictions!
+
+However, developing and maintaining this tool (and everything that surrounds it, like support and the docs) takes up a lot of time. 
+
+Like most developers, I run on caffeïne - so if you can spare it, a cup of coffee is always very much appreciated!</value>
+  </data>
+  <data name="Donate_Title" xml:space="preserve">
+    <value>Donate</value>
+  </data>
+  <data name="Main_NotifyIcon_MouseClick_MessageBox1" xml:space="preserve">
+    <value>No URL has been set! Please configure the webview through Configuration -&gt; Tray Icon.</value>
+  </data>
+  <data name="Main_TsCheckForUpdates" xml:space="preserve">
+    <value>Check for Updates</value>
+  </data>
+  <data name="OnboardingApi_BtnTest_MessageBox5" xml:space="preserve">
+	  <value>The API token you have provided doesn't appear to be valid, please ensure you selected the entire token (Don't use CTRL + A or double-click). A valid API key contains three sections, separated by two dots.
+
+Are you sure you want to use this key anyway?</value>
+  </data>
+  <data name="OnboardingApi_BtnTest_MessageBox6" xml:space="preserve">
+	  <value>The URI you have provided does not appear to be valid, a valid URI may look like either of the following:
+- http://homeassistant.local:8123
+- http://192.168.0.1:8123
+
+Are you sure you want to use this URI anyway?</value>
+  </data>
+  <data name="OnboardingDone_LblInfo6" xml:space="preserve">
+    <value>Currently, we (HASS.Agent Team maintaining the fork) do not accept donations in any form :)
+Please however feel free to donate to the original author of HASS.Agent - Sam! Wherever they currently are, cup of coffee might brighten their day.</value>
+  </data>
+  <data name="OnboardingDone_LblTip2" xml:space="preserve">
+    <value>Tip: Other donation methods are available on the About Window.</value>
+  </data>
+  <data name="OnboardingIntegrations_CbEnableMediaPlayer" xml:space="preserve">
+    <value>Enable &amp;Media Player (including text-to-speech)</value>
+  </data>
+  <data name="OnboardingIntegrations_CbEnableNotifications" xml:space="preserve">
+    <value>Enable &amp;Notifications</value>
+  </data>
+  <data name="OnboardingMqtt_CbEnableMqtt" xml:space="preserve">
+    <value>Enable MQTT</value>
+  </data>
+  <data name="PostUpdate_PostUpdate" xml:space="preserve">
+    <value>HASS.Agent Post Update</value>
+  </data>
+  <data name="SensorsManager_BluetoothDevicesSensorDescription" xml:space="preserve">
+	  <value>Provides a sensor with the amount of bluetooth devices found.
+
+The devices and their connected state are added as attributes.</value>
+  </data>
+  <data name="SensorsManager_BluetoothLeDevicesSensorDescription" xml:space="preserve">
+	  <value>Provides a sensors with the amount of bluetooth LE devices found.
+
+The devices and their connected state are added as attributes.
+
+Only shows devices that were seen since the last report, ie. when the sensor publishes, the list clears.</value>
+  </data>
+  <data name="SensorsManager_GeoLocationSensorDescription" xml:space="preserve">
+	  <value>Returns your current latitude, longitude and altitude as a comma-seperated value.
+
+Make sure Windows' location services are enabled!
+
+Depending on your Windows version, this can be found in the new control panel -&gt; 'privacy and security' -&gt; 'location'.</value>
+  </data>
+  <data name="SensorsManager_MicrophoneProcessSensorDescription" xml:space="preserve">
+	  <value>Provides the name of the process that's currently using the microphone.
+
+Note: if used in the satellite service, it won't detect userspace applications.</value>
+  </data>
+  <data name="SensorsManager_MonitorPowerStateSensorDescription" xml:space="preserve">
+	  <value>Provides the last monitor power state change:
+
+Dimmed, PowerOff, PowerOn and Unkown.</value>
+  </data>
+  <data name="SensorsManager_PowershellSensorDescription" xml:space="preserve">
+	  <value>Returns the result of the provided Powershell command or script.
+
+Converts the outcome to text.</value>
+  </data>
+  <data name="SensorsManager_PrintersSensorsDescription" xml:space="preserve">
+    <value>Provides information about all installed printers and their queues.</value>
+  </data>
+  <data name="SensorsManager_WebcamProcessSensorDescription" xml:space="preserve">
+	  <value>Provides the name of the process that's currently using the webcam.
+
+Note: if used in the satellite service, it won't detect userspace applications.</value>
+  </data>
+  <data name="SensorsManager_WindowStateSensorDescription" xml:space="preserve">
+	  <value>Provides the current state of the process' window:
+
+Hidden, Maximized, Minimized, Normal and Unknown.</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_Powershell" xml:space="preserve">
+    <value>powershell command or script</value>
+  </data>
+  <data name="SensorsMod_MessageBox_Sanitize" xml:space="preserve">
+	  <value>The name you provided contains unsupported characters and won't work. The suggested version is:
+
+{0}
+
+Do you want to use this version?</value>
+  </data>
+  <data name="SensorsMod_SensorsMod_BtnTest_Powershell" xml:space="preserve">
+    <value>Test Command/Script</value>
+  </data>
+  <data name="SensorsMod_TestPowershell_MessageBox1" xml:space="preserve">
+    <value>Please enter a command or script!</value>
+  </data>
+  <data name="SensorsMod_TestPowershell_MessageBox2" xml:space="preserve">
+	  <value>Test succesfully executed, result value:
+
+{0}</value>
+  </data>
+  <data name="SensorsMod_TestPowershell_MessageBox3" xml:space="preserve">
+	  <value>The test failed to execute:
+
+{0}
+
+Do you want to open the logs folder?</value>
+  </data>
+  <data name="SensorType_BluetoothDevicesSensor" xml:space="preserve">
+    <value>BluetoothDevices</value>
+  </data>
+  <data name="SensorType_BluetoothLeDevicesSensor" xml:space="preserve">
+    <value>BluetoothLeDevices</value>
+  </data>
+  <data name="ServiceControllerManager_Error_Fatal" xml:space="preserve">
+    <value>Fatal error, please check logs for information!</value>
+  </data>
+  <data name="ServiceControllerManager_Error_Timeout" xml:space="preserve">
+    <value>Timeout expired</value>
+  </data>
+  <data name="ServiceControllerManager_Error_Unknown" xml:space="preserve">
+    <value>unknown reason</value>
+  </data>
+  <data name="ServiceHelper_ChangeStartMode_Error1" xml:space="preserve">
+    <value>unable to open Service Manager</value>
+  </data>
+  <data name="ServiceHelper_ChangeStartMode_Error2" xml:space="preserve">
+    <value>unable to open service</value>
+  </data>
+  <data name="ServiceHelper_ChangeStartMode_Error3" xml:space="preserve">
+    <value>Error configuring startup mode, please check the logs for more information.</value>
+  </data>
+  <data name="ServiceHelper_ChangeStartMode_Error4" xml:space="preserve">
+    <value>Error setting startup mode, please check the logs for more information.</value>
+  </data>
+  <data name="WebView_InitializeAsync_MessageBox1" xml:space="preserve">
+	  <value>Microsoft's WebView2 runtime isn't found on your machine. Usually this is handled by the installer, but you can install it manually.
+
+Do you want to download the runtime installer?</value>
+  </data>
+  <data name="WebView_InitializeAsync_MessageBox2" xml:space="preserve">
+    <value>Something went wrong while initializing the WebView! Please check your logs and open a GitHub issue for further assistance.</value>
+  </data>
+  <data name="QuickActionsMod_ClmDomain" xml:space="preserve">
+	  <value>domain</value>
+  </data>
+  <data name="CommandType_RadioCommand" xml:space="preserve">
+    <value>RadioCommand</value>
+  </data>
+  <data name="SensorType_InternalDeviceSensor" xml:space="preserve">
+    <value>InternalDeviceSensor</value>
+  </data>
+  <data name="SensorType_ActiveDesktopSensor" xml:space="preserve">
+    <value>ActiveDesktop</value>
+  </data>
+  <data name="CommandType_SetApplicationVolumeCommand" xml:space="preserve">
+    <value>SetApplicationVolume</value>
+  </data>
+  <data name="CommandType_SetAudioOutputCommand" xml:space="preserve">
+    <value>SetAudioOutputCommand</value>
+  </data>
+  <data name="SensorType_ScreenshotSensor" xml:space="preserve">
+    <value>Screenshot</value>
+  </data>
+  <data name="CommandType_SetAudioInputCommand" xml:space="preserve">
+    <value>SetAudioInputCommand</value>
+  </data>
+  <data name="CommandType_TrayWebViewCommand" xml:space="preserve">
+    <value>TrayWebView</value>
+  </data>
+  <data name="HassAction_Trigger" xml:space="preserve">
+    <value>Trigger</value>
+  </data>
+  <data name="HassAction_Press" xml:space="preserve">
+    <value>Press</value>
+  </data>
+  <data name="HassDomain_Button" xml:space="preserve">
+    <value>Button</value>
+  </data>
+  <data name="SensorType_NamedActiveWindowSensor" xml:space="preserve">
+    <value>NamedActiveWindow</value>
+  </data>
+  <data name="SensorsManager_NamedActiveWindowSensorDescription" xml:space="preserve">
+    <value>Provides an ON/OFF value based on whether the focused window name contains configured string.</value>
+  </data>
+  <data name="SensorType_AccentColorSensor" xml:space="preserve">
+    <value>AccentColor</value>
+  </data>
+  <data name="HassDomain_InputButton" xml:space="preserve">
+    <value>InputButton</value>
+  </data>
+  <data name="HassDomain_Fan" xml:space="preserve">
+    <value>Fan</value>
+  </data>
+  <data name="CommandsManager_WinformsSleepCommandDescription" xml:space="preserve">
+    <value>Puts the machine to sleep using WinForms API.
+
+Note: due to "Modern Sleep" the sleep commands might behave differently depending on the device OEM and OS configuration.</value>
+  </data>
+  <data name="CommandType_WinformsSleepCommand" xml:space="preserve">
+    <value>WinformsSleep</value>
+  </data>
+  <data name="CommandType_MonitorSleepPowerPlanCommand" xml:space="preserve">
+    <value>MonitorSleepPowerPlan</value>
+  </data>
+  <data name="CommandsManager_MonitorSleepPowerPlanCommandDescription" xml:space="preserve">
+    <value>Puts all monitors in sleep (low power) mode using alternative approach of power plan modification.
+Should provide better experience with new systems with "modern S0ix sleep" and not put the system to sleep.</value>
+  </data>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigExternalTools.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigExternalTools.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigGeneral.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigGeneral.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigHomeAssistantApi.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigHomeAssistantApi.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigHotKey.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigHotKey.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigLocalStorage.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigLocalStorage.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigLogging.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigLogging.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigMqtt.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigMqtt.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigNotifications.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigNotifications.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigService.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigService.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigStartup.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigStartup.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigUpdates.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigUpdates.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-1-Welcome.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-1-Welcome.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-2-Startup.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-2-Startup.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-3-API.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-3-API.zh-CN.resx
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="LblInfo1.Text" xml:space="preserve">
+    <value>为了解您配置了哪些实体并发送快捷操作，HASS.Agent 需要使用
+Home Assistant 的 API。
+
+请提供长期访问令牌和您的 Home Assistant 实例地址。
+您可以在 Home Assistant 中点击左下角的个人资料头像，
+切换到顶部的安全选项卡，然后导航到页面底部，
+直到看到"创建令牌"按钮。
+
+请注意，要使用可操作通知功能，您需要提供管理员账户的令牌。</value>
+  </data>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-4-MQTT.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-4-MQTT.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-5-Integrations.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-5-Integrations.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-6-HotKey.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-6-HotKey.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-7-Updates.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-7-Updates.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-8-Done.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-8-Done.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/QuickActionControl.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/QuickActionControl.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Service/ServiceCommands.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Service/ServiceCommands.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Service/ServiceConnect.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Service/ServiceConnect.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Service/ServiceGeneral.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Service/ServiceGeneral.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Service/ServiceMQTT.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Service/ServiceMQTT.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Service/ServiceSensors.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Service/ServiceSensors.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/About.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/About.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/ChildApplications/CompatibilityTask.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/ChildApplications/CompatibilityTask.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/ChildApplications/PortReservation.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/ChildApplications/PortReservation.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/ChildApplications/PostUpdate.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/ChildApplications/PostUpdate.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/ChildApplications/Restart.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/ChildApplications/Restart.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/ChildApplications/ServiceReinstall.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/ChildApplications/ServiceReinstall.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/ChildApplications/ServiceSetState.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/ChildApplications/ServiceSetState.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/Commands/CommandsConfig.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/Commands/CommandsConfig.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/Commands/CommandsMod.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/Commands/CommandsMod.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/Configuration.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/Configuration.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/ExitDialog.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/ExitDialog.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/Help.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/Help.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/Main.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/Main.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/Onboarding.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/Onboarding.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/QuickActions/QuickActions.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/QuickActions/QuickActions.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/QuickActions/QuickActionsConfig.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/QuickActions/QuickActionsConfig.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/QuickActions/QuickActionsMod.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/QuickActions/QuickActionsMod.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/Sensors/SensorsConfig.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/Sensors/SensorsConfig.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/Sensors/SensorsMod.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/Sensors/SensorsMod.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/Service/ServiceConfig.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/Service/ServiceConfig.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/UpdatePending.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/UpdatePending.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Managers/LocalizationManager.cs
+++ b/src/HASS.Agent/HASS.Agent/Managers/LocalizationManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using HASS.Agent.Models.Internal;
 using HASS.Agent.Shared;
@@ -145,7 +145,7 @@ namespace HASS.Agent.Managers
         /// </summary>
         private static void LoadSupportedUILanguages()
         {
-            var supportedCultureList = new List<string> { "en", "pt-BR", "sl", "es", "nl", "de", "ru", "fr", "pl", "tr" };
+            var supportedCultureList = new List<string> { "en", "pt-BR", "sl", "es", "nl", "de", "ru", "fr", "pl", "tr", "zh-CN" };
 
             foreach (var supportedUILanguage in supportedCultureList.Select(supportedCulture => new CultureInfo(supportedCulture)).Select(culture => new SupportedUILanguage(culture)))
             {

--- a/src/HASS.Agent/HASS.Agent/Properties/Resources.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Properties/Resources.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.zh-CN.resx
@@ -1,0 +1,3490 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ConfigExternalTools_LblInfo1" xml:space="preserve">
+    <value>This page allows you to configure bindings with external tools.</value>
+  </data>
+  <data name="ConfigExternalTools_LblBrowserName" xml:space="preserve">
+    <value>Browser Name</value>
+  </data>
+  <data name="ConfigExternalTools_LblInfo2" xml:space="preserve">
+	  <value>By default HASS.Agent will launch URLs using your default browser. You can also configure
+a specific browser to be used instead along with launch arguments to run in private mode.</value>
+  </data>
+  <data name="ConfigExternalTools_LblBrowserBinary" xml:space="preserve">
+    <value>Browser Binary</value>
+  </data>
+  <data name="ConfigExternalTools_LblLaunchIncogArg" xml:space="preserve">
+    <value>Additional Launch Arguments</value>
+  </data>
+  <data name="ConfigExternalTools_LblCustomExecutorBinary" xml:space="preserve">
+    <value>Custom Executor Binary</value>
+  </data>
+  <data name="ConfigExternalTools_LblInfo3" xml:space="preserve">
+	  <value>You can configure the HASS.Agent to use a specific interpreter such as Perl or Python.
+Use the 'custom executor' command to launch this executor.</value>
+  </data>
+  <data name="ConfigExternalTools_LblCustomExecutorName" xml:space="preserve">
+    <value>Custom Executor Name</value>
+  </data>
+  <data name="ConfigExternalTools_LblTip1" xml:space="preserve">
+    <value>Tip: Double-click to Browse</value>
+  </data>
+  <data name="ConfigExternalTools_BtnExternalBrowserIncognitoTest" xml:space="preserve">
+    <value>&amp;Test</value>
+  </data>
+  <data name="ConfigGeneral_LblInfo4" xml:space="preserve">
+	  <value>HASS.Agent will wait a grace period before notifying you of disconnects from MQTT or HA's API.
+You can set the amount of seconds to wait in this grace period below.</value>
+  </data>
+  <data name="ConfigGeneral_LblDisconGraceSeconds" xml:space="preserve">
+    <value>Seconds</value>
+  </data>
+  <data name="ConfigGeneral_LblDisconGracePeriod" xml:space="preserve">
+    <value>Disconnected Grace &amp;Period</value>
+  </data>
+  <data name="ConfigGeneral_LblInfo3" xml:space="preserve">
+	  <value>IMPORTANT: if you change this value, HASS.Agent will unpublish all your sensors, commands and force a restart of itself so they can be republished under the new device name.
+Your automations and scripts will keep working.</value>
+  </data>
+  <data name="ConfigGeneral_LblInfo2" xml:space="preserve">
+	  <value>The device name is used to identify your machine on Home Assistant.
+It is also used as a prefix for your command/sensor names (this can be changed per entity).</value>
+  </data>
+  <data name="ConfigGeneral_LblInfo1" xml:space="preserve">
+    <value>This page contains general configuration settings, for more settings you can browse the tabs on the left.</value>
+  </data>
+  <data name="ConfigGeneral_LblDeviceName" xml:space="preserve">
+    <value>Device &amp;Name</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_LblTip1" xml:space="preserve">
+    <value>Tip: Double-click this field to browse</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_LblClientCertificate" xml:space="preserve">
+    <value>Client &amp;Certificate</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_CbHassAutoClientCertificate" xml:space="preserve">
+    <value>Use &amp;automatic client certificate selection</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_BtnTestApi" xml:space="preserve">
+    <value>&amp;Test Connection</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_LblInfo1" xml:space="preserve">
+	  <value>To learn which entities you have configured and to send quick actions, HASS.Agent uses
+Home Assistant's API.
+
+Please provide a long-lived access token and the address of your Home Assistant instance.
+You can get a token in Home Assistant by clicking your profile picture at the bottom-left
+and navigating to the bottom of the page until you see the 'CREATE TOKEN' button.
+
+Please note, that for actionable notification functionality you need to provide admin account token.</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_LblApiToken" xml:space="preserve">
+    <value>&amp;API Token</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_LblServerUri" xml:space="preserve">
+    <value>Server &amp;URI</value>
+  </data>
+  <data name="ConfigHotKey_BtnClearHotKey" xml:space="preserve">
+    <value>&amp;Clear</value>
+  </data>
+  <data name="ConfigHotKey_LblInfo1" xml:space="preserve">
+	  <value>An easy way to pull up your quick actions is to use a global hotkey.
+
+This way, whatever you're doing on your machine, you can always interact with Home Assistant.</value>
+  </data>
+  <data name="ConfigHotKey_CbEnableQuickActionsHotkey" xml:space="preserve">
+    <value>&amp;Enable Quick Actions Hotkey</value>
+  </data>
+  <data name="ConfigHotKey_LblHotkeyCombo" xml:space="preserve">
+    <value>&amp;Hotkey Combination</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearImageCache" xml:space="preserve">
+    <value>Clear Image Cache</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnOpenImageCache" xml:space="preserve">
+    <value>Open Folder</value>
+  </data>
+  <data name="ConfigLocalStorage_LblCacheLocations" xml:space="preserve">
+    <value>Image Cache Location</value>
+  </data>
+  <data name="ConfigLocalStorage_LblCacheDays" xml:space="preserve">
+    <value>days</value>
+  </data>
+  <data name="ConfigLocalStorage_LblInfo1" xml:space="preserve">
+	  <value>Some items like images shown in notifications have to be temporarily stored locally. You can
+configure the amount of days they should be kept before HASS.Agent deletes them.
+
+Enter '0' to keep them permanently.</value>
+  </data>
+  <data name="ConfigLogging_LblInfo1" xml:space="preserve">
+	  <value>Extended logging provides more verbose and in-depth logging, in case the default logging isn't
+sufficient. Please note that enabling this can cause the logfiles to grow large, and should only be
+used when you suspect something's wrong with HASS.Agent itself or when asked by the
+developers.</value>
+  </data>
+  <data name="ConfigLogging_CbExtendedLogging" xml:space="preserve">
+    <value>&amp;Enable Extended Logging</value>
+  </data>
+  <data name="ConfigLogging_BtnShowLogs" xml:space="preserve">
+    <value>&amp;Open Logs Folder</value>
+  </data>
+  <data name="ConfigMqtt_LblTip3" xml:space="preserve">
+    <value>Tip: Double-click these fields to browse</value>
+  </data>
+  <data name="ConfigMqtt_LblClientCert" xml:space="preserve">
+    <value>Client Certificate</value>
+  </data>
+  <data name="ConfigMqtt_LblRootCert" xml:space="preserve">
+    <value>Root Certificate</value>
+  </data>
+  <data name="ConfigMqtt_CbUseRetainFlag" xml:space="preserve">
+    <value>Use &amp;Retain Flag</value>
+  </data>
+  <data name="ConfigMqtt_CbAllowUntrustedCertificates" xml:space="preserve">
+    <value>&amp;Allow Untrusted Certificates</value>
+  </data>
+  <data name="ConfigMqtt_BtnMqttClearConfig" xml:space="preserve">
+    <value>&amp;Clear Configuration</value>
+  </data>
+  <data name="ConfigMqtt_LblTip1" xml:space="preserve">
+    <value>(leave default if unsure)</value>
+  </data>
+  <data name="ConfigMqtt_LblInfo1" xml:space="preserve">
+	  <value>Commands and sensors use MQTT, as well as notifications and media player functions when using the new integration. 
+
+Please provide credentials for your broker, if you're using the HA Mosquitto addon, you can probably use the preset address.
+
+Note: these settings (excluding the Client ID) will also be applied to the satellite service.</value>
+  </data>
+  <data name="ConfigMqtt_LblDiscoPrefix" xml:space="preserve">
+    <value>Discovery Prefix</value>
+  </data>
+  <data name="ConfigMqtt_LblBrokerPassword" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="ConfigMqtt_LblBrokerUsername" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="ConfigMqtt_LblBrokerPort" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="ConfigMqtt_LblBrokerIp" xml:space="preserve">
+    <value>Broker IP Address or Hostname</value>
+  </data>
+  <data name="ConfigMqtt_LblTip2" xml:space="preserve">
+    <value>(leave empty to auto generate)</value>
+  </data>
+  <data name="ConfigMqtt_LblClientId" xml:space="preserve">
+    <value>Client ID</value>
+  </data>
+  <data name="ConfigNotifications_LblInfo2" xml:space="preserve">
+	  <value>If something is not working, make sure you try the following steps:
+
+- Install the HASS.Agent integration
+- Restart Home Assistant
+- Make sure HASS.Agent is active with MQTT enabled!
+- Your device should get detected and added as an entity automatically
+- Optionally: manually add it using the local API</value>
+  </data>
+  <data name="ConfigNotifications_LblInfo1" xml:space="preserve">
+    <value>HASS.Agent can receive notifications from Home Assistant, using text, images and actions. If you have MQTT enabled, your device will automatically get added. Otherwise, manually configure the integration to use the local API.</value>
+  </data>
+  <data name="ConfigNotifications_BtnNotificationsReadme" xml:space="preserve">
+    <value>Notifications &amp;Documentation</value>
+  </data>
+  <data name="ConfigNotifications_LblPort" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="ConfigNotifications_CbAcceptNotifications" xml:space="preserve">
+    <value>&amp;Accept Notifications</value>
+  </data>
+  <data name="ConfigNotifications_BtnSendTestNotification" xml:space="preserve">
+    <value>Show Test Notification</value>
+  </data>
+  <data name="ConfigNotifications_BtnExecutePortReservation" xml:space="preserve">
+    <value>Execute Port Reservation</value>
+  </data>
+  <data name="ConfigNotifications_CbNotificationsIgnoreImageCertErrors" xml:space="preserve">
+    <value>&amp;Ignore certificate errors for images</value>
+  </data>
+  <data name="ConfigService_LblInfo1" xml:space="preserve">
+	  <value>The satellite service allows you to run sensors and commands even when no user's logged in. 
+Use the 'satellite service' button on the main window to manage it.</value>
+  </data>
+  <data name="ConfigService_LblServiceStatusInfo" xml:space="preserve">
+    <value>Service Status:</value>
+  </data>
+  <data name="ConfigService_BtnStartService" xml:space="preserve">
+    <value>S&amp;tart Service</value>
+  </data>
+  <data name="ConfigService_BtnDisableService" xml:space="preserve">
+    <value>&amp;Disable Service</value>
+  </data>
+  <data name="ConfigService_BtnStopService" xml:space="preserve">
+    <value>&amp;Stop Service</value>
+  </data>
+  <data name="ConfigService_BtnEnableService" xml:space="preserve">
+    <value>&amp;Enable Service</value>
+  </data>
+  <data name="ConfigService_BtnReinstallService" xml:space="preserve">
+    <value>&amp;Reinstall Service</value>
+  </data>
+  <data name="ConfigService_LblInfo2" xml:space="preserve">
+	  <value>If you do not configure the service, it won't do anything. However, you can still decide to disable it as well.
+The installer will leave the disabled service alone(if you remove the service, the installer will reinstall it).</value>
+  </data>
+  <data name="ConfigService_LblInfo3" xml:space="preserve">
+	  <value>You can try reinstalling the service if it's not working correctly.
+Your configuration and entities won't be removed.</value>
+  </data>
+  <data name="ConfigService_BtnShowLogs" xml:space="preserve">
+    <value>Open Service &amp;Logs Folder</value>
+  </data>
+  <data name="ConfigService_LblInfo4" xml:space="preserve">
+    <value>If the service still fails after reinstalling, please open a ticket and send the content of the latest log.</value>
+  </data>
+  <data name="ConfigStartup_LblInfo1" xml:space="preserve">
+	  <value>HASS.Agent can start when you login by creating an entry in your user profile's registry.
+
+Since HASS.Agent is user based, if you want to launch for another user, just install and config
+HASS.Agent there.</value>
+  </data>
+  <data name="ConfigStartup_BtnSetStartOnLogin" xml:space="preserve">
+    <value>&amp;Enable Start-on-Login</value>
+  </data>
+  <data name="ConfigStartup_LblStartOnLoginStatusInfo" xml:space="preserve">
+    <value>Start-on-Login Status:</value>
+  </data>
+  <data name="ConfigUpdates_CbBetaUpdates" xml:space="preserve">
+    <value>Notify me of &amp;beta releases</value>
+  </data>
+  <data name="ConfigUpdates_LblInfo2" xml:space="preserve">
+	  <value>When a new update is available, HASS.Agent can download the installer and launch it for you.
+
+The certificate of the downloaded file will get checked before running,you will still get to review the release notes and manually approve the update.</value>
+  </data>
+  <data name="ConfigUpdates_CbExecuteUpdater" xml:space="preserve">
+    <value>Automatically &amp;download future updates</value>
+  </data>
+  <data name="ConfigUpdates_LblInfo1" xml:space="preserve">
+	  <value>HASS.Agent checks for updates in the background if enabled.
+
+You will be sent a push notification if a new update is discovered, letting you know a
+new version is ready to be installed.</value>
+  </data>
+  <data name="ConfigUpdates_CbUpdates" xml:space="preserve">
+    <value>Notify me when a new &amp;release is available</value>
+  </data>
+  <data name="OnboardingWelcome_LblInfo1" xml:space="preserve">
+	  <value>Welcome to the HASS.Agent! It looks like this is the first time you are launching the agent.
+
+To assist you with a first time setup, proceed with the configuration steps below
+or alternatively, click 'Close'.</value>
+  </data>
+  <data name="OnboardingWelcome_LblInfo2" xml:space="preserve">
+    <value>The device name is used to identify your machine on Home Assistant, it is also used as a suggested prefix for your commands and sensors.</value>
+  </data>
+  <data name="OnboardingWelcome_LblDeviceName" xml:space="preserve">
+    <value>Device &amp;Name</value>
+  </data>
+  <data name="OnboardingStartup_BtnSetLaunchOnLogin" xml:space="preserve">
+    <value>Yes, &amp;start HASS.Agent on System Login</value>
+  </data>
+  <data name="OnboardingStartup_LblInfo1" xml:space="preserve">
+	  <value>HASS.Agent can start with your system, this allows for any sensors and data transmission between your device and Home Assistant to begin as soon as you login.
+
+This setting can be changed any time later in the HASS.Agent configuration window.</value>
+  </data>
+  <data name="OnboardingStartup_LblCreateInfo" xml:space="preserve">
+    <value>Fetching current state, please wait..</value>
+  </data>
+  <data name="OnboardingNotifications_LblTip1" xml:space="preserve">
+    <value>Note: 5115 is the default port, only change it if you changed it in Home Assistant.</value>
+  </data>
+  <data name="OnboardingNotifications_CbAcceptNotifications" xml:space="preserve">
+    <value>Yes, accept notifications on port</value>
+  </data>
+  <data name="OnboardingNotifications_LblInfo1" xml:space="preserve">
+	  <value>HASS.Agent can receive notifications from Home Assistant, using text and/or images.
+
+Do you want to enable this function?</value>
+  </data>
+  <data name="OnboardingIntegration_LblIntegration" xml:space="preserve">
+    <value>HASS.Agent-Notifier GitHub Page</value>
+  </data>
+  <data name="OnboardingIntegration_LblInfo2" xml:space="preserve">
+	  <value>Make sure you follow these steps:
+
+- Install HASS.Agent-Notifier integration
+- Restart Home Assistant
+- Configure a notifier entity
+- Restart Home Assistant</value>
+  </data>
+  <data name="OnboardingIntegration_LblInfo1" xml:space="preserve">
+	  <value>To use notifications, you need to install and configure the HASS.Agent-notifier integration in
+Home Assistant.
+
+This is very easy using HACS but may also be installed manually, visit the link below for more
+information.</value>
+  </data>
+  <data name="OnboardingApi_LblApiToken" xml:space="preserve">
+    <value>API &amp;Token</value>
+  </data>
+  <data name="OnboardingApi_LblServerUri" xml:space="preserve">
+    <value>Server &amp;URI (should be ok like this)</value>
+  </data>
+  <data name="OnboardingApi_LblInfo1" xml:space="preserve">
+	  <value>To learn which entities you have configured and to send quick actions, HASS.Agent uses
+Home Assistant's API.
+
+Please provide a long-lived access token and the address of your Home Assistant instance.
+You can get a token in Home Assistant by clicking your profile picture at the bottom-left
+and navigating to the bottom of the page until you see the 'CREATE TOKEN' button.</value>
+  </data>
+  <data name="OnboardingApi_BtnTest" xml:space="preserve">
+    <value>Test &amp;Connection</value>
+  </data>
+  <data name="OnboardingApi_LblTip1" xml:space="preserve">
+    <value>Tip: Specialized settings can be found in the Configuration Window.</value>
+  </data>
+  <data name="OnboardingMqtt_LblPassword" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="OnboardingMqtt_LblUsername" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="OnboardingMqtt_LblPort" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="OnboardingMqtt_LblIpAdress" xml:space="preserve">
+    <value>IP Address or Hostname</value>
+  </data>
+  <data name="OnboardingMqtt_LblInfo1" xml:space="preserve">
+	  <value>Commands and sensors are sent through MQTT. The notifications- and media player integration also make use of them.
+
+Tip: if you're using the HA addon, you can probably use the preset address - just provide credentials.
+</value>
+  </data>
+  <data name="OnboardingMqtt_LblDiscoveryPrefix" xml:space="preserve">
+    <value>Discovery Prefix</value>
+  </data>
+  <data name="OnboardingMqtt_LblTip1" xml:space="preserve">
+    <value>(leave default if not sure)</value>
+  </data>
+  <data name="OnboardingMqtt_LblTip2" xml:space="preserve">
+    <value>Tip: Specialized settings can be found in the Configuration Window.</value>
+  </data>
+  <data name="OnboardingHotKey_LblHotkeyCombo" xml:space="preserve">
+    <value>&amp;Hotkey Combination</value>
+  </data>
+  <data name="OnboardingHotKey_LblInfo1" xml:space="preserve">
+	  <value>An easy way to pull up your quick actions is to use a global hotkey.
+
+This way, whatever you're doing on your machine, you can always interact with Home Assistant.
+</value>
+  </data>
+  <data name="OnboardingHotKey_BtnClear" xml:space="preserve">
+    <value>&amp;Clear</value>
+  </data>
+  <data name="OnboardingUpdates_LblInfo1" xml:space="preserve">
+	  <value>HASS.Agent checks for updates in the background if enabled.
+
+You will be sent a push notification if a new update is discovered, letting you know a
+new version is ready to be installed.
+
+Do you want to enable this automatic update checks?</value>
+  </data>
+  <data name="OnboardingUpdates_CbNofityOnUpdate" xml:space="preserve">
+    <value>Yes, notify me on new &amp;updates</value>
+  </data>
+  <data name="OnboardingUpdates_CbExecuteUpdater" xml:space="preserve">
+    <value>Yes, &amp;download and launch the installer for me</value>
+  </data>
+  <data name="OnboardingUpdates_LblInfo2" xml:space="preserve">
+	  <value>When a new update is available, HASS.Agent can download the installer and launch it for you.
+
+The certificate of the downloaded file will get checked before running,you will still get to review the release notes and manually approve the update.</value>
+  </data>
+  <data name="OnboardingDone_LblGitHub" xml:space="preserve">
+    <value>HASS.Agent GitHub page</value>
+  </data>
+  <data name="OnboardingDone_LblInfo3" xml:space="preserve">
+	  <value>There's a lot more to tinker with, so make sure you take a look at the Configuration Window!
+
+
+Thank you for using HASS.Agent, hopefully it'll be useful for you :-)
+</value>
+  </data>
+  <data name="OnboardingDone_LblInfo2" xml:space="preserve">
+    <value>HASS.Agent will now restart to apply your configuration changes.</value>
+  </data>
+  <data name="OnboardingDone_LblInfo1" xml:space="preserve">
+    <value>Yay, done!</value>
+  </data>
+  <data name="ServiceCommands_LblLowIntegrity" xml:space="preserve">
+    <value>Low Integrity</value>
+  </data>
+  <data name="ServiceCommands_ClmName" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="ServiceCommands_ClmType" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="ServiceCommands_BtnRemove" xml:space="preserve">
+    <value>&amp;Remove</value>
+  </data>
+  <data name="ServiceCommands_BtnModify" xml:space="preserve">
+    <value>&amp;Modify</value>
+  </data>
+  <data name="ServiceCommands_BtnAdd" xml:space="preserve">
+    <value>&amp;Add New</value>
+  </data>
+  <data name="ServiceCommands_BtnStore" xml:space="preserve">
+    <value>&amp;Send &amp;&amp; Activate Commands</value>
+  </data>
+  <data name="ServiceCommands_LblStored" xml:space="preserve">
+    <value>commands stored!</value>
+  </data>
+  <data name="ServiceConnect_BtnRetryAuthId" xml:space="preserve">
+    <value>&amp;Apply</value>
+  </data>
+  <data name="ServiceConnect_LblRetryAuthId" xml:space="preserve">
+    <value>Auth &amp;ID</value>
+  </data>
+  <data name="ServiceConnect_LblAuthenticate" xml:space="preserve">
+    <value>Authenticate</value>
+  </data>
+  <data name="ServiceConnect_LblConnect" xml:space="preserve">
+    <value>Connect with service</value>
+  </data>
+  <data name="ServiceConnect_LblLoading" xml:space="preserve">
+    <value>Connecting satellite service, please wait..</value>
+  </data>
+  <data name="ServiceConnect_LblFetchConfig" xml:space="preserve">
+    <value>Fetch Configuration</value>
+  </data>
+  <data name="ServiceGeneral_LblInfo1" xml:space="preserve">
+    <value>This page contains general configuration settings, for MQTT settings, commands, and sensors, browse the different tabs above.</value>
+  </data>
+  <data name="ServiceGeneral_LblAuthId" xml:space="preserve">
+    <value>Auth &amp;ID</value>
+  </data>
+  <data name="ServiceGeneral_LblDeviceName" xml:space="preserve">
+    <value>Device &amp;Name</value>
+  </data>
+  <data name="ServiceGeneral_LblTip1" xml:space="preserve">
+    <value>Tip: Double-click these fields to browse</value>
+  </data>
+  <data name="ServiceGeneral_LblCustomExecBinary" xml:space="preserve">
+    <value>Custom Executor &amp;Binary</value>
+  </data>
+  <data name="ServiceGeneral_LblCustomExecName" xml:space="preserve">
+    <value>Custom &amp;Executor Name</value>
+  </data>
+  <data name="ServiceGeneral_LblSeconds" xml:space="preserve">
+    <value>seconds</value>
+  </data>
+  <data name="ServiceGeneral_LblDisconGrace" xml:space="preserve">
+    <value>Disconnected Grace &amp;Period</value>
+  </data>
+  <data name="ServiceGeneral_Apply" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="ServiceGeneral_LblVersionInfo" xml:space="preserve">
+    <value>Version</value>
+  </data>
+  <data name="ServiceGeneral_LblTip2" xml:space="preserve">
+    <value>Tip: Double-click to generate random</value>
+  </data>
+  <data name="ServiceGeneral_Stored" xml:space="preserve">
+    <value>Stored!</value>
+  </data>
+  <data name="ServiceMqtt_LblTip2" xml:space="preserve">
+    <value>(leave empty to auto generate)</value>
+  </data>
+  <data name="ServiceMqtt_LblClientId" xml:space="preserve">
+    <value>Client ID</value>
+  </data>
+  <data name="ServiceMqtt_LblTip3" xml:space="preserve">
+    <value>Tip: Double-click these fields to browse</value>
+  </data>
+  <data name="ServiceMqtt_LblClientCert" xml:space="preserve">
+    <value>Client Certificate</value>
+  </data>
+  <data name="ServiceMqtt_LblRootCert" xml:space="preserve">
+    <value>Root Certificate</value>
+  </data>
+  <data name="ServiceMqtt_CbUseRetainFlag" xml:space="preserve">
+    <value>Use &amp;Retain Flag</value>
+  </data>
+  <data name="ServiceMqtt_CbAllowUntrustedCertificates" xml:space="preserve">
+    <value>&amp;Allow Untrusted Certificates</value>
+  </data>
+  <data name="ServiceMqtt_BtnMqttClearConfig" xml:space="preserve">
+    <value>&amp;Clear Configuration</value>
+  </data>
+  <data name="ServiceMqtt_LblTip1" xml:space="preserve">
+    <value>(leave default if not sure)</value>
+  </data>
+  <data name="ServiceMqtt_LblInfo1" xml:space="preserve">
+	  <value>Commands and sensors are sent through MQTT. Please provide credentials for your server. If you're using the HA addon,
+you can probably use the preset address.</value>
+  </data>
+  <data name="ServiceMqtt_LblDiscoPrefix" xml:space="preserve">
+    <value>Discovery Prefix</value>
+  </data>
+  <data name="ServiceMqtt_LblBrokerPassword" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="ServiceMqtt_LblBrokerUsername" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="ServiceMqtt_LblBrokerPort" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="ServiceMqtt_LblBrokerIp" xml:space="preserve">
+    <value>Broker IP Address or Hostname</value>
+  </data>
+  <data name="ServiceMqtt_BtnStore" xml:space="preserve">
+    <value>&amp;Send &amp;&amp; Activate Configuration</value>
+  </data>
+  <data name="ServiceMqtt_BtnCopy" xml:space="preserve">
+    <value>Copy from &amp;HASS.Agent</value>
+  </data>
+  <data name="ServiceMqtt_LblStored" xml:space="preserve">
+    <value>Configuration stored!</value>
+  </data>
+  <data name="ServiceMqtt_LblStatusInfo" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="ServiceMqtt_LblStatus" xml:space="preserve">
+    <value>Querying..</value>
+  </data>
+  <data name="ServiceSensors_ClmName" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="ServiceSensors_ClmType" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="ServiceSensors_LblRefresh" xml:space="preserve">
+    <value>Refresh</value>
+  </data>
+  <data name="ServiceSensors_BtnRemove" xml:space="preserve">
+    <value>&amp;Remove</value>
+  </data>
+  <data name="ServiceSensors_BtnAdd" xml:space="preserve">
+    <value>&amp;Add New</value>
+  </data>
+  <data name="ServiceSensors_BtnModify" xml:space="preserve">
+    <value>&amp;Modify</value>
+  </data>
+  <data name="ServiceSensors_BtnStore" xml:space="preserve">
+    <value>&amp;Send &amp;&amp; Activate Sensors</value>
+  </data>
+  <data name="ServiceSensors_LblStored" xml:space="preserve">
+    <value>Sensors stored!</value>
+  </data>
+  <data name="PortReservation_LblInfo1" xml:space="preserve">
+    <value>Please wait a bit while the task is performed ..</value>
+  </data>
+  <data name="PortReservation_LblTask1" xml:space="preserve">
+    <value>Create API Port Binding</value>
+  </data>
+  <data name="PortReservation_LblTask2" xml:space="preserve">
+    <value>Set Firewall Rule</value>
+  </data>
+  <data name="PortReservation_Title" xml:space="preserve">
+    <value>HASS.Agent Port Reservation</value>
+  </data>
+  <data name="PostUpdate_LblInfo1" xml:space="preserve">
+    <value>Please wait a bit while some post-update tasks are performed ..</value>
+  </data>
+  <data name="PostUpdate_LblTask1" xml:space="preserve">
+    <value>Configuring Satellite Service</value>
+  </data>
+  <data name="PostUpdate_LblTask2" xml:space="preserve">
+    <value>Create API Port Binding</value>
+  </data>
+  <data name="PostUpdate_Title" xml:space="preserve">
+    <value>HASS.Agent Post Update</value>
+  </data>
+  <data name="Restart_LblInfo1" xml:space="preserve">
+    <value>Please wait while HASS.Agent restarts..</value>
+  </data>
+  <data name="Restart_LblTask1" xml:space="preserve">
+    <value>Waiting for previous instance to close..</value>
+  </data>
+  <data name="Restart_LblTask2" xml:space="preserve">
+    <value>Relaunch HASS.Agent</value>
+  </data>
+  <data name="Restart_Title" xml:space="preserve">
+    <value>HASS.Agent Restarter</value>
+  </data>
+  <data name="ServiceReinstall_LblInfo1" xml:space="preserve">
+    <value>Please wait while the satellite service is re-installed..</value>
+  </data>
+  <data name="ServiceReinstall_LblTask1" xml:space="preserve">
+    <value>Remove Satellite Service</value>
+  </data>
+  <data name="ServiceReinstall_LblTask2" xml:space="preserve">
+    <value>Install Satellite Service</value>
+  </data>
+  <data name="ServiceReinstall_Title" xml:space="preserve">
+    <value>HASS.Agent Reinstall Satellite Service</value>
+  </data>
+  <data name="ServiceSetState_LblInfo1" xml:space="preserve">
+    <value>Please wait while the satellite service is configured..</value>
+  </data>
+  <data name="ServiceSetState_LblTask1" xml:space="preserve">
+    <value>Enable Satellite Service</value>
+  </data>
+  <data name="ServiceSetState_Title" xml:space="preserve">
+    <value>HASS.Agent Configure Satellite Service</value>
+  </data>
+  <data name="CommandMqttTopic_BtnClose" xml:space="preserve">
+    <value>&amp;Close</value>
+  </data>
+  <data name="CommandMqttTopic_LblInfo1" xml:space="preserve">
+    <value>This is the MQTT topic on which you can publish action commands:</value>
+  </data>
+  <data name="CommandMqttTopic_BtnCopyClipboard" xml:space="preserve">
+    <value>Copy &amp;to Clipboard</value>
+  </data>
+  <data name="CommandMqttTopic_LblHelp" xml:space="preserve">
+    <value>help and examples</value>
+  </data>
+  <data name="CommandMqttTopic_Title" xml:space="preserve">
+    <value>MQTT Action Topic</value>
+  </data>
+  <data name="CommandsConfig_BtnRemove" xml:space="preserve">
+    <value>&amp;Remove</value>
+  </data>
+  <data name="CommandsConfig_BtnModify" xml:space="preserve">
+    <value>&amp;Modify</value>
+  </data>
+  <data name="CommandsConfig_BtnAdd" xml:space="preserve">
+    <value>&amp;Add New</value>
+  </data>
+  <data name="CommandsConfig_BtnStore" xml:space="preserve">
+    <value>&amp;Store and Activate Commands</value>
+  </data>
+  <data name="CommandsConfig_ClmName" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="CommandsConfig_ClmType" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="CommandsConfig_LblLowIntegrity" xml:space="preserve">
+    <value>Low Integrity</value>
+  </data>
+  <data name="CommandsConfig_LblActionInfo" xml:space="preserve">
+    <value>Action</value>
+  </data>
+  <data name="CommandsConfig_Title" xml:space="preserve">
+    <value>Commands Config</value>
+  </data>
+  <data name="CommandsMod_BtnStore" xml:space="preserve">
+    <value>&amp;Store Command</value>
+  </data>
+  <data name="CommandsMod_LblSetting" xml:space="preserve">
+    <value>&amp;Configuration</value>
+  </data>
+  <data name="CommandsMod_LblName" xml:space="preserve">
+    <value>&amp;Name</value>
+  </data>
+  <data name="CommandsMod_LblDescription" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="CommandsMod_CbRunAsLowIntegrity" xml:space="preserve">
+    <value>&amp;Run as 'Low Integrity'</value>
+  </data>
+  <data name="CommandsMod_LblIntegrityInfo" xml:space="preserve">
+    <value>What's this?</value>
+  </data>
+  <data name="CommandsMod_ClmSensorName" xml:space="preserve">
+    <value>  Type</value>
+  </data>
+  <data name="CommandsMod_LblSelectedType" xml:space="preserve">
+    <value>Selected Type</value>
+  </data>
+  <data name="CommandsMod_LblService" xml:space="preserve">
+    <value>Service</value>
+  </data>
+  <data name="CommandsMod_LblAgent" xml:space="preserve">
+    <value>agent</value>
+  </data>
+  <data name="CommandsMod_LblSpecificClient" xml:space="preserve">
+    <value>HASS.Agent only!</value>
+  </data>
+  <data name="CommandsMod_LblEntityType" xml:space="preserve">
+    <value>&amp;Entity Type</value>
+  </data>
+  <data name="CommandsMod_LblMqttTopic" xml:space="preserve">
+    <value>Show MQTT Action Topic</value>
+  </data>
+  <data name="CommandsMod_LblActionInfo" xml:space="preserve">
+    <value>Action</value>
+  </data>
+  <data name="CommandsMod_Title" xml:space="preserve">
+    <value>Command</value>
+  </data>
+  <data name="QuickActions_LblLoading" xml:space="preserve">
+    <value>Retrieving entities, please wait..</value>
+  </data>
+  <data name="QuickActions_Title" xml:space="preserve">
+    <value>Quick Actions</value>
+  </data>
+  <data name="QuickActionsConfig_BtnStore" xml:space="preserve">
+    <value>&amp;Store Quick Actions</value>
+  </data>
+  <data name="QuickActionsConfig_BtnAdd" xml:space="preserve">
+    <value>&amp;Add New</value>
+  </data>
+  <data name="QuickActionsConfig_BtnModify" xml:space="preserve">
+    <value>&amp;Modify</value>
+  </data>
+  <data name="QuickActionsConfig_BtnRemove" xml:space="preserve">
+    <value>&amp;Remove</value>
+  </data>
+  <data name="QuickActionsConfig_BtnPreview" xml:space="preserve">
+    <value>&amp;Preview</value>
+  </data>
+  <data name="QuickActionsConfig_ClmDomain" xml:space="preserve">
+    <value>Domain</value>
+  </data>
+  <data name="QuickActionsConfig_ClmEntity" xml:space="preserve">
+    <value>Entity</value>
+  </data>
+  <data name="QuickActionsConfig_ClmAction" xml:space="preserve">
+    <value>Action</value>
+  </data>
+  <data name="QuickActionsConfig_ClmHotKey" xml:space="preserve">
+    <value>Hotkey</value>
+  </data>
+  <data name="QuickActionsConfig_ClmDescription" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="QuickActionsConfig_LblHotkey" xml:space="preserve">
+	  <value>Hotkey Enabled</value>
+  </data>
+  <data name="QuickActionsConfig_Title" xml:space="preserve">
+    <value>Quick Actions Configuration</value>
+  </data>
+  <data name="QuickActionsMod_BtnStore" xml:space="preserve">
+    <value>&amp;Store Quick Action</value>
+  </data>
+  <data name="QuickActionsMod_LblDomain" xml:space="preserve">
+    <value>Domain</value>
+  </data>
+  <data name="QuickActionsMod_LblEntityInfo" xml:space="preserve">
+    <value>&amp;Entity</value>
+  </data>
+  <data name="QuickActionsMod_LblAction" xml:space="preserve">
+    <value>Desired &amp;Action</value>
+  </data>
+  <data name="QuickActionsMod_LblDescription" xml:space="preserve">
+    <value>&amp;Description</value>
+  </data>
+  <data name="QuickActionsMod_LblLoading" xml:space="preserve">
+    <value>Retrieving entities, please wait..</value>
+  </data>
+  <data name="QuickActionsMod_CbEnableHotkey" xml:space="preserve">
+    <value>enable hotkey</value>
+  </data>
+  <data name="QuickActionsMod_LblHotkey" xml:space="preserve">
+    <value>&amp;hotkey combination</value>
+  </data>
+  <data name="QuickActionsMod_LblTip1" xml:space="preserve">
+    <value>(optional, will be used instead of entity name)</value>
+  </data>
+  <data name="QuickActionsMod_Title" xml:space="preserve">
+    <value>Quick Action</value>
+  </data>
+  <data name="SensorsConfig_BtnRemove" xml:space="preserve">
+    <value>&amp;Remove</value>
+  </data>
+  <data name="SensorsConfig_BtnModify" xml:space="preserve">
+    <value>&amp;Modify</value>
+  </data>
+  <data name="SensorsConfig_BtnAdd" xml:space="preserve">
+    <value>&amp;Add New</value>
+  </data>
+  <data name="SensorsConfig_BtnStore" xml:space="preserve">
+    <value>&amp;Store &amp;&amp; Activate Sensors</value>
+  </data>
+  <data name="SensorsConfig_ClmName" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="SensorsConfig_ClmType" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="SensorsConfig_LblRefresh" xml:space="preserve">
+    <value>Refresh</value>
+  </data>
+  <data name="SensorsConfig_Title" xml:space="preserve">
+    <value>Sensors Configuration</value>
+  </data>
+  <data name="SensorsMod_BtnStore" xml:space="preserve">
+    <value>&amp;Store Sensor</value>
+  </data>
+  <data name="SensorsMod_LblSetting1" xml:space="preserve">
+    <value>setting 1</value>
+  </data>
+  <data name="SensorsMod_LblType" xml:space="preserve">
+    <value>Selected Type</value>
+  </data>
+  <data name="SensorsMod_LblName" xml:space="preserve">
+    <value>&amp;Name</value>
+  </data>
+  <data name="SensorsMod_LblUpdate" xml:space="preserve">
+    <value>&amp;Update every</value>
+  </data>
+  <data name="SensorsMod_LblSeconds" xml:space="preserve">
+    <value>seconds</value>
+  </data>
+  <data name="SensorsMod_LblDescription" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="SensorsMod_LblSetting2" xml:space="preserve">
+    <value>Setting 2</value>
+  </data>
+  <data name="SensorsMod_LblSetting3" xml:space="preserve">
+    <value>Setting 3</value>
+  </data>
+  <data name="SensorsMod_ClmSensorName" xml:space="preserve">
+    <value>  Type</value>
+  </data>
+  <data name="SensorsMod_LblMultiValue" xml:space="preserve">
+	  <value>Multivalue</value>
+  </data>
+  <data name="SensorsMod_LblAgent" xml:space="preserve">
+    <value>Agent</value>
+  </data>
+  <data name="SensorsMod_LblService" xml:space="preserve">
+    <value>Service</value>
+  </data>
+  <data name="SensorsMod_LblSpecificClient" xml:space="preserve">
+    <value>HASS.Agent only!</value>
+  </data>
+  <data name="SensorsMod_Title" xml:space="preserve">
+    <value>Sensor</value>
+  </data>
+  <data name="ServiceConfig_TabGeneral" xml:space="preserve">
+    <value>     General     </value>
+  </data>
+  <data name="ServiceConfig_TabMqtt" xml:space="preserve">
+    <value>     MQTT     </value>
+  </data>
+  <data name="ServiceConfig_TabCommands" xml:space="preserve">
+    <value>     Commands     </value>
+  </data>
+  <data name="ServiceConfig_TabSensors" xml:space="preserve">
+    <value>     Sensors     </value>
+  </data>
+  <data name="ServiceConfig_Title" xml:space="preserve">
+    <value>Satellite Service Configuration</value>
+  </data>
+  <data name="About_BtnClose" xml:space="preserve">
+    <value>&amp;Close</value>
+  </data>
+  <data name="About_LblInfo1" xml:space="preserve">
+    <value>A Windows-based client for the Home Assistant platform.</value>
+  </data>
+  <data name="About_LblInfo3" xml:space="preserve">
+	  <value>This application is open source and completely free, please check the project pages of 
+the used components for their individual licenses:</value>
+  </data>
+  <data name="About_LblInfo4" xml:space="preserve">
+	  <value>A big 'thank you' to the developers of these projects, who were kind enough to share
+their hard work with the rest of us mere mortals. </value>
+  </data>
+  <data name="About_LblInfo5" xml:space="preserve">
+	  <value>And of course; thanks to Paulus Shoutsen and the entire team of developers that 
+created and maintain Home Assistant :-)</value>
+  </data>
+  <data name="About_LblInfo2" xml:space="preserve">
+    <value>Original created with even more love by</value>
+  </data>
+  <data name="About_LblInfo6" xml:space="preserve">
+    <value>HASS.Agent Team does not currently accept donations.
+If you like this tool however, support original (LAB02 Research) developers by buying them a cup of coffee:</value>
+  </data>
+  <data name="About_Title" xml:space="preserve">
+    <value>About</value>
+  </data>
+  <data name="Configuration_TabGeneral" xml:space="preserve">
+    <value>General</value>
+  </data>
+  <data name="Configuration_TabExternalTools" xml:space="preserve">
+    <value>External Tools</value>
+  </data>
+  <data name="Configuration_TabHassApi" xml:space="preserve">
+    <value>Home Assistant API</value>
+  </data>
+  <data name="Configuration_TabHotKey" xml:space="preserve">
+    <value>Hotkey</value>
+  </data>
+  <data name="Configuration_TabLocalStorage" xml:space="preserve">
+    <value>Local Storage</value>
+  </data>
+  <data name="Configuration_TabLogging" xml:space="preserve">
+    <value>Logging</value>
+  </data>
+  <data name="Configuration_TabMQTT" xml:space="preserve">
+    <value>MQTT</value>
+  </data>
+  <data name="Configuration_TabNotifications" xml:space="preserve">
+    <value>Notifications</value>
+  </data>
+  <data name="Configuration_TabService" xml:space="preserve">
+    <value>Satellite Service</value>
+  </data>
+  <data name="Configuration_TabStartup" xml:space="preserve">
+    <value>Startup</value>
+  </data>
+  <data name="Configuration_TabUpdates" xml:space="preserve">
+    <value>Updates</value>
+  </data>
+  <data name="Configuration_BtnAbout" xml:space="preserve">
+    <value>&amp;About</value>
+  </data>
+  <data name="Configuration_BtnHelp" xml:space="preserve">
+    <value>&amp;Help &amp;&amp; Contact</value>
+  </data>
+  <data name="Configuration_BtnStore" xml:space="preserve">
+    <value>&amp;Save Configuration</value>
+  </data>
+  <data name="Configuration_BtnClose" xml:space="preserve">
+    <value>Close &amp;Without Saving</value>
+  </data>
+  <data name="Configuration_Title" xml:space="preserve">
+    <value>Configuration</value>
+  </data>
+  <data name="ExitDialog_LblInfo1" xml:space="preserve">
+    <value>What would you like to do?</value>
+  </data>
+  <data name="ExitDialog_BtnRestart" xml:space="preserve">
+    <value>&amp;Restart</value>
+  </data>
+  <data name="ExitDialog_BtnHide" xml:space="preserve">
+    <value>&amp;Hide</value>
+  </data>
+  <data name="ExitDialog_BtnExit" xml:space="preserve">
+    <value>&amp;Exit</value>
+  </data>
+  <data name="ExitDialog_Title" xml:space="preserve">
+    <value>Exit Dialog</value>
+  </data>
+  <data name="Help_BtnClose" xml:space="preserve">
+    <value>&amp;Close</value>
+  </data>
+  <data name="Help_LblInfo1" xml:space="preserve">
+	  <value>If you are having trouble with HASS.Agent and require support
+with any sensors, commands, or for general support and feedback,
+there are few ways you can reach us:</value>
+  </data>
+  <data name="Help_LblAbout" xml:space="preserve">
+    <value>About</value>
+  </data>
+  <data name="Help_LblHAForum" xml:space="preserve">
+    <value>Home Assistant Forum</value>
+  </data>
+  <data name="Help_LblGitHub" xml:space="preserve">
+    <value>GitHub Issues</value>
+  </data>
+  <data name="Help_LblHAInfo" xml:space="preserve">
+	  <value>Bit of everything, with the addition that other
+HA users can help you out too!</value>
+  </data>
+  <data name="Help_LblGitHubInfo" xml:space="preserve">
+    <value>Report bugs, post feature requests, see latest changes, etc.</value>
+  </data>
+  <data name="Help_LblDiscordInfo" xml:space="preserve">
+	  <value>Get help with setting up and using HASS.Agent, 
+report bugs or get involved in general chit-chat!</value>
+  </data>
+  <data name="Help_LblWikiInfo" xml:space="preserve">
+    <value>Browse HASS.Agent documentation and usage examples.</value>
+  </data>
+  <data name="Help_Title" xml:space="preserve">
+    <value>Help</value>
+  </data>
+  <data name="Main_TsShow" xml:space="preserve">
+    <value>Show HASS.Agent</value>
+  </data>
+  <data name="Main_TsShowQuickActions" xml:space="preserve">
+    <value>Show Quick Actions</value>
+  </data>
+  <data name="Main_TsConfig" xml:space="preserve">
+    <value>Configuration</value>
+  </data>
+  <data name="Main_TsQuickItemsConfig" xml:space="preserve">
+    <value>Manage Quick Actions</value>
+  </data>
+  <data name="Main_TsLocalSensors" xml:space="preserve">
+    <value>Manage Local Sensors</value>
+  </data>
+  <data name="Main_TsCommands" xml:space="preserve">
+    <value>Manage Commands</value>
+  </data>
+  <data name="Main_CheckForUpdates" xml:space="preserve">
+    <value>Check for Updates</value>
+  </data>
+  <data name="Main_TsDonate" xml:space="preserve">
+    <value>Donate</value>
+  </data>
+  <data name="Main_TsHelp" xml:space="preserve">
+    <value>Help &amp;&amp; Contact</value>
+  </data>
+  <data name="Main_TsAbout" xml:space="preserve">
+    <value>About</value>
+  </data>
+  <data name="Main_TsExit" xml:space="preserve">
+    <value>Exit HASS.Agent</value>
+  </data>
+  <data name="Main_BtnHide" xml:space="preserve">
+    <value>&amp;Hide</value>
+  </data>
+  <data name="Main_GpControls" xml:space="preserve">
+    <value>Controls</value>
+  </data>
+  <data name="Main_BtnServiceManager" xml:space="preserve">
+    <value>S&amp;atellite Service</value>
+  </data>
+  <data name="Main_BtnAppSettings" xml:space="preserve">
+    <value>C&amp;onfiguration</value>
+  </data>
+  <data name="Main_BtnActionsManager" xml:space="preserve">
+    <value>&amp;Quick Actions</value>
+  </data>
+  <data name="Main_BtnCommandsManager" xml:space="preserve">
+    <value>Loading..</value>
+  </data>
+  <data name="Main_BtnSensorsManager" xml:space="preserve">
+    <value>Loading..</value>
+  </data>
+  <data name="Main_GpStatus" xml:space="preserve">
+    <value>System Status</value>
+  </data>
+  <data name="Main_LblService" xml:space="preserve">
+    <value>Satellite Service:</value>
+  </data>
+  <data name="Main_LblCommands" xml:space="preserve">
+    <value>Commands:</value>
+  </data>
+  <data name="Main_LblSensors" xml:space="preserve">
+    <value>Sensors:</value>
+  </data>
+  <data name="Main_LblQuickActions" xml:space="preserve">
+    <value>Quick Actions:</value>
+  </data>
+  <data name="Main_LblHomeAssistantApi" xml:space="preserve">
+    <value>Home Assistant API:</value>
+  </data>
+  <data name="Main_LblNotificationApi" xml:space="preserve">
+    <value>notification api:</value>
+  </data>
+  <data name="Onboarding_BtnNext" xml:space="preserve">
+    <value>&amp;Next</value>
+  </data>
+  <data name="Onboarding_BtnClose" xml:space="preserve">
+    <value>&amp;Close</value>
+  </data>
+  <data name="Onboarding_BtnPrevious" xml:space="preserve">
+    <value>&amp;Previous</value>
+  </data>
+  <data name="Onboarding_Onboarding" xml:space="preserve">
+    <value>HASS.Agent Onboarding</value>
+  </data>
+  <data name="UpdatePending_BtnDownload" xml:space="preserve">
+    <value>Fetching info, please wait..</value>
+  </data>
+  <data name="UpdatePending_LblNewReleaseInfo" xml:space="preserve">
+    <value>There's a new release available:</value>
+  </data>
+  <data name="UpdatePending_LblInfo1" xml:space="preserve">
+    <value>Release notes</value>
+  </data>
+  <data name="UpdatePending_BtnIgnore" xml:space="preserve">
+    <value>&amp;Ignore Update</value>
+  </data>
+  <data name="UpdatePending_LblRelease" xml:space="preserve">
+    <value>Release Page</value>
+  </data>
+  <data name="UpdatePending_Title" xml:space="preserve">
+    <value>HASS.Agent Update</value>
+  </data>
+  <data name="CommandsManager_CustomCommandDescription" xml:space="preserve">
+	  <value>Execute a custom command.
+
+These commands run without special elevation. To run elevated, create a Scheduled Task, and use 'schtasks /Run /TN "TaskName"' as the command to execute your task.
+
+Or enable 'run as low integrity' for even stricter execution.</value>
+  </data>
+  <data name="CommandsManager_CustomExecutorCommandDescription" xml:space="preserve">
+	  <value>Executes the command through the configured custom executor (in Configuration -&gt; External Tools).
+
+Your command is provided as an argument 'as is', so you have to supply your own quotes etc. if necessary.</value>
+  </data>
+  <data name="CommandsManager_HibernateCommandDescription" xml:space="preserve">
+    <value>Sets the machine in hibernation.</value>
+  </data>
+  <data name="CommandsManager_KeyCommandDescription" xml:space="preserve">
+	  <value>Simulates a single keypress.
+Making this command a "switch" type will make the button pressed as long as the switch is turned on.
+
+Click on the 'keycode' textbox and press the key you want simulated. The corresponding keycode will be entered for you.
+For TAB key please use LCTRL+TAB.
+
+If you need more keys and/or modifiers like CTRL, use the MultipleKeys command.</value>
+  </data>
+  <data name="CommandsManager_LaunchUrlCommandDescription" xml:space="preserve">
+	  <value>Launches the provided URL, by default in your default browser.
+
+To use 'incognito', provide a specific browser in Configuration -&gt; External Tools.
+
+If you just want a window with a specific URL (not an entire browser), use a 'WebView' command.</value>
+  </data>
+  <data name="CommandsManager_LockCommandDescription" xml:space="preserve">
+    <value>Locks the current session.</value>
+  </data>
+  <data name="CommandsManager_LogOffCommandDescription" xml:space="preserve">
+    <value>Logs off the current session.</value>
+  </data>
+  <data name="CommandsManager_MediaMuteCommandDescription" xml:space="preserve">
+    <value>Simulates 'Mute' key.</value>
+  </data>
+  <data name="CommandsManager_MediaNextCommandDescription" xml:space="preserve">
+    <value>Simulates 'Media Next' key.</value>
+  </data>
+  <data name="CommandsManager_MediaPlayPauseCommandDescription" xml:space="preserve">
+    <value>Simulates 'Media Pause/Play' key.</value>
+  </data>
+  <data name="CommandsManager_MediaPreviousCommandDescription" xml:space="preserve">
+    <value>Simulates 'Media Previous' key.</value>
+  </data>
+  <data name="CommandsManager_MediaVolumeDownCommandDescription" xml:space="preserve">
+    <value>Simulates 'Volume Down' key.</value>
+  </data>
+  <data name="CommandsManager_MediaVolumeUpCommandDescription" xml:space="preserve">
+    <value>Simulates 'Volume Up' key.</value>
+  </data>
+  <data name="CommandsManager_MultipleKeysCommandDescription" xml:space="preserve">
+	  <value>Simulates pressing mulitple keys.
+
+You need to put [ ] between every key, otherwise HASS.Agent can't tell them apart. So say you want to press X TAB Y SHIFT-Z, it'd be [X] [{TAB}] [Y] [+Z].
+
+There are a few tricks you can use:
+
+- If you want a bracket pressed, escape it, so [ is [\[] and ] is [\]] 
+
+- Special keys go between { }, like {TAB} or {UP}
+
+- Put a + in front of a key to add SHIFT, ^ for CTRL and % for ALT. So, +C is SHIFT-C. Or, +(CD) is SHIFT-C and SHIFT-D, while +CD is SHIFT-C and D
+
+- For multiple presses, use {z 15}, which means Z will get pressed 15 times.
+
+More info: https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.sendkeys</value>
+  </data>
+  <data name="CommandsManager_PowershellCommandDescription" xml:space="preserve">
+	  <value>Execute a Powershell command or script.
+
+You can either provide the location of a script (*.ps1), or a single-line command.
+
+This will run without special elevation.</value>
+  </data>
+  <data name="CommandsManager_PublishAllSensorsCommandDescription" xml:space="preserve">
+	  <value>Resets all sensor checks, forcing all sensors to process and send their value.
+
+Useful for example if you want to force HASS.Agent to update all your sensors after a HA reboot.</value>
+  </data>
+  <data name="CommandsManager_RestartCommandDescription" xml:space="preserve">
+	  <value>Restarts the machine after one minute.
+
+Tip: Accidentally triggered? Run 'shutdown /a' to abort shutdown.</value>
+  </data>
+  <data name="CommandsManager_ShutdownCommandDescription" xml:space="preserve">
+	  <value>Shuts down the machine after one minute.
+
+Tip: Accidentally triggered? Run 'shutdown /a' to abort shutdown.</value>
+  </data>
+  <data name="CommandsManager_SleepCommandDescription" xml:space="preserve">
+	  <value>Puts the machine to sleep.
+
+Note: due to a limitation in Windows, this only works if hibernation is disabled, otherwise it will just hibernate.
+
+You can use something like NirCmd (http://www.nirsoft.net/utils/nircmd.html) to circumvent this.</value>
+  </data>
+  <data name="ConfigExternalTools_BtnExternalBrowserIncognitoTest_MessageBox1" xml:space="preserve">
+    <value>Please enter the location of your browser's binary! (.exe file)</value>
+  </data>
+  <data name="ConfigExternalTools_ConfigExternalTools_BtnExternalBrowserIncognitoTest_MessageBox2" xml:space="preserve">
+    <value>The browser binary provided could not be found, please ensure the path is correct and try again.</value>
+  </data>
+  <data name="ConfigExternalTools_BtnExternalBrowserIncognitoTest_MessageBox3" xml:space="preserve">
+	  <value>No incognito arguments were provided so the browser will likely launch normally.
+
+Do you want to continue?</value>
+  </data>
+  <data name="ConfigExternalTools_BtnExternalBrowserIncognitoTest_MessageBox4" xml:space="preserve">
+	  <value>Something went wrong while launching your browser in incognito mode!
+
+Please check the logs for more information.</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox1" xml:space="preserve">
+    <value>Please enter a valid API key!</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox2" xml:space="preserve">
+    <value>Please enter a value for your Home Assistant's URI.</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox3" xml:space="preserve">
+	  <value>Unable to connect, the following error was returned:
+
+{0}</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox4" xml:space="preserve">
+	  <value>Connection OK!
+
+Home Assistant version: {0}</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearImageCache_MessageBox1" xml:space="preserve">
+    <value>Image cache has been cleared!</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearImageCache_InfoText1" xml:space="preserve">
+    <value>Cleaning..</value>
+  </data>
+  <data name="ConfigNotifications_BtnSendTestNotification_MessageBox1" xml:space="preserve">
+    <value>Notifications are currently disabled, please enable them and restart the HASS.Agent, then try again.</value>
+  </data>
+  <data name="ConfigNotifications_BtnSendTestNotification_MessageBox2" xml:space="preserve">
+	  <value>The test notification should have appeared, if you did not receive it please check the logs or consult the documentation for troubleshooting tips.
+
+Note: This only tests locally whether notifications can be shown!</value>
+  </data>
+  <data name="ConfigNotifications_TestNotification" xml:space="preserve">
+    <value>This is a test notification!</value>
+  </data>
+  <data name="ConfigNotifications_BtnExecutePortReservation_Busy" xml:space="preserve">
+    <value>Executing, please wait..</value>
+  </data>
+  <data name="ConfigNotifications_BtnExecutePortReservation_MessageBox1" xml:space="preserve">
+	  <value>Something went wrong whilst reserving the port!
+
+Manual execution is required and a command has been copied to your clipboard, please open an elevated terminal and paste the command.
+
+Additionally, remember to change your Firewall Rules port!</value>
+  </data>
+  <data name="ConfigService_NotInstalled" xml:space="preserve">
+    <value>Not Installed</value>
+  </data>
+  <data name="ConfigService_Disabled" xml:space="preserve">
+    <value>Disabled</value>
+  </data>
+  <data name="ConfigService_Running" xml:space="preserve">
+    <value>Running</value>
+  </data>
+  <data name="ConfigService_Stopped" xml:space="preserve">
+    <value>Stopped</value>
+  </data>
+  <data name="ConfigService_Failed" xml:space="preserve">
+    <value>Failed</value>
+  </data>
+  <data name="ConfigService_BtnStopService_MessageBox1" xml:space="preserve">
+	  <value>Something went wrong whilst stopping the service, did you allow the UAC prompt?
+
+Check the HASS.Agent (not the service) logs for more information.</value>
+  </data>
+  <data name="ConfigService_BtnStartService_MessageBox1" xml:space="preserve">
+	  <value>The service is set to 'disabled', so it cannot be started.
+
+Please enable the service first and try again.</value>
+  </data>
+  <data name="ConfigService_BtnStartService_MessageBox2" xml:space="preserve">
+	  <value>Something went wrong whilst starting the service, did you allow the UAC prompt?
+
+Check the HASS.Agent (not the service) logs for more information.</value>
+  </data>
+  <data name="ConfigService_BtnDisableService_MessageBox1" xml:space="preserve">
+	  <value>Something went wrong whilst disabling the service, did you allow the UAC prompt?
+
+Check the HASS.Agent (not the service) logs for more information.</value>
+  </data>
+  <data name="ConfigService_BtnEnableService_MessageBox1" xml:space="preserve">
+	  <value>Something went wrong whilst enabling the service, did you allow the UAC prompt?
+
+Check the HASS.Agent (not the service) logs for more information.</value>
+  </data>
+  <data name="ConfigService_BtnShowLogs_MessageBox1" xml:space="preserve">
+	  <value>Something went wrong whilst reinstalling the service, did you allow the UAC prompt?
+
+Check the HASS.Agent (not the service) logs for more information.</value>
+  </data>
+  <data name="ConfigStartup_BtnSetStartOnLogin_MessageBox1" xml:space="preserve">
+    <value>Something went wrong whilst disabling Start-on-Login, please check the logs for more information.</value>
+  </data>
+  <data name="ConfigStartup_BtnSetStartOnLogin_MessageBox2" xml:space="preserve">
+    <value>Something went wrong whilst disabling Start-on-Login, please check the logs for more information.</value>
+  </data>
+  <data name="ConfigStartup_Enabled" xml:space="preserve">
+    <value>Enabled</value>
+  </data>
+  <data name="ConfigStartup_Disable" xml:space="preserve">
+    <value>Disable Start-on-Login</value>
+  </data>
+  <data name="ConfigStartup_Disabled" xml:space="preserve">
+    <value>Disabled</value>
+  </data>
+  <data name="ConfigStartup_Enable" xml:space="preserve">
+    <value>Enable Start-on-Login</value>
+  </data>
+  <data name="OnboardingStartup_Activated" xml:space="preserve">
+    <value>Start-on-Login has been activated!</value>
+  </data>
+  <data name="OnboardingStartup_EnableNow" xml:space="preserve">
+    <value>Do you want to enable Start-on-Login now?</value>
+  </data>
+  <data name="OnboardingStartup_AlreadyActivated" xml:space="preserve">
+    <value>Start-on-Login is already activated, all set!</value>
+  </data>
+  <data name="OnboardingStartup_Activating" xml:space="preserve">
+    <value>Activating Start-on-Login..</value>
+  </data>
+  <data name="OnboardingStartup_Failed" xml:space="preserve">
+    <value>Something went wrong. You can try again, or skip to the next page and retry after HASS.Agent's restart.</value>
+  </data>
+  <data name="OnboardingStartup_BtnSetLaunchOnLogin_2" xml:space="preserve">
+    <value>Enable Start-on-Login</value>
+  </data>
+  <data name="OnboardingApi_BtnTest_MessageBox1" xml:space="preserve">
+    <value>Please provide a valid API key.</value>
+  </data>
+  <data name="OnboardingApi_BtnTest_MessageBox2" xml:space="preserve">
+    <value>Please enter your Home Assistant's URI.</value>
+  </data>
+  <data name="OnboardingApi_BtnTest_MessageBox3" xml:space="preserve">
+	  <value>Unable to connect, the following error was returned:
+
+{0}</value>
+  </data>
+  <data name="OnboardingApi_BtnTest_MessageBox4" xml:space="preserve">
+	  <value>Connection OK!
+
+Home Assistant version: {0}</value>
+  </data>
+  <data name="OnboardingApi_BtnTest_Testing" xml:space="preserve">
+    <value>Testing..</value>
+  </data>
+  <data name="ServiceCommands_BtnStore_MessageBox1" xml:space="preserve">
+    <value>An error occurred whilst saving your commands, please check the logs for more information.</value>
+  </data>
+  <data name="ServiceCommands_BtnStore_Storing" xml:space="preserve">
+    <value>Storing and registering, please wait..</value>
+  </data>
+  <data name="ServiceConnect_Connecting" xml:space="preserve">
+    <value>Connecting with satellite service, please wait..</value>
+  </data>
+  <data name="ServiceConnect_Failed" xml:space="preserve">
+    <value>Connecting to the service has failed!</value>
+  </data>
+  <data name="ServiceConnect_FailedMessage" xml:space="preserve">
+	  <value>The service hasn't been found! You can install and manage it from the configuration panel.
+
+When it's up and running, come back here to configure the commands and sensors.</value>
+  </data>
+  <data name="ServiceConnect_CommunicationFailed" xml:space="preserve">
+    <value>Communicating with the service has failed!</value>
+  </data>
+  <data name="ServiceConnect_CommunicationFailedMessage" xml:space="preserve">
+	  <value>Unable to communicate with the service. Check the logs for more info.
+
+You can open the logs and manage the service from the configuration panel.</value>
+  </data>
+  <data name="ServiceConnect_Unauthorized" xml:space="preserve">
+    <value>Unauthorized</value>
+  </data>
+  <data name="ServiceConnect_UnauthorizedMessage" xml:space="preserve">
+	  <value>You are not authorized to contact the service.
+
+If you have the correct auth ID, you can set it now and try again.</value>
+  </data>
+  <data name="ServiceConnect_SettingsFailed" xml:space="preserve">
+    <value>Fetching settings failed!</value>
+  </data>
+  <data name="ServiceConnect_SettingsFailedMessage" xml:space="preserve">
+	  <value>The service returned an error while requesting its settings. Check the logs for more info.
+
+You can open the logs and manage the service from the configuration panel.</value>
+  </data>
+  <data name="ServiceConnect_MqttFailed" xml:space="preserve">
+    <value>Fetching MQTT settings failed!</value>
+  </data>
+  <data name="ServiceConnect_MqttFailedMessage" xml:space="preserve">
+	  <value>The service returned an error while requesting its MQTT settings. Check the logs for more info.
+
+You can open the logs and manage the service from the configuration panel.</value>
+  </data>
+  <data name="ServiceConnect_CommandsFailed" xml:space="preserve">
+    <value>Fetching configured commands failed!</value>
+  </data>
+  <data name="ServiceConnect_CommandsFailedMessage" xml:space="preserve">
+	  <value>The service returned an error while requesting its configured commands. Check the logs for more info.
+
+You can open the logs and manage the service from the configuration panel.</value>
+  </data>
+  <data name="ServiceConnect_SensorsFailed" xml:space="preserve">
+    <value>Fetching configured sensors failed!</value>
+  </data>
+  <data name="ServiceConnect_SensorsFailedMessage" xml:space="preserve">
+	  <value>The service returned an error while requesting its configured sensors. Check the logs for more info.
+
+You can open the logs and manage the service from the configuration panel.</value>
+  </data>
+  <data name="ServiceGeneral_TbAuthId_MessageBox1" xml:space="preserve">
+	  <value>Storing an empty auth ID will allow all HASS.Agent to access the service.
+
+Are you sure you want this?</value>
+  </data>
+  <data name="ServiceGeneral_SavingFailedMessageBox" xml:space="preserve">
+    <value>An error occurred whilst saving, check the logs for more information.</value>
+  </data>
+  <data name="ServiceGeneral_BtnStoreDeviceName_MessageBox1" xml:space="preserve">
+    <value>Please provide a device name!</value>
+  </data>
+  <data name="ServiceGeneral_BtnStoreCustomExecutor_MessageBox1" xml:space="preserve">
+    <value>Please select an executor first. (Tip: Double click to Browse)</value>
+  </data>
+  <data name="ServiceGeneral_BtnStoreCustomExecutor_MessageBox2" xml:space="preserve">
+    <value>The selected executor could not be found, please ensure the path provided is correct and try again.</value>
+  </data>
+  <data name="ServiceGeneral_LblAuthIdInfo_MessageBox1" xml:space="preserve">
+	  <value>Set an auth ID if you don't want every instance of HASS.Agent on this PC to connect with the satellite service.
+
+Only the instances that have the correct ID, can connect.
+
+Leave empty to allow all to connect.</value>
+  </data>
+  <data name="ServiceGeneral_LblDeviceNameInfo_MessageBox1" xml:space="preserve">
+	  <value>This is the name with which the satellite service registers itself on Home Assistant.
+
+By default, it's your PC's name plus '-satellite'.</value>
+  </data>
+  <data name="ServiceGeneral_LblDisconGraceInfo_MessageBox1" xml:space="preserve">
+    <value>The amount of time the satellite service will wait before reporting a lost connection to the MQTT broker.</value>
+  </data>
+  <data name="ServiceMqtt_StatusError" xml:space="preserve">
+    <value>Error fetching status, please check logs for information.</value>
+  </data>
+  <data name="ServiceMqtt_BtnStore_MessageBox1" xml:space="preserve">
+    <value>An error occurred whilst saving the configuration, please check the logs for more information.</value>
+  </data>
+  <data name="ServiceMqtt_BtnStore_Storing" xml:space="preserve">
+    <value>Storing and registering, please wait..</value>
+  </data>
+  <data name="ServiceSensors_BtnStore_MessageBox1" xml:space="preserve">
+    <value>An error occurred whilst saving the sensors, please check the logs for more information.</value>
+  </data>
+  <data name="ServiceSensors_BtnStore_Storing" xml:space="preserve">
+    <value>Storing and registering, please wait..</value>
+  </data>
+  <data name="PortReservation_ProcessPostUpdate_MessageBox1" xml:space="preserve">
+    <value>Not all steps completed succesfully. Please consult the logs for more information.</value>
+  </data>
+  <data name="PostUpdate_ProcessPostUpdate_MessageBox1" xml:space="preserve">
+    <value>Not all steps completed succesfully. Please consult the logs for more information.</value>
+  </data>
+  <data name="Restart_ProcessRestart_MessageBox1" xml:space="preserve">
+	  <value>HASS.Agent is still active after {0} seconds. Please close all instances and restart manually.
+
+Check the logs for more info, and optionally inform the developers.</value>
+  </data>
+  <data name="ServiceReinstall_ProcessReinstall_MessageBox1" xml:space="preserve">
+    <value>Not all steps completed successfully, please check the logs for more information.</value>
+  </data>
+  <data name="ServiceSetState_Enabled" xml:space="preserve">
+    <value>Enable Satellite Service</value>
+  </data>
+  <data name="ServiceSetState_Disabled" xml:space="preserve">
+    <value>Disable Satellite Service</value>
+  </data>
+  <data name="ServiceSetState_Started" xml:space="preserve">
+    <value>Start Satellite Service</value>
+  </data>
+  <data name="ServiceSetState_Stopped" xml:space="preserve">
+    <value>Stop Satellite Service</value>
+  </data>
+  <data name="ServiceSetState_ProcessState_MessageBox1" xml:space="preserve">
+	  <value>Something went wrong while processing the desired service state.
+
+Please consult the logs for more information.</value>
+  </data>
+  <data name="CommandMqttTopic_BtnCopyClipboard_Copied" xml:space="preserve">
+    <value>Topic copied to clipboard!</value>
+  </data>
+  <data name="CommandsConfig_BtnStore_Storing" xml:space="preserve">
+    <value>Storing and registering, please wait..</value>
+  </data>
+  <data name="CommandsConfig_BtnStore_MessageBox1" xml:space="preserve">
+    <value>An error occurred whilst saving commands, please check the logs for more information.</value>
+  </data>
+  <data name="CommandsMod_Title_NewCommand" xml:space="preserve">
+    <value>New Command</value>
+  </data>
+  <data name="CommandsMod_Title_ModCommand" xml:space="preserve">
+    <value>Mod Command</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox1" xml:space="preserve">
+    <value>Please select a command type!</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox2" xml:space="preserve">
+    <value>Please select a valid command type!</value>
+  </data>
+  <data name="CommandsMod_MessageBox_EntityType" xml:space="preserve">
+    <value>Select a valid entity type first.</value>
+  </data>
+  <data name="CommandsMod_MessageBox_Name" xml:space="preserve">
+    <value>Please provide a name!</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox3" xml:space="preserve">
+    <value>A command with that name already exists, are you sure you want to continue?</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox4" xml:space="preserve">
+	  <value>If a command is not provided, you may only use this entity with an 'action' value via Home Assistant, running it as-is will have no action.
+
+Are you sure you want to proceed?</value>
+  </data>
+  <data name="CommandsMod_MessageBox_Action" xml:space="preserve">
+	  <value>If you don't enter a command or script, you can only use this entity with an 'action' value through Home Assistant. Running it as-is won't do anything.
+
+Are you sure you want this?</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox5" xml:space="preserve">
+    <value>Please enter a key code!</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox6" xml:space="preserve">
+    <value>Checking keys failed: {0}</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox7" xml:space="preserve">
+	  <value>If a URL is not provided, you may only use this entity with an 'action' value via Home Assistant, running it as-is will have no action.
+
+Are you sure you want to proceed?</value>
+  </data>
+  <data name="CommandsMod_LblSetting_Command" xml:space="preserve">
+    <value>Command</value>
+  </data>
+  <data name="CommandsMod_LblSetting_CommandScript" xml:space="preserve">
+    <value>Command or Script</value>
+  </data>
+  <data name="CommandsMod_LblSetting_KeyCode" xml:space="preserve">
+    <value>Keycode</value>
+  </data>
+  <data name="CommandsMod_LblSetting_KeyCodes" xml:space="preserve">
+    <value>Keycodes</value>
+  </data>
+  <data name="CommandsMod_CbCommandSpecific_Incognito" xml:space="preserve">
+    <value>Launch in Incognito Mode</value>
+  </data>
+  <data name="CommandsMod_LblInfo_Browser" xml:space="preserve">
+	  <value>Browser: Default
+
+Please configure a custom browser to enable incognito mode.</value>
+  </data>
+  <data name="CommandsMod_LblSetting_Url" xml:space="preserve">
+    <value>URL</value>
+  </data>
+  <data name="CommandsMod_LblInfo_BrowserSpecific" xml:space="preserve">
+    <value>Browser: {0}</value>
+  </data>
+  <data name="CommandsMod_LblInfo_Executor" xml:space="preserve">
+	  <value>Executor: None
+
+Please configure an executor or your command will not run.</value>
+  </data>
+  <data name="CommandsMod_LblInfo_ExecutorSpecific" xml:space="preserve">
+    <value>Executor: {0}</value>
+  </data>
+  <data name="CommandsMod_LblIntegrityInfo_InfoMsg1" xml:space="preserve">
+    <value>Low integrity means your command will be executed with restricted privileges.</value>
+  </data>
+  <data name="CommandsMod_LblIntegrityInfo_InfoMsg2" xml:space="preserve">
+    <value>This means it will only be able to save and modify files in certain locations,</value>
+  </data>
+  <data name="CommandsMod_LblIntegrityInfo_InfoMsg3" xml:space="preserve">
+    <value>such as the '%USERPROFILE%\AppData\LocalLow' folder or</value>
+  </data>
+  <data name="CommandsMod_LblIntegrityInfo_InfoMsg4" xml:space="preserve">
+    <value>the 'HKEY_CURRENT_USER\Software\AppDataLow' registry key.</value>
+  </data>
+  <data name="CommandsMod_LblIntegrityInfo_InfoMsg5" xml:space="preserve">
+    <value>You should test your command to make sure it's not influenced by this!</value>
+  </data>
+  <data name="CommandsMod_SpecificClient" xml:space="preserve">
+    <value>{0} only!</value>
+  </data>
+  <data name="CommandsMod_LblMqttTopic_MessageBox1" xml:space="preserve">
+    <value>The MQTT manager hasn't been configured properly, or hasn't yet completed its startup.</value>
+  </data>
+  <data name="QuickActions_CheckHassManager_MessageBox1" xml:space="preserve">
+    <value>Unable to fetch your entities because of missing config, please enter the required values in the config screen.</value>
+  </data>
+  <data name="QuickActions_MessageBox_EntityFailed" xml:space="preserve">
+    <value>There was an error trying to fetch your entities!</value>
+  </data>
+  <data name="QuickActionsMod_Title_New" xml:space="preserve">
+    <value>New Quick Action</value>
+  </data>
+  <data name="QuickActionsMod_Title_Mod" xml:space="preserve">
+    <value>Mod Quick Action</value>
+  </data>
+  <data name="QuickActionsMod_CheckHassManager_MessageBox1" xml:space="preserve">
+    <value>Unable to fetch your entities because of missing config, please enter the required values in the config screen.</value>
+  </data>
+  <data name="QuickActionsMod_MessageBox_Entities" xml:space="preserve">
+    <value>There was an error trying to fetch your entities.</value>
+  </data>
+  <data name="QuickActionsMod_BtnStore_MessageBox1" xml:space="preserve">
+    <value>Please select an entity!</value>
+  </data>
+  <data name="QuickActionsMod_BtnStore_MessageBox2" xml:space="preserve">
+    <value>Please select an domain!</value>
+  </data>
+  <data name="QuickActionsMod_BtnStore_MessageBox3" xml:space="preserve">
+    <value>Unknown action, please select a valid one.</value>
+  </data>
+  <data name="SensorsConfig_BtnStore_Storing" xml:space="preserve">
+    <value>Storing and registering, please wait..</value>
+  </data>
+  <data name="SensorsConfig_BtnStore_MessageBox1" xml:space="preserve">
+    <value>An error occurred whilst saving the sensors, please check the logs for more information.</value>
+  </data>
+  <data name="SensorsMod_Title_New" xml:space="preserve">
+    <value>New Sensor</value>
+  </data>
+  <data name="SensorsMod_Title_Mod" xml:space="preserve">
+    <value>Mod Sensor</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_WindowName" xml:space="preserve">
+    <value>Window Name</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_Wmi" xml:space="preserve">
+    <value>WMI Query</value>
+  </data>
+  <data name="SensorsMod_LblSetting2_Wmi" xml:space="preserve">
+    <value>WMI Scope (optional)</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_Category" xml:space="preserve">
+    <value>Category</value>
+  </data>
+  <data name="SensorsMod_LblSetting2_Counter" xml:space="preserve">
+    <value>Counter</value>
+  </data>
+  <data name="SensorsMod_LblSetting3_Instance" xml:space="preserve">
+    <value>Instance (optional)</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_Process" xml:space="preserve">
+    <value>Process</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_Service" xml:space="preserve">
+    <value>Service</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox1" xml:space="preserve">
+    <value>Please select a sensor type!</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox2" xml:space="preserve">
+    <value>Please select a valid sensor type!</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox3" xml:space="preserve">
+    <value>Please provide a name!</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox4" xml:space="preserve">
+    <value>A single-value sensor already exists with that name, are you sure you want to proceed?</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox5" xml:space="preserve">
+    <value>A multi-value sensor already exists with that name, are you sure you want to proceed?</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox6" xml:space="preserve">
+    <value>Please provide an interval between 1 and 43200 (12 hours)!</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox7" xml:space="preserve">
+    <value>Please enter a window name!</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox8" xml:space="preserve">
+    <value>Please enter a query!</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox9" xml:space="preserve">
+    <value>Please enter a category and instance!</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox10" xml:space="preserve">
+    <value>Please enter the name of a process!</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox11" xml:space="preserve">
+    <value>Please enter the name of a service!</value>
+  </data>
+  <data name="SensorsMod_SpecificClient" xml:space="preserve">
+    <value>{0} only!</value>
+  </data>
+  <data name="Configuration_ProcessChanges_MessageBox1" xml:space="preserve">
+	  <value>You've changed your device's name.
+
+All your sensors and commands will now be unpublished, and HASS.Agent will restart afterwards to republish them.
+
+Don't worry, they'll keep their current names, so your automations or scripts will keep working.
+
+Note: the name will get 'sanitized', which means everything except letters, digits and whitespace get replaced by an underscore. This is required by HA.</value>
+  </data>
+  <data name="Configuration_ProcessChanges_MessageBox2" xml:space="preserve">
+	  <value>You've changed the local API's port. This new port needs to be reserved.
+
+You'll get an UAC request to do so, please approve.</value>
+  </data>
+  <data name="Configuration_ProcessChanges_MessageBox3" xml:space="preserve">
+	  <value>Something went wrong!
+
+Please manually execute the required command. It has been copied onto your clipboard, you just need to paste it into an elevated command prompt.
+
+Remember to change your firewall rule's port as well.</value>
+  </data>
+  <data name="Configuration_ProcessChanges_MessageBox4" xml:space="preserve">
+	  <value>The port has succesfully been reserved!
+
+HASS.Agent will now restart to activate the new configuration.</value>
+  </data>
+  <data name="Configuration_MessageBox_RestartManually" xml:space="preserve">
+	  <value>Something went wrong while preparing to restart.
+Please restart manually.</value>
+  </data>
+  <data name="Configuration_ProcessChanges_MessageBox5" xml:space="preserve">
+	  <value>Your configuration has been saved. Most changes require HASS.Agent to restart before they take effect.
+
+Do you want to restart now?</value>
+  </data>
+  <data name="Main_Load_MessageBox1" xml:space="preserve">
+	  <value>Something went wrong while loading your settings.
+
+Check appsettings.json in the 'config' subfolder, or just delete it to start fresh.</value>
+  </data>
+  <data name="Main_Load_MessageBox2" xml:space="preserve">
+	  <value>There was an error launching HASS.Agent.
+Please check the logs and make a bug report on GitHub.</value>
+  </data>
+  <data name="Main_BtnSensorsManage_Ready" xml:space="preserve">
+	  <value>&amp;Sensors</value>
+  </data>
+  <data name="Main_BtnCommandsManager_Ready" xml:space="preserve">
+    <value>&amp;Commands</value>
+  </data>
+  <data name="Main_Checking" xml:space="preserve">
+    <value>Checking..</value>
+  </data>
+  <data name="Main_CheckForUpdate_MessageBox1" xml:space="preserve">
+    <value>You're running the latest version: {0}{1}</value>
+  </data>
+  <data name="UpdatePending_NewBetaRelease" xml:space="preserve">
+    <value>There's a new BETA release available:</value>
+  </data>
+  <data name="UpdatePending_Title_Beta" xml:space="preserve">
+    <value>HASS.Agent BETA Update</value>
+  </data>
+  <data name="UpdatePending_LblUpdateQuestion_Download" xml:space="preserve">
+    <value>Do you want to &amp;download and launch the installer?</value>
+  </data>
+  <data name="UpdatePending_LblUpdateQuestion_Navigate" xml:space="preserve">
+    <value>Do you want to &amp;navigate to the release page?</value>
+  </data>
+  <data name="UpdatePending_InstallUpdate" xml:space="preserve">
+    <value>Install Update</value>
+  </data>
+  <data name="UpdatePending_InstallBetaRelease" xml:space="preserve">
+    <value>Install Beta Release</value>
+  </data>
+  <data name="UpdatePending_OpenReleasePage" xml:space="preserve">
+    <value>Open Release Page</value>
+  </data>
+  <data name="UpdatePending_OpenBetaReleasePage" xml:space="preserve">
+    <value>Open Beta Release Page</value>
+  </data>
+  <data name="UpdatePending_LblUpdateQuestion_Processing" xml:space="preserve">
+    <value>Processing request, please wait..</value>
+  </data>
+  <data name="UpdatePending_BtnDownload_Processing" xml:space="preserve">
+    <value>Processing..</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_Start" xml:space="preserve">
+    <value>HASS.Agent Onboarding: Start [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_Startup" xml:space="preserve">
+    <value>HASS.Agent Onboarding: Startup [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_Notifications" xml:space="preserve">
+    <value>HASS.Agent Onboarding: Notifications [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_Integration" xml:space="preserve">
+    <value>HASS.Agent Onboarding: Integration [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_Api" xml:space="preserve">
+    <value>HASS.Agent Onboarding: API [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_Mqtt" xml:space="preserve">
+    <value>HASS.Agent Onboarding: MQTT [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_HotKey" xml:space="preserve">
+    <value>HASS.Agent Onboarding: HotKey [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_Updates" xml:space="preserve">
+    <value>HASS.Agent Onboarding: Updates [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_Completed" xml:space="preserve">
+    <value>HASS.Agent Onboarding: Completed [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_ConfirmBeforeClose_MessageBox1" xml:space="preserve">
+	  <value>Are you sure you want to abort the onboarding process?
+
+Your progress will not be saved, and it will not be shown again on next launch.</value>
+  </data>
+  <data name="UpdateManager_GetLatestVersionInfo_Error" xml:space="preserve">
+    <value>Error fetching info, please check logs for more information.</value>
+  </data>
+  <data name="UpdateManager_DownloadAndExecuteUpdate_MessageBox1" xml:space="preserve">
+	  <value>Unable to prepare downloading the update, check the logs for more info.
+
+The release page will now open instead.</value>
+  </data>
+  <data name="UpdateManager_DownloadAndExecuteUpdate_MessageBox2" xml:space="preserve">
+	  <value>Unable to download the update, check the logs for more info.
+
+The release page will now open instead.</value>
+  </data>
+  <data name="UpdateManager_DownloadAndExecuteUpdate_MessageBox3" xml:space="preserve">
+	  <value>The downloaded file FAILED the certificate check.
+
+This could be a technical error, but also a tampered file!
+
+Please check the logs, and post a ticket with the findings.</value>
+  </data>
+  <data name="UpdateManager_DownloadAndExecuteUpdate_MessageBox4" xml:space="preserve">
+	  <value>Unable to launch the installer (did you approve the UAC prompt?), check the logs for more info.
+
+The release page will now open instead.</value>
+  </data>
+  <data name="HassApiManager_ToolTip_ConnectionSetupFailed" xml:space="preserve">
+    <value>HASS API: Connection setup failed.</value>
+  </data>
+  <data name="HassApiManager_ToolTip_InitialConnectionFailed" xml:space="preserve">
+    <value>HASS API: Initial connection failed.</value>
+  </data>
+  <data name="HassApiManager_ToolTip_ConnectionFailed" xml:space="preserve">
+    <value>HASS API: Connection failed.</value>
+  </data>
+  <data name="HassApiManager_CheckHassConfig_CertNotFound" xml:space="preserve">
+    <value>Client certificate file not found.</value>
+  </data>
+  <data name="HassApiManager_CheckHassConfig_UnableToConnect" xml:space="preserve">
+    <value>Unable to connect, check URI.</value>
+  </data>
+  <data name="HassApiManager_CheckHassConfig_ConfigFailed" xml:space="preserve">
+    <value>Unable to fetch configuration, please check API key.</value>
+  </data>
+  <data name="HassApiManager_ConnectionFailed" xml:space="preserve">
+    <value>Unable to connect, please check URI and configuration.</value>
+  </data>
+  <data name="HassApiManager_ToolTip_QuickActionFailed" xml:space="preserve">
+    <value>quick action: action failed, check the logs for info</value>
+  </data>
+  <data name="HassApiManager_ToolTip_QuickActionFailedOnEntity" xml:space="preserve">
+    <value>quick action: action failed, entity not found</value>
+  </data>
+  <data name="MqttManager_ToolTip_ConnectionError" xml:space="preserve">
+    <value>MQTT: Error while connecting</value>
+  </data>
+  <data name="MqttManager_ToolTip_ConnectionFailed" xml:space="preserve">
+    <value>MQTT: Failed to connect</value>
+  </data>
+  <data name="MqttManager_ToolTip_Disconnected" xml:space="preserve">
+    <value>MQTT: Disconnected</value>
+  </data>
+  <data name="NotifierManager_Initialize_MessageBox1" xml:space="preserve">
+	  <value>Error trying to bind the API to port {0}.
+
+Make sure no other instance of HASS.Agent is running and the port is available and registered.</value>
+  </data>
+  <data name="SensorsManager_ActiveWindowSensorDescription" xml:space="preserve">
+    <value>Provides the title of the current active window.</value>
+  </data>
+  <data name="SensorsManager_AudioSensorsDescription" xml:space="preserve">
+	  <value>Provides information various aspects of your device's audio:
+
+Current peak volume level (can be used as a simple 'is something playing' value).
+
+Default audio device: name, state and volume.
+
+Summary of your audio sessions: application name, muted state, volume and current peak volume.</value>
+  </data>
+  <data name="SensorsManager_BatterySensorsDescription" xml:space="preserve">
+    <value>Provides a sensor with the current charging status, estimated amount of minutes on a full charge, remaining charge as a percentage, remaining charge in minutes and the powerline status.</value>
+  </data>
+  <data name="SensorsManager_CpuLoadSensorDescription" xml:space="preserve">
+    <value>Provides the current load of the first CPU as a percentage.</value>
+  </data>
+  <data name="SensorsManager_CurrentClockSpeedSensorDescription" xml:space="preserve">
+    <value>Provides the current clockspeed of the first CPU.</value>
+  </data>
+  <data name="SensorsManager_CurrentVolumeSensorDescription" xml:space="preserve">
+	  <value>Provides the current volume level as a percentage.
+
+Currently takes the volume of your default device.</value>
+  </data>
+  <data name="SensorsManager_DisplaySensorsDescription" xml:space="preserve">
+    <value>Provides a sensor with the amount of displays, name of the primary display, and per display its name, resolution and bits per pixel.</value>
+  </data>
+  <data name="SensorsManager_DummySensorDescription" xml:space="preserve">
+    <value>Dummy sensor for testing purposes, sends a random integer value between 0 and 100.</value>
+  </data>
+  <data name="SensorsManager_GpuLoadSensorDescription" xml:space="preserve">
+    <value>Provides the current load of the first GPU as a percentage.</value>
+  </data>
+  <data name="SensorsManager_GpuTemperatureSensorDescription" xml:space="preserve">
+    <value>NOTE: This is a non-functioning sensor.
+
+Due to the security concerns regarding Libre Hardware Monitor (library allowing HASS.Agent to access GPU temperature data) this sensor is left for backward compatibility reasons and will always return 0.
+Please see documentation for alternative options.</value>
+  </data>
+  <data name="SensorsManager_LastActiveSensorDescription" xml:space="preserve">
+    <value>Provides a datetime value containing the last moment the user provided input.
+
+Optionally updates the sensor with current date, when system has been woken from sleep/hibernation in configuerd time window and no user activity was performed.</value>
+  </data>
+  <data name="SensorsManager_LastBootSensorDescription" xml:space="preserve">
+	  <value>Provides a datetime value containing the last moment the system (re)booted.
+
+Important: Windows' FastBoot option can throw this value off, because that's a form of hibernation. You can disable it through Power Options -&gt; 'Choose what the power buttons do' -&gt; uncheck 'Turn on fast start-up'. It doesn't make much difference for modern machines with SSDs, but disabling makes sure you get a clean state after rebooting.</value>
+  </data>
+  <data name="SensorsManager_LastSystemStateChangeSensorDescription" xml:space="preserve">
+	  <value>Provides the last system state change:
+
+ApplicationStarted, Logoff, SystemShutdown, Resume, Suspend, ConsoleConnect, ConsoleDisconnect, RemoteConnect, RemoteDisconnect, SessionLock, SessionLogoff, SessionLogon, SessionRemoteControl and SessionUnlock.</value>
+  </data>
+  <data name="SensorsManager_LoggedUserSensorDescription" xml:space="preserve">
+	  <value>Returns the name of the currently logged user.
+
+This will only show active users, and falls back to 'Empty' if there are none. If there are multiple, the first will be used.</value>
+  </data>
+  <data name="SensorsManager_LoggedUsersSensorDescription" xml:space="preserve">
+	  <value>Returns a json-formatted list of currently logged users.
+
+This will also contain users that aren't active. If you only want the current active user, use the LoggedUser sensor instead.</value>
+  </data>
+  <data name="SensorsManager_MemoryUsageSensorDescription" xml:space="preserve">
+    <value>Provides the amount of used memory as a percentage.</value>
+  </data>
+  <data name="SensorsManager_MicrophoneActiveSensorDescription" xml:space="preserve">
+	  <value>Provides a bool value based on whether the microphone is currently being used.
+
+Note: if used in the satellite service, it won't detect userspace applications.</value>
+  </data>
+  <data name="SensorsManager_NamedWindowSensorDescription" xml:space="preserve">
+    <value>Provides an ON/OFF value based on whether the window is currently open (doesn't have to be active).</value>
+  </data>
+  <data name="SensorsManager_NetworkSensorsDescription" xml:space="preserve">
+	  <value>Provides card info, configuration, transfer- &amp; package statistics and addresses (ip, mac, dhcp, dns) of the selected network card(s).
+
+This is a multi-value sensor.</value>
+  </data>
+  <data name="SensorsManager_PerformanceCounterSensorDescription" xml:space="preserve">
+	  <value>Provides the values of a performance counter.
+
+For example, the built-in CPU load sensor uses these values:
+
+Category: Processor
+Counter: % Processor Time
+Instance: _Total
+
+You can explore the counters through Windows' 'perfmon.exe' tool.</value>
+  </data>
+  <data name="SensorsManager_ProcessActiveSensorDescription" xml:space="preserve">
+	  <value>Provides the number of active instances of the process.
+
+Note: don't add the extension (eg. notepad.exe becomes notepad).</value>
+  </data>
+  <data name="SensorsManager_ServiceStateSensorDescription" xml:space="preserve">
+	  <value>Returns the state of the provided service: NotFound, Stopped, StartPending, StopPending, Running, ContinuePending, PausePending or Paused.
+
+Make sure to provide the 'Service name', not the 'Display name'.</value>
+  </data>
+  <data name="SensorsManager_SessionStateSensorDescription" xml:space="preserve">
+	  <value>Provides the current session state:
+
+Locked, Unlocked or Unknown.
+
+Use a LastSystemStateChangeSensor to monitor session state changes.</value>
+  </data>
+  <data name="SensorsManager_StorageSensorsDescription" xml:space="preserve">
+    <value>Provides the labels, total size (MB), available space (MB), used space (MB) and file system of all present non-removable disks.</value>
+  </data>
+  <data name="SensorsManager_UserNotificationStateSensorDescription" xml:space="preserve">
+	  <value>Provides the current user state:
+
+NotPresent, Busy, RunningDirect3dFullScreen, PresentationMode, AcceptsNotifications, QuietTime or RunningWindowsStoreApp.
+
+Can for instance be used to determine whether to send notifications or TTS messages.</value>
+  </data>
+  <data name="SensorsManager_WebcamActiveSensorDescription" xml:space="preserve">
+	  <value>Provides a bool value based on whether the webcam is currently being used.
+
+Note: if used in the satellite service, it won't detect userspace applications.</value>
+  </data>
+  <data name="SensorsManager_WindowsUpdatesSensorsDescription" xml:space="preserve">
+	  <value>Provides a sensor with the amount of pending driver updates, a sensor with the amount of pending software updates, a sensor containing all pending driver updates information (title, kb article id's, hidden, type and categories) and a sensor containing the same for pending software updates.
+
+This is a costly request, so the recommended interval is 15 minutes (900 seconds). But it's capped at 10 minutes, if you provide a lower value, you'll get the last known list.</value>
+  </data>
+  <data name="SensorsManager_WmiQuerySensorDescription" xml:space="preserve">
+    <value>Provides the result of the WMI query.</value>
+  </data>
+  <data name="SettingsManager_LoadAppSettings_MessageBox1" xml:space="preserve">
+	  <value>Error loading settings:
+
+{0}</value>
+  </data>
+  <data name="SettingsManager_StoreInitialSettings_MessageBox1" xml:space="preserve">
+	  <value>Error storing initial settings:
+
+{0}</value>
+  </data>
+  <data name="SettingsManager_StoreAppSettings_MessageBox1" xml:space="preserve">
+	  <value>Error storing settings:
+
+{0}</value>
+  </data>
+  <data name="StoredCommands_Load_MessageBox1" xml:space="preserve">
+	  <value>Error loading commands:
+
+{0}</value>
+  </data>
+  <data name="StoredCommands_Store_MessageBox1" xml:space="preserve">
+	  <value>Error storing commands:
+
+{0}</value>
+  </data>
+  <data name="StoredQuickActions_Load_MessageBox1" xml:space="preserve">
+	  <value>Error loading quick actions:
+
+{0}</value>
+  </data>
+  <data name="StoredQuickActions_Store_MessageBox1" xml:space="preserve">
+	  <value>Error storing quick actions:
+
+{0}</value>
+  </data>
+  <data name="StoredSensors_Load_MessageBox1" xml:space="preserve">
+	  <value>Error loading sensors:
+
+{0}</value>
+  </data>
+  <data name="StoredSensors_Store_MessageBox1" xml:space="preserve">
+	  <value>Error storing sensors:
+
+{0}</value>
+  </data>
+  <data name="Main_LblMqtt" xml:space="preserve">
+    <value>MQTT:</value>
+  </data>
+  <data name="Help_LblWiki" xml:space="preserve">
+    <value>Wiki</value>
+  </data>
+  <data name="Configuration_BtnStore_Busy" xml:space="preserve">
+    <value>Busy, please wait..</value>
+  </data>
+  <data name="ConfigGeneral_LblInterfaceLangauge" xml:space="preserve">
+    <value>Interface &amp;Language</value>
+  </data>
+  <data name="About_LblOr" xml:space="preserve">
+    <value>or</value>
+  </data>
+  <data name="OnboardingManager_BtnNext_Finish" xml:space="preserve">
+    <value>Finish</value>
+  </data>
+  <data name="OnboardingWelcome_LblInterfaceLangauge" xml:space="preserve">
+    <value>Interface &amp;Language</value>
+  </data>
+  <data name="ServiceMqtt_SetMqttStatus_ConfigError" xml:space="preserve">
+    <value>Configuration missing</value>
+  </data>
+  <data name="ServiceMqtt_SetMqttStatus_Connected" xml:space="preserve">
+    <value>Connected</value>
+  </data>
+  <data name="ServiceMqtt_SetMqttStatus_Connecting" xml:space="preserve">
+    <value>Connecting..</value>
+  </data>
+  <data name="ServiceMqtt_SetMqttStatus_Disconnected" xml:space="preserve">
+    <value>Disconnected</value>
+  </data>
+  <data name="ServiceMqtt_SetMqttStatus_Error" xml:space="preserve">
+    <value>Error</value>
+  </data>
+  <data name="CommandType_CustomCommand" xml:space="preserve">
+    <value>Custom</value>
+  </data>
+  <data name="CommandType_CustomExecutorCommand" xml:space="preserve">
+    <value>CustomExecutor</value>
+  </data>
+  <data name="CommandType_HibernateCommand" xml:space="preserve">
+    <value>Hibernate</value>
+  </data>
+  <data name="CommandType_KeyCommand" xml:space="preserve">
+    <value>Key</value>
+  </data>
+  <data name="CommandType_LaunchUrlCommand" xml:space="preserve">
+    <value>LaunchUrl</value>
+  </data>
+  <data name="CommandType_LockCommand" xml:space="preserve">
+    <value>Lock</value>
+  </data>
+  <data name="CommandType_LogOffCommand" xml:space="preserve">
+    <value>LogOff</value>
+  </data>
+  <data name="CommandType_MediaMuteCommand" xml:space="preserve">
+    <value>MediaMute</value>
+  </data>
+  <data name="CommandType_MediaNextCommand" xml:space="preserve">
+    <value>MediaNext</value>
+  </data>
+  <data name="CommandType_MediaPlayPauseCommand" xml:space="preserve">
+    <value>MediaPlayPause</value>
+  </data>
+  <data name="CommandType_MediaPreviousCommand" xml:space="preserve">
+    <value>MediaPrevious</value>
+  </data>
+  <data name="CommandType_MediaVolumeDownCommand" xml:space="preserve">
+    <value>MediaVolumeDown</value>
+  </data>
+  <data name="CommandType_MediaVolumeUpCommand" xml:space="preserve">
+    <value>MediaVolumeUp</value>
+  </data>
+  <data name="CommandType_MultipleKeysCommand" xml:space="preserve">
+    <value>MultipleKeys</value>
+  </data>
+  <data name="CommandType_PowershellCommand" xml:space="preserve">
+    <value>Powershell</value>
+  </data>
+  <data name="CommandType_PublishAllSensorsCommand" xml:space="preserve">
+    <value>PublishAllSensors</value>
+  </data>
+  <data name="CommandType_RestartCommand" xml:space="preserve">
+    <value>Restart</value>
+  </data>
+  <data name="CommandType_ShutdownCommand" xml:space="preserve">
+    <value>Shutdown</value>
+  </data>
+  <data name="CommandType_SleepCommand" xml:space="preserve">
+    <value>Sleep</value>
+  </data>
+  <data name="UserNotificationState_AcceptsNotifications" xml:space="preserve">
+    <value>AcceptsNotifications</value>
+  </data>
+  <data name="UserNotificationState_Busy" xml:space="preserve">
+    <value>Busy</value>
+  </data>
+  <data name="UserNotificationState_NotPresent" xml:space="preserve">
+    <value>NotPresent</value>
+  </data>
+  <data name="UserNotificationState_PresentationMode" xml:space="preserve">
+    <value>PresentationMode</value>
+  </data>
+  <data name="UserNotificationState_QuietTime" xml:space="preserve">
+    <value>QuietTime</value>
+  </data>
+  <data name="UserNotificationState_RunningDirect3dFullScreen" xml:space="preserve">
+    <value>RunningDirect3dFullScreen</value>
+  </data>
+  <data name="UserNotificationState_RunningWindowsStoreApp" xml:space="preserve">
+    <value>RunningWindowsStoreApp</value>
+  </data>
+  <data name="SystemStateEvent_ConsoleConnect" xml:space="preserve">
+    <value>ConsoleConnect</value>
+  </data>
+  <data name="SystemStateEvent_ConsoleDisconnect" xml:space="preserve">
+    <value>ConsoleDisconnect</value>
+  </data>
+  <data name="SystemStateEvent_HassAgentSatelliteServiceStarted" xml:space="preserve">
+    <value>HassAgentSatelliteServiceStarted</value>
+  </data>
+  <data name="SystemStateEvent_HassAgentStarted" xml:space="preserve">
+    <value>HassAgentStarted</value>
+  </data>
+  <data name="SystemStateEvent_Logoff" xml:space="preserve">
+    <value>Logoff</value>
+  </data>
+  <data name="SystemStateEvent_RemoteConnect" xml:space="preserve">
+    <value>RemoteConnect</value>
+  </data>
+  <data name="SystemStateEvent_RemoteDisconnect" xml:space="preserve">
+    <value>RemoteDisconnect</value>
+  </data>
+  <data name="SystemStateEvent_Resume" xml:space="preserve">
+    <value>Resume</value>
+  </data>
+  <data name="SystemStateEvent_SessionLock" xml:space="preserve">
+    <value>SessionLock</value>
+  </data>
+  <data name="SystemStateEvent_SessionLogoff" xml:space="preserve">
+    <value>SessionLogoff</value>
+  </data>
+  <data name="SystemStateEvent_SessionLogon" xml:space="preserve">
+    <value>SessionLogon</value>
+  </data>
+  <data name="SystemStateEvent_SessionRemoteControl" xml:space="preserve">
+    <value>SessionRemoteControl</value>
+  </data>
+  <data name="SystemStateEvent_SessionUnlock" xml:space="preserve">
+    <value>SessionUnlock</value>
+  </data>
+  <data name="SystemStateEvent_Suspend" xml:space="preserve">
+    <value>Suspend</value>
+  </data>
+  <data name="SystemStateEvent_SystemShutdown" xml:space="preserve">
+    <value>SystemShutdown</value>
+  </data>
+  <data name="SensorType_ActiveWindowSensor" xml:space="preserve">
+    <value>ActiveWindow</value>
+  </data>
+  <data name="SensorType_AudioSensors" xml:space="preserve">
+    <value>Audio</value>
+  </data>
+  <data name="SensorType_BatterySensors" xml:space="preserve">
+    <value>Battery</value>
+  </data>
+  <data name="SensorType_CpuLoadSensor" xml:space="preserve">
+    <value>CpuLoad</value>
+  </data>
+  <data name="SensorType_CurrentClockSpeedSensor" xml:space="preserve">
+    <value>CurrentClockSpeed</value>
+  </data>
+  <data name="SensorType_CurrentVolumeSensor" xml:space="preserve">
+    <value>CurrentVolume</value>
+  </data>
+  <data name="SensorType_DisplaySensors" xml:space="preserve">
+    <value>Display</value>
+  </data>
+  <data name="SensorType_DummySensor" xml:space="preserve">
+    <value>Dummy</value>
+  </data>
+  <data name="SensorType_GpuLoadSensor" xml:space="preserve">
+    <value>GpuLoad</value>
+  </data>
+  <data name="SensorType_GpuTemperatureSensor" xml:space="preserve">
+    <value>GpuTemperature</value>
+  </data>
+  <data name="SensorType_LastActiveSensor" xml:space="preserve">
+    <value>LastActive</value>
+  </data>
+  <data name="SensorType_LastBootSensor" xml:space="preserve">
+    <value>LastBoot</value>
+  </data>
+  <data name="SensorType_LastSystemStateChangeSensor" xml:space="preserve">
+    <value>LastSystemStateChange</value>
+  </data>
+  <data name="SensorType_LoggedUserSensor" xml:space="preserve">
+    <value>LoggedUser</value>
+  </data>
+  <data name="SensorType_LoggedUsersSensor" xml:space="preserve">
+    <value>LoggedUsers</value>
+  </data>
+  <data name="SensorType_MemoryUsageSensor" xml:space="preserve">
+    <value>MemoryUsage</value>
+  </data>
+  <data name="SensorType_MicrophoneActiveSensor" xml:space="preserve">
+    <value>MicrophoneActive</value>
+  </data>
+  <data name="SensorType_NamedWindowSensor" xml:space="preserve">
+    <value>NamedWindow</value>
+  </data>
+  <data name="SensorType_NetworkSensors" xml:space="preserve">
+    <value>Network</value>
+  </data>
+  <data name="SensorType_PerformanceCounterSensor" xml:space="preserve">
+    <value>PerformanceCounter</value>
+  </data>
+  <data name="SensorType_ProcessActiveSensor" xml:space="preserve">
+    <value>ProcessActive</value>
+  </data>
+  <data name="SensorType_ServiceStateSensor" xml:space="preserve">
+    <value>ServiceState</value>
+  </data>
+  <data name="SensorType_SessionStateSensor" xml:space="preserve">
+    <value>SessionState</value>
+  </data>
+  <data name="SensorType_StorageSensors" xml:space="preserve">
+    <value>Storage</value>
+  </data>
+  <data name="SensorType_UserNotificationStateSensor" xml:space="preserve">
+    <value>UserNotification</value>
+  </data>
+  <data name="SensorType_WebcamActiveSensor" xml:space="preserve">
+    <value>WebcamActive</value>
+  </data>
+  <data name="SensorType_WindowsUpdatesSensors" xml:space="preserve">
+    <value>WindowsUpdates</value>
+  </data>
+  <data name="SensorType_WmiQuerySensor" xml:space="preserve">
+    <value>WmiQuery</value>
+  </data>
+  <data name="HassDomain_Automation" xml:space="preserve">
+    <value>Automation</value>
+  </data>
+  <data name="HassDomain_Climate" xml:space="preserve">
+    <value>Climate</value>
+  </data>
+  <data name="HassDomain_Cover" xml:space="preserve">
+    <value>Cover</value>
+  </data>
+  <data name="HassDomain_InputBoolean" xml:space="preserve">
+    <value>InputBoolean</value>
+  </data>
+  <data name="HassDomain_Light" xml:space="preserve">
+    <value>Light</value>
+  </data>
+  <data name="HassDomain_MediaPlayer" xml:space="preserve">
+    <value>MediaPlayer</value>
+  </data>
+  <data name="HassDomain_Scene" xml:space="preserve">
+    <value>Scene</value>
+  </data>
+  <data name="HassDomain_Script" xml:space="preserve">
+    <value>Script</value>
+  </data>
+  <data name="HassDomain_Switch" xml:space="preserve">
+    <value>Switch</value>
+  </data>
+  <data name="HassAction_Close" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="HassAction_Off" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="HassAction_On" xml:space="preserve">
+    <value>On</value>
+  </data>
+  <data name="HassAction_Open" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="HassAction_Pause" xml:space="preserve">
+    <value>Pause</value>
+  </data>
+  <data name="HassAction_Play" xml:space="preserve">
+    <value>Play</value>
+  </data>
+  <data name="HassAction_Stop" xml:space="preserve">
+    <value>Stop</value>
+  </data>
+  <data name="HassAction_Toggle" xml:space="preserve">
+    <value>Toggle</value>
+  </data>
+  <data name="CommandEntityType_Button" xml:space="preserve">
+    <value>Button</value>
+  </data>
+  <data name="CommandEntityType_Light" xml:space="preserve">
+    <value>Light</value>
+  </data>
+  <data name="CommandEntityType_Lock" xml:space="preserve">
+    <value>Lock</value>
+  </data>
+  <data name="CommandEntityType_Siren" xml:space="preserve">
+    <value>Siren</value>
+  </data>
+  <data name="CommandEntityType_Switch" xml:space="preserve">
+    <value>Switch</value>
+  </data>
+  <data name="ComponentStatus_Connecting" xml:space="preserve">
+    <value>Connecting..</value>
+  </data>
+  <data name="ComponentStatus_Disabled" xml:space="preserve">
+    <value>Disabled</value>
+  </data>
+  <data name="ComponentStatus_Failed" xml:space="preserve">
+    <value>Failed</value>
+  </data>
+  <data name="ComponentStatus_Loading" xml:space="preserve">
+    <value>Loading..</value>
+  </data>
+  <data name="ComponentStatus_Ok" xml:space="preserve">
+	  <value>Running</value>
+  </data>
+  <data name="ComponentStatus_Stopped" xml:space="preserve">
+    <value>Stopped</value>
+  </data>
+  <data name="LockState_Locked" xml:space="preserve">
+    <value>Locked</value>
+  </data>
+  <data name="LockState_Unknown" xml:space="preserve">
+    <value>Unknown</value>
+  </data>
+  <data name="LockState_Unlocked" xml:space="preserve">
+    <value>Unlocked</value>
+  </data>
+  <data name="SensorType_GeoLocationSensor" xml:space="preserve">
+    <value>GeoLocation</value>
+  </data>
+  <data name="SensorsMod_All" xml:space="preserve">
+    <value>All</value>
+  </data>
+  <data name="SensorsMod_BtnTest" xml:space="preserve">
+    <value>&amp;Test</value>
+  </data>
+  <data name="SensorsMod_BtnTest_PerformanceCounter" xml:space="preserve">
+    <value>Test Performance Counter</value>
+  </data>
+  <data name="SensorsMod_BtnTest_Wmi" xml:space="preserve">
+    <value>Test WMI Query</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_Network" xml:space="preserve">
+    <value>Network Card</value>
+  </data>
+  <data name="SensorsMod_TestPerformanceCounter_MessageBox1" xml:space="preserve">
+    <value>Enter a category and counter first.</value>
+  </data>
+  <data name="SensorsMod_TestPerformanceCounter_MessageBox2" xml:space="preserve">
+	  <value>Test succesfully executed, result value:
+
+{0}</value>
+  </data>
+  <data name="SensorsMod_TestPerformanceCounter_MessageBox3" xml:space="preserve">
+	  <value>The test failed to execute:
+
+{0}
+
+Do you want to open the logs folder?</value>
+  </data>
+  <data name="SensorsMod_TestWmi_MessageBox1" xml:space="preserve">
+    <value>Enter a WMI query first.</value>
+  </data>
+  <data name="SensorsMod_TestWmi_MessageBox2" xml:space="preserve">
+	  <value>Query succesfully executed, result value:
+
+{0}</value>
+  </data>
+  <data name="SensorsMod_TestWmi_MessageBox3" xml:space="preserve">
+	  <value>The query failed to execute:
+
+{0}
+
+Do you want to open the logs folder?</value>
+  </data>
+  <data name="SensorsMod_WmiTestFailed" xml:space="preserve">
+	  <value>It looks like your scope is malformed, it should probably start like this:
+
+\\.\ROOT\
+
+The scope you entered:
+
+{0}
+
+Tip: make sure you haven't switched the scope and query fields around.
+
+Do you still want to use the current values?</value>
+  </data>
+  <data name="SystemStateEvent_ApplicationStarted" xml:space="preserve">
+    <value>ApplicationStarted</value>
+  </data>
+  <data name="ServiceGeneral_LblInfo2" xml:space="preserve">
+    <value>You can use the satellite service to run sensors and commands without having to be logged in. Not all types are available, for instance the 'LaunchUrl' command can only be added as a regular command.</value>
+  </data>
+  <data name="SensorsConfig_ClmValue" xml:space="preserve">
+    <value>Last Known Value</value>
+  </data>
+  <data name="LocalApiManager_Initialize_MessageBox1" xml:space="preserve">
+	  <value>Error trying to bind the API to port {0}.
+
+Make sure no other instance of HASS.Agent is running and the port is available and registered.</value>
+  </data>
+  <data name="CommandType_SendWindowToFrontCommand" xml:space="preserve">
+    <value>SendWindowToFront</value>
+  </data>
+  <data name="CommandType_WebViewCommand" xml:space="preserve">
+    <value>WebView</value>
+  </data>
+  <data name="CommandsManager_WebViewCommandDescription" xml:space="preserve">
+	  <value>Shows a window with the provided URL.
+
+This differs from the 'LaunchUrl' command in that it doesn't load a full-fledged browser, just the provided URL in its own window.
+
+You can use this to for instance quickly show Home Assistant's dashboard.
+
+By default, it stores cookies indefinitely so you only have to log in once.</value>
+  </data>
+  <data name="HassDomain_HASSAgentCommands" xml:space="preserve">
+    <value>HASS.Agent Commands</value>
+  </data>
+  <data name="CommandsManager_CommandsManager_SendWindowToFrontCommandDescription" xml:space="preserve">
+	  <value>Looks for the specified process, and tries to send its main window to the front.
+
+If the application is minimized, it'll get restored.
+
+Example: if you want to send VLC to the foreground, use 'vlc'.</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox8" xml:space="preserve">
+	  <value>If you do not configure the command, you may only use this entity with an 'action' value via Home Assistant and it will appear using the default settings, running it as-is will have no action.
+
+Are you sure you want to do this?</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearAudioCache" xml:space="preserve">
+    <value>Clear Audio Cache</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearAudioCache_InfoText1" xml:space="preserve">
+    <value>Cleaning..</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearAudioCache_MessageBox1" xml:space="preserve">
+    <value>The audio cache has been cleared!</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearWebViewCache" xml:space="preserve">
+    <value>Clear WebView Cache</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearWebViewCache_InfoText1" xml:space="preserve">
+    <value>Cleaning..</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearWebViewCache_MessageBox1" xml:space="preserve">
+    <value>The WebView cache has been cleared!</value>
+  </data>
+  <data name="Main_CheckDpiScalingFactor_MessageBox1" xml:space="preserve">
+	  <value>It looks like you're using an alternative scaling. This may result in some parts of HASS.Agent not looking as intended.
+
+Please report any unusable aspects on GitHub. Thanks!
+
+Note: this message only shows once.</value>
+  </data>
+  <data name="WebViewCommandConfig_SetStoredVariables_MessageBox1" xml:space="preserve">
+    <value>Unable to load the stored command settings, resetting to default.</value>
+  </data>
+  <data name="CommandsMod_BtnConfigureCommand" xml:space="preserve">
+    <value>Configure Command &amp;Parameters</value>
+  </data>
+  <data name="ConfigLocalApi_BtnExecutePortReservation" xml:space="preserve">
+    <value>Execute Port &amp;Reservation</value>
+  </data>
+  <data name="ConfigLocalApi_CbLocalApiActive" xml:space="preserve">
+    <value>&amp;Enable Local API</value>
+  </data>
+  <data name="ConfigLocalApi_LblInfo1" xml:space="preserve">
+	  <value>HASS.Agent has its own local API, so Home Assistant can send requests (for instance to send a notification). You can configure it globally here, and afterwards you can configure the dependent sections (currently notifications and mediaplayer).
+
+Note: this is not required for the new integration to function. Only enable and use it if you don't use MQTT.</value>
+  </data>
+  <data name="ConfigLocalApi_LblInfo2" xml:space="preserve">
+    <value>To be able to listen to the requests, HASS.Agent needs to have its port reserved and opened in your firewall. You can use this button to have it done for you.</value>
+  </data>
+  <data name="ConfigLocalApi_LblPort" xml:space="preserve">
+    <value>&amp;Port</value>
+  </data>
+  <data name="ConfigLocalStorage_LblAudioCacheLocation" xml:space="preserve">
+    <value>Audio Cache Location</value>
+  </data>
+  <data name="ConfigLocalStorage_LblImageCacheDays" xml:space="preserve">
+    <value>days</value>
+  </data>
+  <data name="ConfigLocalStorage_LblImageCacheLocation" xml:space="preserve">
+    <value>Image Cache Location</value>
+  </data>
+  <data name="ConfigLocalStorage_LblKeepAudio" xml:space="preserve">
+    <value>Keep audio for</value>
+  </data>
+  <data name="ConfigLocalStorage_LblKeepImages" xml:space="preserve">
+    <value>Keep images for</value>
+  </data>
+  <data name="ConfigLocalStorage_LblKeepWebView" xml:space="preserve">
+    <value>Clear cache every</value>
+  </data>
+  <data name="ConfigLocalStorage_LblWebViewCacheLocation" xml:space="preserve">
+    <value>WebView Cache Location</value>
+  </data>
+  <data name="ConfigMediaPlayer_BtnMediaPlayerReadme" xml:space="preserve">
+    <value>Media Player &amp;Documentation</value>
+  </data>
+  <data name="ConfigMediaPlayer_CbEnableMediaPlayer" xml:space="preserve">
+    <value>&amp;Enable Media Player Functionality</value>
+  </data>
+  <data name="ConfigMediaPlayer_LblInfo1" xml:space="preserve">
+    <value>HASS.Agent can act as a media player for Home Assistant, so you'll be able to see and control any media that's playing, and send text-to-speech. If you have MQTT enabled, your device will automatically get added. Otherwise, manually configure the integration to use the local API.</value>
+  </data>
+  <data name="ConfigMediaPlayer_LblInfo2" xml:space="preserve">
+	  <value>If something is not working, make sure you try the following steps:
+
+- Install the HASS.Agent integration
+- Restart Home Assistant
+- Make sure HASS.Agent is active with MQTT enabled!
+- Your device should get detected and added as an entity automatically
+- Optionally: manually add it using the local API</value>
+  </data>
+  <data name="ConfigMediaPlayer_LblLocalApiDisabled" xml:space="preserve">
+    <value>The local API is disabled however the media player requires it in order to function.</value>
+  </data>
+  <data name="ConfigMqtt_CbMqttTls" xml:space="preserve">
+    <value>&amp;TLS</value>
+  </data>
+  <data name="ConfigNotifications_LblLocalApiDisabled" xml:space="preserve">
+    <value>The local API is disabled however the media player requires it in order to function.</value>
+  </data>
+  <data name="ConfigTrayIcon_BtnShowWebViewPreview" xml:space="preserve">
+    <value>Show &amp;Preview</value>
+  </data>
+  <data name="ConfigTrayIcon_CbDefaultMenu" xml:space="preserve">
+    <value>Show &amp;Default Menu</value>
+  </data>
+  <data name="ConfigTrayIcon_CbShowWebView" xml:space="preserve">
+    <value>Show &amp;WebView</value>
+  </data>
+  <data name="ConfigTrayIcon_CbWebViewKeepLoaded" xml:space="preserve">
+    <value>&amp;Keep page loaded in the background</value>
+  </data>
+  <data name="ConfigTrayIcon_LblInfo1" xml:space="preserve">
+    <value>Control the behaviour of the tray icon when it is right-clicked.</value>
+  </data>
+  <data name="ConfigTrayIcon_LblInfo2" xml:space="preserve">
+    <value>(This uses extra resources, but reduces loading time.)</value>
+  </data>
+  <data name="ConfigTrayIcon_LblWebViewSize" xml:space="preserve">
+    <value>Size (px)</value>
+  </data>
+  <data name="ConfigTrayIcon_LblWebViewUrl" xml:space="preserve">
+    <value>&amp;WebView URL (For instance, your Home Assistant Dashboard URL)</value>
+  </data>
+  <data name="Configuration_TablLocalApi" xml:space="preserve">
+    <value>Local API</value>
+  </data>
+  <data name="Configuration_TabMediaPlayer" xml:space="preserve">
+    <value>Media Player</value>
+  </data>
+  <data name="Configuration_TabTrayIcon" xml:space="preserve">
+    <value>Tray Icon</value>
+  </data>
+  <data name="HelperFunctions_InputLanguageCheckDiffers_ErrorMsg1" xml:space="preserve">
+    <value>Your input language '{0}' is known to collide with the default CTRL-ALT-Q hotkey. Please set your own.</value>
+  </data>
+  <data name="HelperFunctions_InputLanguageCheckDiffers_ErrorMsg2" xml:space="preserve">
+    <value>Your input language '{0}' is unknown, and might collide with the default CTRL-ALT-Q hotkey. Please check to be sure. If it does, consider opening a ticket on GitHub so it can be added to the list.</value>
+  </data>
+  <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg1" xml:space="preserve">
+    <value>No keys found</value>
+  </data>
+  <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg2" xml:space="preserve">
+    <value>brackets missing, start and close all keys with [ ]</value>
+  </data>
+  <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg3" xml:space="preserve">
+    <value>Error while parsing keys, please check the logs for more information.</value>
+  </data>
+  <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg4" xml:space="preserve">
+    <value>The number of open brackets ('[') does not correspond to the number of closed brackets. (']')! ({0} to {1})</value>
+  </data>
+  <data name="Help_LblDocumentation" xml:space="preserve">
+    <value>Documentation</value>
+  </data>
+  <data name="Help_LblDocumentationInfo" xml:space="preserve">
+    <value>Documentation and Usage Examples</value>
+  </data>
+  <data name="Main_BtnCheckForUpdate" xml:space="preserve">
+    <value>Check for &amp;Updates</value>
+  </data>
+  <data name="Main_LblLocalApi" xml:space="preserve">
+    <value>Local API:</value>
+  </data>
+  <data name="Main_TsSatelliteService" xml:space="preserve">
+    <value>Manage Satellite Service</value>
+  </data>
+  <data name="OnboardingIntegrations_LblInfo1" xml:space="preserve">
+	  <value>To use notifications, you need to install and configure the HASS.Agent integration in
+Home Assistant.
+
+This is very easy using HACS, but you can also install manually. Visit the link below for more
+information.</value>
+  </data>
+  <data name="OnboardingIntegrations_LblInfo2" xml:space="preserve">
+	  <value>Make sure you follow these steps:
+
+- Install the HASS.Agent-Notifier and / or HASS.Agent-MediaPlayer integration
+- Restart Home Assistant
+-Configure a notifier and / or media_player entity
+-Restart Home Assistant</value>
+  </data>
+  <data name="OnboardingIntegrations_LblInfo3" xml:space="preserve">
+    <value>The same goes for the media player, this integration allows you to control your device as a media_player entity, see what's playing and send text-to-speech.</value>
+  </data>
+  <data name="OnboardingIntegrations_LblMediaPlayerIntegration" xml:space="preserve">
+    <value>HASS.Agent-MediaPlayer GitHub Page</value>
+  </data>
+  <data name="OnboardingIntegrations_LblNotifierIntegration" xml:space="preserve">
+    <value>HASS.Agent-Integration GitHub Page</value>
+  </data>
+  <data name="OnboardingLocalApi_CbEnableLocalApi" xml:space="preserve">
+    <value>Yes, &amp;enable the local API on port</value>
+  </data>
+  <data name="OnboardingLocalApi_CbEnableMediaPlayer" xml:space="preserve">
+    <value>Enable &amp;Media Player and text-to-speech (TTS)</value>
+  </data>
+  <data name="OnboardingLocalApi_CbEnableNotifications" xml:space="preserve">
+    <value>Enable &amp;Notifications</value>
+  </data>
+  <data name="OnboardingLocalApi_LblInfo1" xml:space="preserve">
+	  <value>HASS.Agent has its own internal API, so Home Assistant can send requests (like notifications or text-to-speech).
+
+Do you want to enable it?</value>
+  </data>
+  <data name="OnboardingLocalApi_LblInfo2" xml:space="preserve">
+    <value>You can choose what modules you want to enable. They require HA integrations, but don't worry, the next page will give you more info on how to set them up.</value>
+  </data>
+  <data name="OnboardingLocalApi_LblTip1" xml:space="preserve">
+    <value>Note: 5115 is the default port, only change it if you changed it in Home Assistant.</value>
+  </data>
+  <data name="OnboardingMqtt_CbMqttTls" xml:space="preserve">
+    <value>&amp;TLS</value>
+  </data>
+  <data name="OnboardingWelcome_Store_MessageBox1" xml:space="preserve">
+	  <value>Your device name contained some characters that are not allowed by HA (only letters, digits and whitespace).
+
+The final name is: {0}
+
+Do you want to use that version?</value>
+  </data>
+  <data name="Onboarding_Title" xml:space="preserve">
+    <value>HASS.Agent Onboarding</value>
+  </data>
+  <data name="ServiceGeneral_LblAuthStored" xml:space="preserve">
+    <value>stored!</value>
+  </data>
+  <data name="ServiceMqtt_CbMqttTls" xml:space="preserve">
+    <value>&amp;TLS</value>
+  </data>
+  <data name="WebViewCommandConfig_BtnSave" xml:space="preserve">
+    <value>&amp;Save</value>
+  </data>
+  <data name="WebViewCommandConfig_CbCenterScreen" xml:space="preserve">
+    <value>&amp;Always show centered in screen</value>
+  </data>
+  <data name="WebViewCommandConfig_CbShowTitleBar" xml:space="preserve">
+    <value>Show the window's &amp;title bar</value>
+  </data>
+  <data name="WebViewCommandConfig_CbTopMost" xml:space="preserve">
+    <value>Set window as 'Always on &amp;Top'</value>
+  </data>
+  <data name="WebViewCommandConfig_LblInfo1" xml:space="preserve">
+    <value>Drag and resize this window to set the size and location of your webview command.</value>
+  </data>
+  <data name="WebViewCommandConfig_LblLocation" xml:space="preserve">
+    <value>Location</value>
+  </data>
+  <data name="WebViewCommandConfig_LblSize" xml:space="preserve">
+    <value>Size</value>
+  </data>
+  <data name="WebViewCommandConfig_LblTip1" xml:space="preserve">
+    <value>Tip: Press ESCAPE to close a WebView.</value>
+  </data>
+  <data name="WebViewCommandConfig_LblUrl" xml:space="preserve">
+    <value>&amp;URL</value>
+  </data>
+  <data name="WebViewCommandConfig_Title" xml:space="preserve">
+    <value>WebView Configuration</value>
+  </data>
+  <data name="WebView_Title" xml:space="preserve">
+    <value>WebView</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox9" xml:space="preserve">
+	  <value>The keycode you have provided is not a valid number!
+
+Please ensure the keycode field is in focus and press the key you want simulated, the keycode should then be generated for you.</value>
+  </data>
+  <data name="ConfigGeneral_CbEnableDeviceNameSanitation" xml:space="preserve">
+    <value>Enable Device Name &amp;Sanitation</value>
+  </data>
+  <data name="ConfigGeneral_CbEnableStateNotifications" xml:space="preserve">
+    <value>Enable State Notifications</value>
+  </data>
+  <data name="ConfigGeneral_LblInfo5" xml:space="preserve">
+    <value>HASS.Agent will sanitize your device name to make sure HA will accept it, you can overrule this rule below if you're sure that your name will be accepted as-is.</value>
+  </data>
+  <data name="ConfigGeneral_LblInfo6" xml:space="preserve">
+    <value>HASS.Agent sends notifications when the state of a module changes, you can adjust whether or not you want to receive these notifications below.</value>
+  </data>
+  <data name="Configuration_ProcessChanges_MessageBox6" xml:space="preserve">
+	  <value>You've changed your device's name.
+
+All your sensors and commands will now be unpublished and published again after the HASS.Agent restarts.
+
+Don't worry! they'll keep their current names so your automations and scripts will continue to work.
+
+Note: You disabled sanitation, so make sure your device name is accepted by Home Assistant.</value>
+  </data>
+  <data name="SensorType_PrintersSensors" xml:space="preserve">
+    <value>Printers</value>
+  </data>
+  <data name="CommandType_MonitorSleepCommand" xml:space="preserve">
+    <value>MonitorSleep</value>
+  </data>
+  <data name="CommandType_MonitorWakeCommand" xml:space="preserve">
+    <value>MonitorWake</value>
+  </data>
+  <data name="MonitorPowerEvent_PowerOn" xml:space="preserve">
+    <value>PowerOn</value>
+  </data>
+  <data name="MonitorPowerEvent_PowerOff" xml:space="preserve">
+    <value>PowerOff</value>
+  </data>
+  <data name="MonitorPowerEvent_Dimmed" xml:space="preserve">
+    <value>Dimmed</value>
+  </data>
+  <data name="MonitorPowerEvent_Unknown" xml:space="preserve">
+    <value>Unknown</value>
+  </data>
+  <data name="SensorType_MonitorPowerStateSensor" xml:space="preserve">
+    <value>MonitorPowerState</value>
+  </data>
+  <data name="SensorType_PowershellSensor" xml:space="preserve">
+    <value>PowershellSensor</value>
+  </data>
+  <data name="CommandType_SetVolumeCommand" xml:space="preserve">
+    <value>SetVolume</value>
+  </data>
+  <data name="WindowState_Maximized" xml:space="preserve">
+    <value>Maximized</value>
+  </data>
+  <data name="WindowState_Minimized" xml:space="preserve">
+    <value>Minimized</value>
+  </data>
+  <data name="WindowState_Normal" xml:space="preserve">
+    <value>Normal</value>
+  </data>
+  <data name="WindowState_Unknown" xml:space="preserve">
+    <value>Unknown</value>
+  </data>
+  <data name="WindowState_Hidden" xml:space="preserve">
+    <value>Hidden</value>
+  </data>
+  <data name="SensorType_WindowStateSensor" xml:space="preserve">
+    <value>WindowState</value>
+  </data>
+  <data name="SensorType_WebcamProcessSensor" xml:space="preserve">
+    <value>WebcamProcess</value>
+  </data>
+  <data name="SensorType_MicrophoneProcessSensor" xml:space="preserve">
+    <value>MicrophoneProcess</value>
+  </data>
+  <data name="CommandsManager_MonitorSleepCommandDescription" xml:space="preserve">
+    <value>Puts all monitors in sleep (low power) mode.</value>
+  </data>
+  <data name="CommandsManager_MonitorWakeCommandDescription" xml:space="preserve">
+    <value>Tries to wake up all monitors by simulating a 'arrow up' keypress.</value>
+  </data>
+  <data name="CommandsManager_SetVolumeCommandDescription" xml:space="preserve">
+    <value>Sets the volume of the current default audiodevice to the specified level.</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox10" xml:space="preserve">
+    <value>Please enter a value between 0-100 as the desired volume level!</value>
+  </data>
+  <data name="CommandsMod_CommandsMod" xml:space="preserve">
+    <value>Command</value>
+  </data>
+  <data name="CommandsMod_MessageBox_Action2" xml:space="preserve">
+	  <value>If you don't enter a volume value, you can only use this entity with an 'action' value through Home Assistant. Running it as-is won't do anything.
+
+Are you sure you want this?</value>
+  </data>
+  <data name="CommandsMod_MessageBox_Sanitize" xml:space="preserve">
+	  <value>The name you provided contains unsupported characters and won't work. The suggested version is:
+
+{0}
+
+Do you want to use this version?</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox5" xml:space="preserve">
+	  <value>The API token you have provided doesn't appear to be valid, please ensure you selected the entire token (Don't use CTRL + A or double-click). A valid API key contains three sections, separated by two dots.
+
+Are you sure you want to use this key anyway?</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox6" xml:space="preserve">
+	  <value>The URI you have provided does not appear to be valid, a valid URI may look like either of the following:
+- http://homeassistant.local:8123
+- http://192.168.0.1:8123
+
+Are you sure you want to use this URI anyway?</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_BtnTestApi_Testing" xml:space="preserve">
+    <value>Testing..</value>
+  </data>
+  <data name="ConfigMediaPlayer_LblConnectivityDisabled" xml:space="preserve">
+    <value>both the local API and MQTT are disabled, but the integration needs at least one for it to work</value>
+  </data>
+  <data name="ConfigMqtt_CbEnableMqtt" xml:space="preserve">
+    <value>Enable MQTT</value>
+  </data>
+  <data name="ConfigMqtt_LblMqttDisabledWarning" xml:space="preserve">
+    <value>If MQTT is not enabled, commands and sensors will not work!</value>
+  </data>
+  <data name="ConfigNotifications_LblConnectivityDisabled" xml:space="preserve">
+    <value>both the local API and MQTT are disabled, but the integration needs at least one for it to work</value>
+  </data>
+  <data name="ConfigService_BtnManageService" xml:space="preserve">
+    <value>&amp;Manage Service</value>
+  </data>
+  <data name="ConfigService_BtnManageService_MessageBox1" xml:space="preserve">
+	  <value>The service is currently stopped and cannot be configured.
+
+Please start the service first in order to configure it.</value>
+  </data>
+  <data name="ConfigService_LblInfo5" xml:space="preserve">
+    <value>If you want to manage the service (add commands and sensor, change settings) you can do so here, or by using the 'satellite service' button on the main window.</value>
+  </data>
+  <data name="ConfigTrayIcon_CbWebViewShowMenuOnLeftClick" xml:space="preserve">
+    <value>Show default menu on mouse left-click</value>
+  </data>
+  <data name="Configuration_CheckValues_MessageBox1" xml:space="preserve">
+	  <value>Your Home Assistant API token doesn't look right. Make sure you selected the entire token (don't use CTRL+A or doubleclick).
+It should contain three sections (seperated by two dots).
+
+Are you sure you want to use it like this?</value>
+  </data>
+  <data name="Configuration_CheckValues_MessageBox2" xml:space="preserve">
+	  <value>Your Home Assistant URI doesn't look right. It should look something like 'http://homeassistant.local:8123' or 'https://192.168.0.1:8123'.
+
+Are you sure you want to use it like this?</value>
+  </data>
+  <data name="Configuration_CheckValues_MessageBox3" xml:space="preserve">
+	  <value>Your MQTT broker URI doesn't look right. It should look something like 'homeassistant.local' or '192.168.0.1'.
+
+Are you sure you want to use it like this?</value>
+  </data>
+  <data name="Donate_BtnClose" xml:space="preserve">
+    <value>&amp;Close</value>
+  </data>
+  <data name="Donate_CbHideDonateButton" xml:space="preserve">
+    <value>I already donated, hide the button on the main window.</value>
+  </data>
+  <data name="Donate_LblInfo" xml:space="preserve">
+	  <value>HASS.Agent is completely free, and will always stay that way without restrictions!
+
+However, developing and maintaining this tool (and everything that surrounds it, like support and the docs) takes up a lot of time. 
+
+Like most developers, I run on caffeïne - so if you can spare it, a cup of coffee is always very much appreciated!</value>
+  </data>
+  <data name="Donate_Title" xml:space="preserve">
+    <value>Donate</value>
+  </data>
+  <data name="Main_NotifyIcon_MouseClick_MessageBox1" xml:space="preserve">
+    <value>No URL has been set! Please configure the webview through Configuration -&gt; Tray Icon.</value>
+  </data>
+  <data name="Main_TsCheckForUpdates" xml:space="preserve">
+    <value>Check for Updates</value>
+  </data>
+  <data name="OnboardingApi_BtnTest_MessageBox5" xml:space="preserve">
+	  <value>The API token you have provided doesn't appear to be valid, please ensure you selected the entire token (Don't use CTRL + A or double-click). A valid API key contains three sections, separated by two dots.
+
+Are you sure you want to use this key anyway?</value>
+  </data>
+  <data name="OnboardingApi_BtnTest_MessageBox6" xml:space="preserve">
+	  <value>The URI you have provided does not appear to be valid, a valid URI may look like either of the following:
+- http://homeassistant.local:8123
+- http://192.168.0.1:8123
+
+Are you sure you want to use this URI anyway?</value>
+  </data>
+  <data name="OnboardingDone_LblInfo6" xml:space="preserve">
+    <value>Currently, we (HASS.Agent Team maintaining the fork) do not accept donations in any form :)
+Please however feel free to donate to the original author of HASS.Agent - Sam! Wherever they currently are, cup of coffee might brighten their day.</value>
+  </data>
+  <data name="OnboardingDone_LblTip2" xml:space="preserve">
+    <value>Tip: Other donation methods are available on the About Window.</value>
+  </data>
+  <data name="OnboardingIntegrations_CbEnableMediaPlayer" xml:space="preserve">
+    <value>Enable &amp;Media Player (including text-to-speech)</value>
+  </data>
+  <data name="OnboardingIntegrations_CbEnableNotifications" xml:space="preserve">
+    <value>Enable &amp;Notifications</value>
+  </data>
+  <data name="OnboardingMqtt_CbEnableMqtt" xml:space="preserve">
+    <value>Enable MQTT</value>
+  </data>
+  <data name="PostUpdate_PostUpdate" xml:space="preserve">
+    <value>HASS.Agent Post Update</value>
+  </data>
+  <data name="SensorsManager_BluetoothDevicesSensorDescription" xml:space="preserve">
+	  <value>Provides a sensor with the amount of bluetooth devices found.
+
+The devices and their connected state are added as attributes.</value>
+  </data>
+  <data name="SensorsManager_BluetoothLeDevicesSensorDescription" xml:space="preserve">
+	  <value>Provides a sensors with the amount of bluetooth LE devices found.
+
+The devices and their connected state are added as attributes.
+
+Only shows devices that were seen since the last report, ie. when the sensor publishes, the list clears.</value>
+  </data>
+  <data name="SensorsManager_GeoLocationSensorDescription" xml:space="preserve">
+	  <value>Returns your current latitude, longitude and altitude as a comma-seperated value.
+
+Make sure Windows' location services are enabled!
+
+Depending on your Windows version, this can be found in the new control panel -&gt; 'privacy and security' -&gt; 'location'.</value>
+  </data>
+  <data name="SensorsManager_MonitorPowerStateSensorDescription" xml:space="preserve">
+	  <value>Provides the last monitor power state change:
+
+Dimmed, PowerOff, PowerOn and Unkown.</value>
+  </data>
+  <data name="SensorsManager_PowershellSensorDescription" xml:space="preserve">
+	  <value>Returns the result of the provided Powershell command or script.
+Note: please keep in mind that Home Assistant accepts payload up to 255 characters.
+
+Converts the outcome to text.</value>
+  </data>
+  <data name="SensorsManager_PrintersSensorsDescription" xml:space="preserve">
+    <value>Provides information about all installed printers and their queues.</value>
+  </data>
+  <data name="SensorsManager_WebcamProcessSensorDescription" xml:space="preserve">
+	  <value>Provides the name of the process that's currently using the webcam.
+
+Note: if used in the satellite service, it won't detect userspace applications.</value>
+  </data>
+  <data name="SensorsManager_WindowStateSensorDescription" xml:space="preserve">
+	  <value>Provides the current state of the process' window:
+
+Hidden, Maximized, Minimized, Normal and Unknown.</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_Powershell" xml:space="preserve">
+    <value>powershell command or script</value>
+  </data>
+  <data name="SensorsMod_MessageBox_Sanitize" xml:space="preserve">
+	  <value>The name you provided contains unsupported characters and won't work. The suggested version is:
+
+{0}
+
+Do you want to use this version?</value>
+  </data>
+  <data name="SensorsMod_SensorsMod_BtnTest_Powershell" xml:space="preserve">
+    <value>Test Command/Script</value>
+  </data>
+  <data name="SensorsMod_TestPowershell_MessageBox1" xml:space="preserve">
+    <value>Please enter a command or script!</value>
+  </data>
+  <data name="SensorsMod_TestPowershell_MessageBox2" xml:space="preserve">
+	  <value>Test succesfully executed, result value:
+
+{0}</value>
+  </data>
+  <data name="SensorsMod_TestPowershell_MessageBox3" xml:space="preserve">
+	  <value>The test failed to execute:
+
+{0}
+
+Do you want to open the logs folder?</value>
+  </data>
+  <data name="SensorType_BluetoothDevicesSensor" xml:space="preserve">
+    <value>BluetoothDevices</value>
+  </data>
+  <data name="SensorType_BluetoothLeDevicesSensor" xml:space="preserve">
+    <value>BluetoothLeDevices</value>
+  </data>
+  <data name="ServiceControllerManager_Error_Fatal" xml:space="preserve">
+    <value>Fatal error, please check logs for information!</value>
+  </data>
+  <data name="ServiceControllerManager_Error_Timeout" xml:space="preserve">
+    <value>Timeout expired</value>
+  </data>
+  <data name="ServiceControllerManager_Error_Unknown" xml:space="preserve">
+    <value>unknown reason</value>
+  </data>
+  <data name="ServiceHelper_ChangeStartMode_Error1" xml:space="preserve">
+    <value>unable to open Service Manager</value>
+  </data>
+  <data name="ServiceHelper_ChangeStartMode_Error2" xml:space="preserve">
+    <value>unable to open service</value>
+  </data>
+  <data name="ServiceHelper_ChangeStartMode_Error3" xml:space="preserve">
+    <value>Error configuring startup mode, please check the logs for more information.</value>
+  </data>
+  <data name="ServiceHelper_ChangeStartMode_Error4" xml:space="preserve">
+    <value>Error setting startup mode, please check the logs for more information.</value>
+  </data>
+  <data name="WebView_InitializeAsync_MessageBox1" xml:space="preserve">
+	  <value>Microsoft's WebView2 runtime isn't found on your machine. Usually this is handled by the installer, but you can install it manually.
+
+Do you want to download the runtime installer?</value>
+  </data>
+  <data name="WebView_InitializeAsync_MessageBox2" xml:space="preserve">
+    <value>Something went wrong while initializing the WebView! Please check your logs and open a GitHub issue for further assistance.</value>
+  </data>
+  <data name="QuickActionsMod_ClmDomain" xml:space="preserve">
+	  <value>domain</value>
+  </data>
+  <data name="CommandsManager_SwitchDesktopCommandDescription" xml:space="preserve">
+    <value>Activates provided Virtual Desktop. Desktop ID can be retrieved from the "ActiveDesktop" sensor.</value>
+  </data>
+  <data name="SensorsManager_ActiveDesktopSensorDescription" xml:space="preserve">
+    <value>Provides the ID of the currently active virtual desktop.</value>
+  </data>
+  <data name="CommandsManager_RadioCommandDescription" xml:space="preserve">
+    <value>Switches selected radio device on/off. Availability of radio devices depends on the device HASS.Agent is installed on.</value>
+  </data>
+  <data name="CommandType_RadioCommand" xml:space="preserve">
+    <value>RadioCommand</value>
+  </data>
+  <data name="CommandsMod_LblSetting_Radio" xml:space="preserve">
+    <value>Radio device</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox11" xml:space="preserve">
+    <value>Please select radio device!</value>
+  </data>
+  <data name="SensorsManager_InternalDeviceSensorDescription" xml:space="preserve">
+    <value>Provides data from the internal device sensor.
+Availability of the sensor depends on the device, in some cases no sensors will be available.</value>
+  </data>
+  <data name="SensorType_InternalDeviceSensor" xml:space="preserve">
+    <value>InternalDeviceSensor</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_InternalSensor" xml:space="preserve">
+    <value>Internal Sensor</value>
+  </data>
+  <data name="SensorsMod_None" xml:space="preserve">
+    <value>None</value>
+  </data>
+  <data name="SensorsMod_CbIgnoreAvailability" xml:space="preserve">
+    <value>&amp;Ignore availability</value>
+  </data>
+  <data name="SensorsMod_IgnoreAvailability_Info" xml:space="preserve">
+    <value>Please note that ignoring availability will cause Home Assistant to always display last value for a given sensor, even when HASS.Agent is offline.</value>
+  </data>
+  <data name="ConfigNotifications_CbNotificationsOpenActionUri" xml:space="preserve">
+    <value>&amp;Treat URI Action elements like Android Companion App (open)</value>
+  </data>
+  <data name="ConfigNotifications_TestNotification_No" xml:space="preserve">
+    <value>No</value>
+  </data>
+  <data name="ConfigNotifications_TestNotification_Yes" xml:space="preserve">
+    <value>Yes</value>
+  </data>
+  <data name="ConfigNotifications_TestNotification_InputText" xml:space="preserve">
+    <value>Notification Input Text</value>
+  </data>
+  <data name="ConfigNotifications_TestNotification_InputTitle" xml:space="preserve">
+    <value>Notification Input Title</value>
+  </data>
+  <data name="SensorsMod_BtnStore_DeviceNameInSensorName" xml:space="preserve">
+    <value>Device name in the sensor name might cause issues with Home Assistant versions starting with 2023.8.</value>
+  </data>
+  <data name="CommandsMod_BtnStore_DeviceNameInSensorName" xml:space="preserve">
+    <value>Device name in the command name might cause issues with Home Assistant versions starting with 2023.8.</value>
+  </data>
+  <data name="Compat_NameTask_Name" xml:space="preserve">
+    <value>Changing entity names
+to match Home Assistant 2023.8 requirements</value>
+  </data>
+  <data name="Compat_Error_CheckLogs" xml:space="preserve">
+    <value>Error, please check logs for more information.</value>
+  </data>
+  <data name="Compat_NameTask_Error_SingleValueSensors" xml:space="preserve">
+    <value>Error converting single value sensors!</value>
+  </data>
+  <data name="Compat_NameTask_Error_Commands" xml:space="preserve">
+    <value>Error converting commands!</value>
+  </data>
+  <data name="Compat_NameTask_Error_MultiValueSensors" xml:space="preserve">
+    <value>Error converting multi value sensors!</value>
+  </data>
+  <data name="SensorsMod_CbApplyRounding_LastActive" xml:space="preserve">
+    <value>Force action
+when system
+wakes from sleep/hibernation</value>
+  </data>
+  <data name="CommandsManager_SetApplicationVolumeCommandDescription" xml:space="preserve">
+    <value>Sets the volume and mute status of the provided application on provided audio device to the specified level.
+Command / payload needs to be in JSON format. Example of all possible options:
+{
+  "playbackDevice": "Speakers (THX Spatial Audio)",
+  "applicationName": "Discord",
+  "volume": 90,
+  "mute": true
+}
+
+If no "playbackDevice" is provided, HASS.Agent will use the default one.
+If no "volume" is provided, HASS.Agent will set only mute status.
+If no "mute" is provided, HASS.Agent will unmute the provided application.
+
+Advanced option: additional "sessionId" can be provided to set volume only for specific session of the application, session id can be obtained from "Audio Sessions" sensor:
+{
+   "playbackDevice":"Speakers (THX SpatialAudio)",
+   "applicationName":"Discord",
+   "volume":50,
+   "sessionid":"&lt;LONG SESSION ID FROM SENSOR&gt;"
+}Sets the volume and mute status of the provided application on provided audio device to the specified level.
+Command / payload needs to be in JSON format. Example of all possible options:
+{
+  "playbackDevice": "Speakers (THX Spatial Audio)",
+  "applicationName": "Discord",
+  "volume": 90,
+  "mute": true
+}
+
+If no "playbackDevice" is provided, HASS.Agent will use the default one.
+If no "volume" is provided, HASS.Agent will set only mute status.
+If no "mute" is provided, HASS.Agent will unmute the provided application.
+
+Advanced option: additional "sessionId" can be provided to set volume only for specific session of the application, session id can be obtained from "Audio Sessions" sensor:
+{
+   "playbackDevice":"Speakers (THX SpatialAudio)",
+   "applicationName":"Discord",
+   "volume":50,
+   "sessionid":"&lt;LONG SESSION ID FROM SENSOR&gt;"
+}</value>
+  </data>
+  <data name="CommandsMod_BtnStore_InvalidJson" xml:space="preserve">
+    <value>Please enter a valid JSON string!</value>
+  </data>
+  <data name="CommandsMod_BtnStore_VirtualDesktop_Unavailable" xml:space="preserve">
+    <value>Virtual Desktop management is unavailable on your machine.
+Usually this is due to the virtual desktop management library not being updated to support your version of Windows.</value>
+  </data>
+  <data name="Compat_MigrateTask_Name" xml:space="preserve">
+    <value>Migrating HASS.Agent configuration
+from the original version</value>
+  </data>
+  <data name="About_LblInfo2_1" xml:space="preserve">
+    <value>Updated and maintained with love by</value>
+  </data>
+  <data name="About_LblInfo4_1" xml:space="preserve">
+    <value>Even bigger 'thank you' for LAB02 Research and Sam for developing the original version of HASS.Agent - this would wouldn't exist without it!</value>
+  </data>
+  <data name="Compat_NameTask_Error_ServiceStart" xml:space="preserve">
+    <value>Error starting satellite service!</value>
+  </data>
+  <data name="Compat_NameTask_Error_ServiceCommunication" xml:space="preserve">
+    <value>Error communicating with the satellite service!</value>
+  </data>
+  <data name="CommandsManager_SetAudioOutputCommandDescription" xml:space="preserve">
+    <value>Sets the default audio output for the system.
+Requires audio device name as a payload.</value>
+  </data>
+  <data name="CommandsMod_LblSetting_AudioDeviceName" xml:space="preserve">
+    <value>Audio Device Name</value>
+  </data>
+  <data name="CommandsMod_LblSetting_JsonPayload" xml:space="preserve">
+    <value>JSON Command Payload</value>
+  </data>
+  <data name="CommandsMod_LblSetting_VolumeRange" xml:space="preserve">
+    <value>Volume (between 0 and 100)</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_ScreenNumber" xml:space="preserve">
+    <value>Screen number</value>
+  </data>
+  <data name="SensorsManager_ScreenshotSensorDescription" xml:space="preserve">
+    <value>Provides a screenshot sensor in form of a camera entity.
+Screen number depends on system configuration - starts at 0.</value>
+  </data>
+  <data name="CommandsManager_SetAudioInputCommandDescription" xml:space="preserve">
+    <value>Sets the default audio input for the system (including default communication device).
+Requires audio device name as a payload.</value>
+  </data>
+  <data name="ConfigMqtt_CbIgnoreGracePeriod" xml:space="preserve">
+    <value>Ignore grace period after waking up from hibernation</value>
+  </data>
+  <data name="ConfigTrayIcon_CbUseModernIcon" xml:space="preserve">
+    <value>Use modern tray icon</value>
+  </data>
+  <data name="SensorsManager_MicrophoneProcessSensorDescription" xml:space="preserve">
+    <value>Provides the number of the processes that currently use the microphone - additionally provides name of the processes in the sensor's attributes.
+
+Note: if used in the satellite service, it won't detect userspace applications.</value>
+  </data>
+  <data name="Configuration_NFC" xml:space="preserve">
+    <value>NFC</value>
+  </data>
+  <data name="SensorsMod_BtnAdvancedSettings" xml:space="preserve">
+    <value>Ad&amp;vanced Settings</value>
+  </data>
+  <data name="AdvancedSensorConfig_Warning" xml:space="preserve">
+    <value>Warning, adding following settings (overrides) may break the sensor, use with caution!</value>
+  </data>
+  <data name="AdvancedSensorConfig_LblDeviceClass" xml:space="preserve">
+    <value>Device class</value>
+  </data>
+  <data name="AdvancedSensorConfig_LblUnitOfMeasurement" xml:space="preserve">
+    <value>Unit of measurement</value>
+  </data>
+  <data name="AdvancedSensorConfig_LblStateClass" xml:space="preserve">
+    <value>State class</value>
+  </data>
+  <data name="AdvancedSensorConfig_Title" xml:space="preserve">
+    <value>Advanced Settings</value>
+  </data>
+  <data name="CommandsManager_TrayWebViewCommandDescription" xml:space="preserve">
+    <value>Shows / hides the Tray Icon Web View.
+Requires it to be configured in "Configuration -&gt; Tray Icon"</value>
+  </data>
+  <data name="HassAction_Trigger" xml:space="preserve">
+    <value>Trigger</value>
+  </data>
+  <data name="HassDomain_Button" xml:space="preserve">
+    <value>Button</value>
+  </data>
+  <data name="HassAction_Press" xml:space="preserve">
+    <value>Press</value>
+  </data>
+  <data name="Notification_Dismiss" xml:space="preserve">
+    <value>Dismiss</value>
+  </data>
+  <data name="Main_CheckForUpdateFailed_MessageBox1" xml:space="preserve">
+    <value>Failed checking for update!</value>
+  </data>
+  <data name="SensorType_NamedActiveWindowSensor" xml:space="preserve">
+    <value>NamedActiveWindow</value>
+  </data>
+  <data name="SensorsManager_NamedActiveWindowSensorDescription" xml:space="preserve">
+    <value>Provides an ON/OFF value based on whether the focused window name contains configured string.</value>
+  </data>
+  <data name="SensorsManager_AccentColorSensorDescription" xml:space="preserve">
+    <value>Provides #RRGGBB color values for system accent colors.
+Main accent color is the sensor value, additional accent colors are available as attributes.</value>
+  </data>
+  <data name="ConfigMqtt_CbUseWebSocket" xml:space="preserve">
+    <value>Use &amp;WebSocket</value>
+  </data>
+  <data name="ServiceMqtt_CbUseWebSocket" xml:space="preserve">
+    <value>Use &amp;WebSocket</value>
+  </data>
+  <data name="HassDomain_InputButton" xml:space="preserve">
+    <value>InputButton</value>
+  </data>
+  <data name="HassDomain_Fan" xml:space="preserve">
+    <value>Fan</value>
+  </data>
+  <data name="CommandsManager_WinformsSleepCommandDescription" xml:space="preserve">
+    <value>Puts the machine to sleep using WinForms API.
+
+Note: due to "Modern Sleep" the sleep commands might behave differently depending on the device OEM and OS configuration.</value>
+  </data>
+  <data name="CommandType_WinformsSleepCommand" xml:space="preserve">
+    <value>WinformsSleep</value>
+  </data>
+  <data name="OnboardingMqtt_BtnTest_MessageOk" xml:space="preserve">
+    <value>Connection OK!</value>
+  </data>
+  <data name="OnboardingMqtt_BtnTest_MessageError" xml:space="preserve">
+    <value>Unable to connect.</value>
+  </data>
+  <data name="CommandType_MonitorSleepPowerPlanCommand" xml:space="preserve">
+    <value>MonitorSleepPowerPlan</value>
+  </data>
+  <data name="CommandsManager_MonitorSleepPowerPlanCommandDescription" xml:space="preserve">
+    <value>Puts all monitors in sleep (low power) mode using alternative approach of power plan modification.
+Should provide better experience with new systems with "modern S0ix sleep" and not put the system to sleep.</value>
+  </data>
+</root>


### PR DESCRIPTION
- Register zh-CN in LocalizationManager supported culture list
- Add 49 .zh-CN.resx resource files (skeleton + translated entries)
- Translate Onboarding-3-API API token instructions

Note: main Languages.zh-CN.resx (965 strings) and Shared Languages.zh-CN.resx (917 strings) still contain English values pending translation.