### PR TITLE
Add Simplified Chinese (zh-CN) localization

### DIFF
--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.zh-CN.resx
@@ -1,0 +1,3289 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ConfigExternalTools_LblInfo1" xml:space="preserve">
+    <value>This page allows you to configure bindings with external tools.</value>
+  </data>
+  <data name="ConfigExternalTools_LblBrowserName" xml:space="preserve">
+    <value>Browser Name</value>
+  </data>
+  <data name="ConfigExternalTools_LblInfo2" xml:space="preserve">
+	  <value>By default HASS.Agent will launch URLs using your default browser. You can also configure
+a specific browser to be used instead along with launch arguments to run in private mode.</value>
+  </data>
+  <data name="ConfigExternalTools_LblBrowserBinary" xml:space="preserve">
+    <value>Browser Binary</value>
+  </data>
+  <data name="ConfigExternalTools_LblLaunchIncogArg" xml:space="preserve">
+    <value>Additional Launch Arguments</value>
+  </data>
+  <data name="ConfigExternalTools_LblCustomExecutorBinary" xml:space="preserve">
+    <value>Custom Executor Binary</value>
+  </data>
+  <data name="ConfigExternalTools_LblInfo3" xml:space="preserve">
+	  <value>You can configure the HASS.Agent to use a specific interpreter such as Perl or Python.
+Use the 'custom executor' command to launch this executor.</value>
+  </data>
+  <data name="ConfigExternalTools_LblCustomExecutorName" xml:space="preserve">
+    <value>Custom Executor Name</value>
+  </data>
+  <data name="ConfigExternalTools_LblTip1" xml:space="preserve">
+    <value>Tip: Double-click to Browse</value>
+  </data>
+  <data name="ConfigExternalTools_BtnExternalBrowserIncognitoTest" xml:space="preserve">
+    <value>&amp;Test</value>
+  </data>
+  <data name="ConfigGeneral_LblInfo4" xml:space="preserve">
+	  <value>HASS.Agent will wait a grace period before notifying you of disconnects from MQTT or HA's API.
+You can set the amount of seconds to wait in this grace period below.</value>
+  </data>
+  <data name="ConfigGeneral_LblDisconGraceSeconds" xml:space="preserve">
+    <value>Seconds</value>
+  </data>
+  <data name="ConfigGeneral_LblDisconGracePeriod" xml:space="preserve">
+    <value>Disconnected Grace &amp;Period</value>
+  </data>
+  <data name="ConfigGeneral_LblInfo3" xml:space="preserve">
+	  <value>IMPORTANT: if you change this value, HASS.Agent will unpublish all your sensors, commands and force a restart of itself so they can be republished under the new device name.
+Your automations and scripts will keep working.</value>
+  </data>
+  <data name="ConfigGeneral_LblInfo2" xml:space="preserve">
+	  <value>The device name is used to identify your machine on Home Assistant.
+It is also used as a prefix for your command/sensor names (this can be changed per entity).</value>
+  </data>
+  <data name="ConfigGeneral_LblInfo1" xml:space="preserve">
+    <value>This page contains general configuration settings, for more settings you can browse the tabs on the left.</value>
+  </data>
+  <data name="ConfigGeneral_LblDeviceName" xml:space="preserve">
+    <value>Device &amp;Name</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_LblTip1" xml:space="preserve">
+    <value>Tip: Double-click this field to browse</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_LblClientCertificate" xml:space="preserve">
+    <value>Client &amp;Certificate</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_CbHassAutoClientCertificate" xml:space="preserve">
+    <value>Use &amp;automatic client certificate selection</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_BtnTestApi" xml:space="preserve">
+    <value>&amp;Test Connection</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_LblInfo1" xml:space="preserve">
+	  <value>To learn which entities you have configured and to send quick actions, HASS.Agent uses
+Home Assistant's API.
+
+Please provide a long-lived access token and the address of your Home Assistant instance.
+You can get a token in Home Assistant by clicking your profile picture at the bottom-left
+and navigating to the bottom of the page until you see the 'CREATE TOKEN' button.</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_LblApiToken" xml:space="preserve">
+    <value>&amp;API Token</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_LblServerUri" xml:space="preserve">
+    <value>Server &amp;URI</value>
+  </data>
+  <data name="ConfigHotKey_BtnClearHotKey" xml:space="preserve">
+    <value>&amp;Clear</value>
+  </data>
+  <data name="ConfigHotKey_LblInfo1" xml:space="preserve">
+	  <value>An easy way to pull up your quick actions is to use a global hotkey.
+
+This way, whatever you're doing on your machine, you can always interact with Home Assistant.</value>
+  </data>
+  <data name="ConfigHotKey_CbEnableQuickActionsHotkey" xml:space="preserve">
+    <value>&amp;Enable Quick Actions Hotkey</value>
+  </data>
+  <data name="ConfigHotKey_LblHotkeyCombo" xml:space="preserve">
+    <value>&amp;Hotkey Combination</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearImageCache" xml:space="preserve">
+    <value>Clear Image Cache</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnOpenImageCache" xml:space="preserve">
+    <value>Open Folder</value>
+  </data>
+  <data name="ConfigLocalStorage_LblCacheLocations" xml:space="preserve">
+    <value>Image Cache Location</value>
+  </data>
+  <data name="ConfigLocalStorage_LblCacheDays" xml:space="preserve">
+    <value>days</value>
+  </data>
+  <data name="ConfigLocalStorage_LblInfo1" xml:space="preserve">
+	  <value>Some items like images shown in notifications have to be temporarily stored locally. You can
+configure the amount of days they should be kept before HASS.Agent deletes them.
+
+Enter '0' to keep them permanently.</value>
+  </data>
+  <data name="ConfigLogging_LblInfo1" xml:space="preserve">
+	  <value>Extended logging provides more verbose and in-depth logging, in case the default logging isn't
+sufficient. Please note that enabling this can cause the logfiles to grow large, and should only be
+used when you suspect something's wrong with HASS.Agent itself or when asked by the
+developers.</value>
+  </data>
+  <data name="ConfigLogging_CbExtendedLogging" xml:space="preserve">
+    <value>&amp;Enable Extended Logging</value>
+  </data>
+  <data name="ConfigLogging_BtnShowLogs" xml:space="preserve">
+    <value>&amp;Open Logs Folder</value>
+  </data>
+  <data name="ConfigMqtt_LblTip3" xml:space="preserve">
+    <value>Tip: Double-click these fields to browse</value>
+  </data>
+  <data name="ConfigMqtt_LblClientCert" xml:space="preserve">
+    <value>Client Certificate</value>
+  </data>
+  <data name="ConfigMqtt_LblRootCert" xml:space="preserve">
+    <value>Root Certificate</value>
+  </data>
+  <data name="ConfigMqtt_CbUseRetainFlag" xml:space="preserve">
+    <value>Use &amp;Retain Flag</value>
+  </data>
+  <data name="ConfigMqtt_CbAllowUntrustedCertificates" xml:space="preserve">
+    <value>&amp;Allow Untrusted Certificates</value>
+  </data>
+  <data name="ConfigMqtt_BtnMqttClearConfig" xml:space="preserve">
+    <value>&amp;Clear Configuration</value>
+  </data>
+  <data name="ConfigMqtt_LblTip1" xml:space="preserve">
+    <value>(leave default if unsure)</value>
+  </data>
+  <data name="ConfigMqtt_LblInfo1" xml:space="preserve">
+	  <value>Commands and sensors use MQTT, as well as notifications and media player functions when using the new integration. 
+
+Please provide credentials for your broker, if you're using the HA Mosquitto addon, you can probably use the preset address.
+
+Note: these settings (excluding the Client ID) will also be applied to the satellite service.</value>
+  </data>
+  <data name="ConfigMqtt_LblDiscoPrefix" xml:space="preserve">
+    <value>Discovery Prefix</value>
+  </data>
+  <data name="ConfigMqtt_LblBrokerPassword" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="ConfigMqtt_LblBrokerUsername" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="ConfigMqtt_LblBrokerPort" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="ConfigMqtt_LblBrokerIp" xml:space="preserve">
+    <value>Broker IP Address or Hostname</value>
+  </data>
+  <data name="ConfigMqtt_LblTip2" xml:space="preserve">
+    <value>(leave empty to auto generate)</value>
+  </data>
+  <data name="ConfigMqtt_LblClientId" xml:space="preserve">
+    <value>Client ID</value>
+  </data>
+  <data name="ConfigNotifications_LblInfo2" xml:space="preserve">
+	  <value>If something is not working, make sure you try the following steps:
+
+- Install the HASS.Agent integration
+- Restart Home Assistant
+- Make sure HASS.Agent is active with MQTT enabled!
+- Your device should get detected and added as an entity automatically
+- Optionally: manually add it using the local API</value>
+  </data>
+  <data name="ConfigNotifications_LblInfo1" xml:space="preserve">
+    <value>HASS.Agent can receive notifications from Home Assistant, using text, images and actions. If you have MQTT enabled, your device will automatically get added. Otherwise, manually configure the integration to use the local API.</value>
+  </data>
+  <data name="ConfigNotifications_BtnNotificationsReadme" xml:space="preserve">
+    <value>Notifications &amp;Documentation</value>
+  </data>
+  <data name="ConfigNotifications_LblPort" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="ConfigNotifications_CbAcceptNotifications" xml:space="preserve">
+    <value>&amp;Accept Notifications</value>
+  </data>
+  <data name="ConfigNotifications_BtnSendTestNotification" xml:space="preserve">
+    <value>Show Test Notification</value>
+  </data>
+  <data name="ConfigNotifications_BtnExecutePortReservation" xml:space="preserve">
+    <value>Execute Port Reservation</value>
+  </data>
+  <data name="ConfigNotifications_CbNotificationsIgnoreImageCertErrors" xml:space="preserve">
+    <value>&amp;Ignore certificate errors for images</value>
+  </data>
+  <data name="ConfigService_LblInfo1" xml:space="preserve">
+	  <value>The satellite service allows you to run sensors and commands even when no user's logged in. 
+Use the 'satellite service' button on the main window to manage it.</value>
+  </data>
+  <data name="ConfigService_LblServiceStatusInfo" xml:space="preserve">
+    <value>Service Status:</value>
+  </data>
+  <data name="ConfigService_BtnStartService" xml:space="preserve">
+    <value>S&amp;tart Service</value>
+  </data>
+  <data name="ConfigService_BtnDisableService" xml:space="preserve">
+    <value>&amp;Disable Service</value>
+  </data>
+  <data name="ConfigService_BtnStopService" xml:space="preserve">
+    <value>&amp;Stop Service</value>
+  </data>
+  <data name="ConfigService_BtnEnableService" xml:space="preserve">
+    <value>&amp;Enable Service</value>
+  </data>
+  <data name="ConfigService_BtnReinstallService" xml:space="preserve">
+    <value>&amp;Reinstall Service</value>
+  </data>
+  <data name="ConfigService_LblInfo2" xml:space="preserve">
+	  <value>If you do not configure the service, it won't do anything. However, you can still decide to disable it as well.
+The installer will leave the disabled service alone(if you remove the service, the installer will reinstall it).</value>
+  </data>
+  <data name="ConfigService_LblInfo3" xml:space="preserve">
+	  <value>You can try reinstalling the service if it's not working correctly.
+Your configuration and entities won't be removed.</value>
+  </data>
+  <data name="ConfigService_BtnShowLogs" xml:space="preserve">
+    <value>Open Service &amp;Logs Folder</value>
+  </data>
+  <data name="ConfigService_LblInfo4" xml:space="preserve">
+    <value>If the service still fails after reinstalling, please open a ticket and send the content of the latest log.</value>
+  </data>
+  <data name="ConfigStartup_LblInfo1" xml:space="preserve">
+	  <value>HASS.Agent can start when you login by creating an entry in your user profile's registry.
+
+Since HASS.Agent is user based, if you want to launch for another user, just install and config
+HASS.Agent there.</value>
+  </data>
+  <data name="ConfigStartup_BtnSetStartOnLogin" xml:space="preserve">
+    <value>&amp;Enable Start-on-Login</value>
+  </data>
+  <data name="ConfigStartup_LblStartOnLoginStatusInfo" xml:space="preserve">
+    <value>Start-on-Login Status:</value>
+  </data>
+  <data name="ConfigUpdates_CbBetaUpdates" xml:space="preserve">
+    <value>Notify me of &amp;beta releases</value>
+  </data>
+  <data name="ConfigUpdates_LblInfo2" xml:space="preserve">
+	  <value>When a new update is available, HASS.Agent can download the installer and launch it for you.
+
+The certificate of the downloaded file will get checked before running,you will still get to review the release notes and manually approve the update.</value>
+  </data>
+  <data name="ConfigUpdates_CbExecuteUpdater" xml:space="preserve">
+    <value>Automatically &amp;download future updates</value>
+  </data>
+  <data name="ConfigUpdates_LblInfo1" xml:space="preserve">
+	  <value>HASS.Agent checks for updates in the background if enabled.
+
+You will be sent a push notification if a new update is discovered, letting you know a
+new version is ready to be installed.</value>
+  </data>
+  <data name="ConfigUpdates_CbUpdates" xml:space="preserve">
+    <value>Notify me when a new &amp;release is available</value>
+  </data>
+  <data name="OnboardingWelcome_LblInfo1" xml:space="preserve">
+	  <value>Welcome to the HASS.Agent! It looks like this is the first time you are launching the agent.
+
+To assist you with a first time setup, proceed with the configuration steps below
+or alternatively, click 'Close'.</value>
+  </data>
+  <data name="OnboardingWelcome_LblInfo2" xml:space="preserve">
+    <value>The device name is used to identify your machine on Home Assistant, it is also used as a suggested prefix for your commands and sensors.</value>
+  </data>
+  <data name="OnboardingWelcome_LblDeviceName" xml:space="preserve">
+    <value>Device &amp;Name</value>
+  </data>
+  <data name="OnboardingStartup_BtnSetLaunchOnLogin" xml:space="preserve">
+    <value>Yes, &amp;start HASS.Agent on System Login</value>
+  </data>
+  <data name="OnboardingStartup_LblInfo1" xml:space="preserve">
+	  <value>HASS.Agent can start with your system, this allows for any sensors and data transmission between your device and Home Assistant to begin as soon as you login.
+
+This setting can be changed any time later in the HASS.Agent configuration window.</value>
+  </data>
+  <data name="OnboardingStartup_LblCreateInfo" xml:space="preserve">
+    <value>Fetching current state, please wait..</value>
+  </data>
+  <data name="OnboardingNotifications_LblTip1" xml:space="preserve">
+    <value>Note: 5115 is the default port, only change it if you changed it in Home Assistant.</value>
+  </data>
+  <data name="OnboardingNotifications_CbAcceptNotifications" xml:space="preserve">
+    <value>Yes, accept notifications on port</value>
+  </data>
+  <data name="OnboardingNotifications_LblInfo1" xml:space="preserve">
+	  <value>HASS.Agent can receive notifications from Home Assistant, using text and/or images.
+
+Do you want to enable this function?</value>
+  </data>
+  <data name="OnboardingIntegration_LblIntegration" xml:space="preserve">
+    <value>HASS.Agent-Notifier GitHub Page</value>
+  </data>
+  <data name="OnboardingIntegration_LblInfo2" xml:space="preserve">
+	  <value>Make sure you follow these steps:
+
+- Install HASS.Agent-Notifier integration
+- Restart Home Assistant
+- Configure a notifier entity
+- Restart Home Assistant</value>
+  </data>
+  <data name="OnboardingIntegration_LblInfo1" xml:space="preserve">
+	  <value>To use notifications, you need to install and configure the HASS.Agent-notifier integration in
+Home Assistant.
+
+This is very easy using HACS but may also be installed manually, visit the link below for more
+information.</value>
+  </data>
+  <data name="OnboardingApi_LblApiToken" xml:space="preserve">
+    <value>API &amp;Token</value>
+  </data>
+  <data name="OnboardingApi_LblServerUri" xml:space="preserve">
+    <value>Server &amp;URI (should be ok like this)</value>
+  </data>
+  <data name="OnboardingApi_LblInfo1" xml:space="preserve">
+	  <value>To learn which entities you have configured and to send quick actions, HASS.Agent uses
+Home Assistant's API.
+
+Please provide a long-lived access token and the address of your Home Assistant instance.
+You can get a token in Home Assistant by clicking your profile picture at the bottom-left
+and navigating to the bottom of the page until you see the 'CREATE TOKEN' button.</value>
+  </data>
+  <data name="OnboardingApi_BtnTest" xml:space="preserve">
+    <value>Test &amp;Connection</value>
+  </data>
+  <data name="OnboardingApi_LblTip1" xml:space="preserve">
+    <value>Tip: Specialized settings can be found in the Configuration Window.</value>
+  </data>
+  <data name="OnboardingMqtt_LblPassword" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="OnboardingMqtt_LblUsername" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="OnboardingMqtt_LblPort" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="OnboardingMqtt_LblIpAdress" xml:space="preserve">
+    <value>IP Address or Hostname</value>
+  </data>
+  <data name="OnboardingMqtt_LblInfo1" xml:space="preserve">
+	  <value>Commands and sensors are sent through MQTT. The notifications- and media player integration also make use of them.
+
+Tip: if you're using the HA addon, you can probably use the preset address - just provide credentials.
+</value>
+  </data>
+  <data name="OnboardingMqtt_LblDiscoveryPrefix" xml:space="preserve">
+    <value>Discovery Prefix</value>
+  </data>
+  <data name="OnboardingMqtt_LblTip1" xml:space="preserve">
+    <value>(leave default if not sure)</value>
+  </data>
+  <data name="OnboardingMqtt_LblTip2" xml:space="preserve">
+    <value>Tip: Specialized settings can be found in the Configuration Window.</value>
+  </data>
+  <data name="OnboardingHotKey_LblHotkeyCombo" xml:space="preserve">
+    <value>&amp;Hotkey Combination</value>
+  </data>
+  <data name="OnboardingHotKey_LblInfo1" xml:space="preserve">
+	  <value>An easy way to pull up your quick actions is to use a global hotkey.
+
+This way, whatever you're doing on your machine, you can always interact with Home Assistant.
+</value>
+  </data>
+  <data name="OnboardingHotKey_BtnClear" xml:space="preserve">
+    <value>&amp;Clear</value>
+  </data>
+  <data name="OnboardingUpdates_LblInfo1" xml:space="preserve">
+	  <value>HASS.Agent checks for updates in the background if enabled.
+
+You will be sent a push notification if a new update is discovered, letting you know a
+new version is ready to be installed.
+
+Do you want to enable this automatic update checks?</value>
+  </data>
+  <data name="OnboardingUpdates_CbNofityOnUpdate" xml:space="preserve">
+    <value>Yes, notify me on new &amp;updates</value>
+  </data>
+  <data name="OnboardingUpdates_CbExecuteUpdater" xml:space="preserve">
+    <value>Yes, &amp;download and launch the installer for me</value>
+  </data>
+  <data name="OnboardingUpdates_LblInfo2" xml:space="preserve">
+	  <value>When a new update is available, HASS.Agent can download the installer and launch it for you.
+
+The certificate of the downloaded file will get checked before running,you will still get to review the release notes and manually approve the update.</value>
+  </data>
+  <data name="OnboardingDone_LblGitHub" xml:space="preserve">
+    <value>HASS.Agent GitHub page</value>
+  </data>
+  <data name="OnboardingDone_LblInfo3" xml:space="preserve">
+	  <value>There's a lot more to tinker with, so make sure you take a look at the Configuration Window!
+
+
+Thank you for using HASS.Agent, hopefully it'll be useful for you :-)
+</value>
+  </data>
+  <data name="OnboardingDone_LblInfo2" xml:space="preserve">
+    <value>HASS.Agent will now restart to apply your configuration changes.</value>
+  </data>
+  <data name="OnboardingDone_LblInfo1" xml:space="preserve">
+    <value>Yay, done!</value>
+  </data>
+  <data name="ServiceCommands_LblLowIntegrity" xml:space="preserve">
+    <value>Low Integrity</value>
+  </data>
+  <data name="ServiceCommands_ClmName" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="ServiceCommands_ClmType" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="ServiceCommands_BtnRemove" xml:space="preserve">
+    <value>&amp;Remove</value>
+  </data>
+  <data name="ServiceCommands_BtnModify" xml:space="preserve">
+    <value>&amp;Modify</value>
+  </data>
+  <data name="ServiceCommands_BtnAdd" xml:space="preserve">
+    <value>&amp;Add New</value>
+  </data>
+  <data name="ServiceCommands_BtnStore" xml:space="preserve">
+    <value>&amp;Send &amp;&amp; Activate Commands</value>
+  </data>
+  <data name="ServiceCommands_LblStored" xml:space="preserve">
+    <value>commands stored!</value>
+  </data>
+  <data name="ServiceConnect_BtnRetryAuthId" xml:space="preserve">
+    <value>&amp;Apply</value>
+  </data>
+  <data name="ServiceConnect_LblRetryAuthId" xml:space="preserve">
+    <value>Auth &amp;ID</value>
+  </data>
+  <data name="ServiceConnect_LblAuthenticate" xml:space="preserve">
+    <value>Authenticate</value>
+  </data>
+  <data name="ServiceConnect_LblConnect" xml:space="preserve">
+    <value>Connect with service</value>
+  </data>
+  <data name="ServiceConnect_LblLoading" xml:space="preserve">
+    <value>Connecting satellite service, please wait..</value>
+  </data>
+  <data name="ServiceConnect_LblFetchConfig" xml:space="preserve">
+    <value>Fetch Configuration</value>
+  </data>
+  <data name="ServiceGeneral_LblInfo1" xml:space="preserve">
+    <value>This page contains general configuration settings, for MQTT settings, commands, and sensors, browse the different tabs above.</value>
+  </data>
+  <data name="ServiceGeneral_LblAuthId" xml:space="preserve">
+    <value>Auth &amp;ID</value>
+  </data>
+  <data name="ServiceGeneral_LblDeviceName" xml:space="preserve">
+    <value>Device &amp;Name</value>
+  </data>
+  <data name="ServiceGeneral_LblTip1" xml:space="preserve">
+    <value>Tip: Double-click these fields to browse</value>
+  </data>
+  <data name="ServiceGeneral_LblCustomExecBinary" xml:space="preserve">
+    <value>Custom Executor &amp;Binary</value>
+  </data>
+  <data name="ServiceGeneral_LblCustomExecName" xml:space="preserve">
+    <value>Custom &amp;Executor Name</value>
+  </data>
+  <data name="ServiceGeneral_LblSeconds" xml:space="preserve">
+    <value>seconds</value>
+  </data>
+  <data name="ServiceGeneral_LblDisconGrace" xml:space="preserve">
+    <value>Disconnected Grace &amp;Period</value>
+  </data>
+  <data name="ServiceGeneral_Apply" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="ServiceGeneral_LblVersionInfo" xml:space="preserve">
+    <value>Version</value>
+  </data>
+  <data name="ServiceGeneral_LblTip2" xml:space="preserve">
+    <value>Tip: Double-click to generate random</value>
+  </data>
+  <data name="ServiceGeneral_Stored" xml:space="preserve">
+    <value>Stored!</value>
+  </data>
+  <data name="ServiceMqtt_LblTip2" xml:space="preserve">
+    <value>(leave empty to auto generate)</value>
+  </data>
+  <data name="ServiceMqtt_LblClientId" xml:space="preserve">
+    <value>Client ID</value>
+  </data>
+  <data name="ServiceMqtt_LblTip3" xml:space="preserve">
+    <value>Tip: Double-click these fields to browse</value>
+  </data>
+  <data name="ServiceMqtt_LblClientCert" xml:space="preserve">
+    <value>Client Certificate</value>
+  </data>
+  <data name="ServiceMqtt_LblRootCert" xml:space="preserve">
+    <value>Root Certificate</value>
+  </data>
+  <data name="ServiceMqtt_CbUseRetainFlag" xml:space="preserve">
+    <value>Use &amp;Retain Flag</value>
+  </data>
+  <data name="ServiceMqtt_CbAllowUntrustedCertificates" xml:space="preserve">
+    <value>&amp;Allow Untrusted Certificates</value>
+  </data>
+  <data name="ServiceMqtt_BtnMqttClearConfig" xml:space="preserve">
+    <value>&amp;Clear Configuration</value>
+  </data>
+  <data name="ServiceMqtt_LblTip1" xml:space="preserve">
+    <value>(leave default if not sure)</value>
+  </data>
+  <data name="ServiceMqtt_LblInfo1" xml:space="preserve">
+	  <value>Commands and sensors are sent through MQTT. Please provide credentials for your server. If you're using the HA addon,
+you can probably use the preset address.</value>
+  </data>
+  <data name="ServiceMqtt_LblDiscoPrefix" xml:space="preserve">
+    <value>Discovery Prefix</value>
+  </data>
+  <data name="ServiceMqtt_LblBrokerPassword" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="ServiceMqtt_LblBrokerUsername" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="ServiceMqtt_LblBrokerPort" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="ServiceMqtt_LblBrokerIp" xml:space="preserve">
+    <value>Broker IP Address or Hostname</value>
+  </data>
+  <data name="ServiceMqtt_BtnStore" xml:space="preserve">
+    <value>&amp;Send &amp;&amp; Activate Configuration</value>
+  </data>
+  <data name="ServiceMqtt_BtnCopy" xml:space="preserve">
+    <value>Copy from &amp;HASS.Agent</value>
+  </data>
+  <data name="ServiceMqtt_LblStored" xml:space="preserve">
+    <value>Configuration stored!</value>
+  </data>
+  <data name="ServiceMqtt_LblStatusInfo" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="ServiceMqtt_LblStatus" xml:space="preserve">
+    <value>Querying..</value>
+  </data>
+  <data name="ServiceSensors_ClmName" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="ServiceSensors_ClmType" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="ServiceSensors_LblRefresh" xml:space="preserve">
+    <value>Refresh</value>
+  </data>
+  <data name="ServiceSensors_BtnRemove" xml:space="preserve">
+    <value>&amp;Remove</value>
+  </data>
+  <data name="ServiceSensors_BtnAdd" xml:space="preserve">
+    <value>&amp;Add New</value>
+  </data>
+  <data name="ServiceSensors_BtnModify" xml:space="preserve">
+    <value>&amp;Modify</value>
+  </data>
+  <data name="ServiceSensors_BtnStore" xml:space="preserve">
+    <value>&amp;Send &amp;&amp; Activate Sensors</value>
+  </data>
+  <data name="ServiceSensors_LblStored" xml:space="preserve">
+    <value>Sensors stored!</value>
+  </data>
+  <data name="PortReservation_LblInfo1" xml:space="preserve">
+    <value>Please wait a bit while the task is performed ..</value>
+  </data>
+  <data name="PortReservation_LblTask1" xml:space="preserve">
+    <value>Create API Port Binding</value>
+  </data>
+  <data name="PortReservation_LblTask2" xml:space="preserve">
+    <value>Set Firewall Rule</value>
+  </data>
+  <data name="PortReservation_Title" xml:space="preserve">
+    <value>HASS.Agent Port Reservation</value>
+  </data>
+  <data name="PostUpdate_LblInfo1" xml:space="preserve">
+    <value>Please wait a bit while some post-update tasks are performed ..</value>
+  </data>
+  <data name="PostUpdate_LblTask1" xml:space="preserve">
+    <value>Configuring Satellite Service</value>
+  </data>
+  <data name="PostUpdate_LblTask2" xml:space="preserve">
+    <value>Create API Port Binding</value>
+  </data>
+  <data name="PostUpdate_Title" xml:space="preserve">
+    <value>HASS.Agent Post Update</value>
+  </data>
+  <data name="Restart_LblInfo1" xml:space="preserve">
+    <value>Please wait while HASS.Agent restarts..</value>
+  </data>
+  <data name="Restart_LblTask1" xml:space="preserve">
+    <value>Waiting for previous instance to close..</value>
+  </data>
+  <data name="Restart_LblTask2" xml:space="preserve">
+    <value>Relaunch HASS.Agent</value>
+  </data>
+  <data name="Restart_Title" xml:space="preserve">
+    <value>HASS.Agent Restarter</value>
+  </data>
+  <data name="ServiceReinstall_LblInfo1" xml:space="preserve">
+    <value>Please wait while the satellite service is re-installed..</value>
+  </data>
+  <data name="ServiceReinstall_LblTask1" xml:space="preserve">
+    <value>Remove Satellite Service</value>
+  </data>
+  <data name="ServiceReinstall_LblTask2" xml:space="preserve">
+    <value>Install Satellite Service</value>
+  </data>
+  <data name="ServiceReinstall_Title" xml:space="preserve">
+    <value>HASS.Agent Reinstall Satellite Service</value>
+  </data>
+  <data name="ServiceSetState_LblInfo1" xml:space="preserve">
+    <value>Please wait while the satellite service is configured..</value>
+  </data>
+  <data name="ServiceSetState_LblTask1" xml:space="preserve">
+    <value>Enable Satellite Service</value>
+  </data>
+  <data name="ServiceSetState_Title" xml:space="preserve">
+    <value>HASS.Agent Configure Satellite Service</value>
+  </data>
+  <data name="CommandMqttTopic_BtnClose" xml:space="preserve">
+    <value>&amp;Close</value>
+  </data>
+  <data name="CommandMqttTopic_LblInfo1" xml:space="preserve">
+    <value>This is the MQTT topic on which you can publish action commands:</value>
+  </data>
+  <data name="CommandMqttTopic_BtnCopyClipboard" xml:space="preserve">
+    <value>Copy &amp;to Clipboard</value>
+  </data>
+  <data name="CommandMqttTopic_LblHelp" xml:space="preserve">
+    <value>help and examples</value>
+  </data>
+  <data name="CommandMqttTopic_Title" xml:space="preserve">
+    <value>MQTT Action Topic</value>
+  </data>
+  <data name="CommandsConfig_BtnRemove" xml:space="preserve">
+    <value>&amp;Remove</value>
+  </data>
+  <data name="CommandsConfig_BtnModify" xml:space="preserve">
+    <value>&amp;Modify</value>
+  </data>
+  <data name="CommandsConfig_BtnAdd" xml:space="preserve">
+    <value>&amp;Add New</value>
+  </data>
+  <data name="CommandsConfig_BtnStore" xml:space="preserve">
+    <value>&amp;Store and Activate Commands</value>
+  </data>
+  <data name="CommandsConfig_ClmName" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="CommandsConfig_ClmType" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="CommandsConfig_LblLowIntegrity" xml:space="preserve">
+    <value>Low Integrity</value>
+  </data>
+  <data name="CommandsConfig_LblActionInfo" xml:space="preserve">
+    <value>Action</value>
+  </data>
+  <data name="CommandsConfig_Title" xml:space="preserve">
+    <value>Commands Config</value>
+  </data>
+  <data name="CommandsMod_BtnStore" xml:space="preserve">
+    <value>&amp;Store Command</value>
+  </data>
+  <data name="CommandsMod_LblSetting" xml:space="preserve">
+    <value>&amp;Configuration</value>
+  </data>
+  <data name="CommandsMod_LblName" xml:space="preserve">
+    <value>&amp;Name</value>
+  </data>
+  <data name="CommandsMod_LblDescription" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="CommandsMod_CbRunAsLowIntegrity" xml:space="preserve">
+    <value>&amp;Run as 'Low Integrity'</value>
+  </data>
+  <data name="CommandsMod_LblIntegrityInfo" xml:space="preserve">
+    <value>What's this?</value>
+  </data>
+  <data name="CommandsMod_ClmSensorName" xml:space="preserve">
+    <value>  Type</value>
+  </data>
+  <data name="CommandsMod_LblSelectedType" xml:space="preserve">
+    <value>Selected Type</value>
+  </data>
+  <data name="CommandsMod_LblService" xml:space="preserve">
+    <value>Service</value>
+  </data>
+  <data name="CommandsMod_LblAgent" xml:space="preserve">
+    <value>agent</value>
+  </data>
+  <data name="CommandsMod_LblSpecificClient" xml:space="preserve">
+    <value>HASS.Agent only!</value>
+  </data>
+  <data name="CommandsMod_LblEntityType" xml:space="preserve">
+    <value>&amp;Entity Type</value>
+  </data>
+  <data name="CommandsMod_LblMqttTopic" xml:space="preserve">
+    <value>Show MQTT Action Topic</value>
+  </data>
+  <data name="CommandsMod_LblActionInfo" xml:space="preserve">
+    <value>Action</value>
+  </data>
+  <data name="CommandsMod_Title" xml:space="preserve">
+    <value>Command</value>
+  </data>
+  <data name="QuickActions_LblLoading" xml:space="preserve">
+    <value>Retrieving entities, please wait..</value>
+  </data>
+  <data name="QuickActions_Title" xml:space="preserve">
+    <value>Quick Actions</value>
+  </data>
+  <data name="QuickActionsConfig_BtnStore" xml:space="preserve">
+    <value>&amp;Store Quick Actions</value>
+  </data>
+  <data name="QuickActionsConfig_BtnAdd" xml:space="preserve">
+    <value>&amp;Add New</value>
+  </data>
+  <data name="QuickActionsConfig_BtnModify" xml:space="preserve">
+    <value>&amp;Modify</value>
+  </data>
+  <data name="QuickActionsConfig_BtnRemove" xml:space="preserve">
+    <value>&amp;Remove</value>
+  </data>
+  <data name="QuickActionsConfig_BtnPreview" xml:space="preserve">
+    <value>&amp;Preview</value>
+  </data>
+  <data name="QuickActionsConfig_ClmDomain" xml:space="preserve">
+    <value>Domain</value>
+  </data>
+  <data name="QuickActionsConfig_ClmEntity" xml:space="preserve">
+    <value>Entity</value>
+  </data>
+  <data name="QuickActionsConfig_ClmAction" xml:space="preserve">
+    <value>Action</value>
+  </data>
+  <data name="QuickActionsConfig_ClmHotKey" xml:space="preserve">
+    <value>Hotkey</value>
+  </data>
+  <data name="QuickActionsConfig_ClmDescription" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="QuickActionsConfig_LblHotkey" xml:space="preserve">
+	  <value>Hotkey Enabled</value>
+  </data>
+  <data name="QuickActionsConfig_Title" xml:space="preserve">
+    <value>Quick Actions Configuration</value>
+  </data>
+  <data name="QuickActionsMod_BtnStore" xml:space="preserve">
+    <value>&amp;Store Quick Action</value>
+  </data>
+  <data name="QuickActionsMod_LblDomain" xml:space="preserve">
+    <value>Domain</value>
+  </data>
+  <data name="QuickActionsMod_LblEntityInfo" xml:space="preserve">
+    <value>&amp;Entity</value>
+  </data>
+  <data name="QuickActionsMod_LblAction" xml:space="preserve">
+    <value>Desired &amp;Action</value>
+  </data>
+  <data name="QuickActionsMod_LblDescription" xml:space="preserve">
+    <value>&amp;Description</value>
+  </data>
+  <data name="QuickActionsMod_LblLoading" xml:space="preserve">
+    <value>Retrieving entities, please wait..</value>
+  </data>
+  <data name="QuickActionsMod_CbEnableHotkey" xml:space="preserve">
+    <value>enable hotkey</value>
+  </data>
+  <data name="QuickActionsMod_LblHotkey" xml:space="preserve">
+    <value>&amp;hotkey combination</value>
+  </data>
+  <data name="QuickActionsMod_LblTip1" xml:space="preserve">
+    <value>(optional, will be used instead of entity name)</value>
+  </data>
+  <data name="QuickActionsMod_Title" xml:space="preserve">
+    <value>Quick Action</value>
+  </data>
+  <data name="SensorsConfig_BtnRemove" xml:space="preserve">
+    <value>&amp;Remove</value>
+  </data>
+  <data name="SensorsConfig_BtnModify" xml:space="preserve">
+    <value>&amp;Modify</value>
+  </data>
+  <data name="SensorsConfig_BtnAdd" xml:space="preserve">
+    <value>&amp;Add New</value>
+  </data>
+  <data name="SensorsConfig_BtnStore" xml:space="preserve">
+    <value>&amp;Store &amp;&amp; Activate Sensors</value>
+  </data>
+  <data name="SensorsConfig_ClmName" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="SensorsConfig_ClmType" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="SensorsConfig_LblRefresh" xml:space="preserve">
+    <value>Refresh</value>
+  </data>
+  <data name="SensorsConfig_Title" xml:space="preserve">
+    <value>Sensors Configuration</value>
+  </data>
+  <data name="SensorsMod_BtnStore" xml:space="preserve">
+    <value>&amp;Store Sensor</value>
+  </data>
+  <data name="SensorsMod_LblSetting1" xml:space="preserve">
+    <value>setting 1</value>
+  </data>
+  <data name="SensorsMod_LblType" xml:space="preserve">
+    <value>Selected Type</value>
+  </data>
+  <data name="SensorsMod_LblName" xml:space="preserve">
+    <value>&amp;Name</value>
+  </data>
+  <data name="SensorsMod_LblUpdate" xml:space="preserve">
+    <value>&amp;Update every</value>
+  </data>
+  <data name="SensorsMod_LblSeconds" xml:space="preserve">
+    <value>seconds</value>
+  </data>
+  <data name="SensorsMod_LblDescription" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="SensorsMod_LblSetting2" xml:space="preserve">
+    <value>Setting 2</value>
+  </data>
+  <data name="SensorsMod_LblSetting3" xml:space="preserve">
+    <value>Setting 3</value>
+  </data>
+  <data name="SensorsMod_ClmSensorName" xml:space="preserve">
+    <value>  Type</value>
+  </data>
+  <data name="SensorsMod_LblMultiValue" xml:space="preserve">
+	  <value>Multivalue</value>
+  </data>
+  <data name="SensorsMod_LblAgent" xml:space="preserve">
+    <value>Agent</value>
+  </data>
+  <data name="SensorsMod_LblService" xml:space="preserve">
+    <value>Service</value>
+  </data>
+  <data name="SensorsMod_LblSpecificClient" xml:space="preserve">
+    <value>HASS.Agent only!</value>
+  </data>
+  <data name="SensorsMod_Title" xml:space="preserve">
+    <value>Sensor</value>
+  </data>
+  <data name="ServiceConfig_TabGeneral" xml:space="preserve">
+    <value>     General     </value>
+  </data>
+  <data name="ServiceConfig_TabMqtt" xml:space="preserve">
+    <value>     MQTT     </value>
+  </data>
+  <data name="ServiceConfig_TabCommands" xml:space="preserve">
+    <value>     Commands     </value>
+  </data>
+  <data name="ServiceConfig_TabSensors" xml:space="preserve">
+    <value>     Sensors     </value>
+  </data>
+  <data name="ServiceConfig_Title" xml:space="preserve">
+    <value>Satellite Service Configuration</value>
+  </data>
+  <data name="About_BtnClose" xml:space="preserve">
+    <value>&amp;Close</value>
+  </data>
+  <data name="About_LblInfo1" xml:space="preserve">
+    <value>A Windows-based client for the Home Assistant platform.</value>
+  </data>
+  <data name="About_LblInfo3" xml:space="preserve">
+	  <value>This application is open source and completely free, please check the project pages of 
+the used components for their individual licenses:</value>
+  </data>
+  <data name="About_LblInfo4" xml:space="preserve">
+	  <value>A big 'thank you' to the developers of these projects, who were kind enough to share
+their hard work with the rest of us mere mortals. </value>
+  </data>
+  <data name="About_LblInfo5" xml:space="preserve">
+	  <value>And of course; thanks to Paulus Shoutsen and the entire team of developers that 
+created and maintain Home Assistant :-)</value>
+  </data>
+  <data name="About_LblInfo2" xml:space="preserve">
+    <value>Created with love by</value>
+  </data>
+  <data name="About_LblInfo6" xml:space="preserve">
+    <value>Like this tool? Support us (read: keep us awake) by buying a cup of coffee:</value>
+  </data>
+  <data name="About_Title" xml:space="preserve">
+    <value>About</value>
+  </data>
+  <data name="Configuration_TabGeneral" xml:space="preserve">
+    <value>General</value>
+  </data>
+  <data name="Configuration_TabExternalTools" xml:space="preserve">
+    <value>External Tools</value>
+  </data>
+  <data name="Configuration_TabHassApi" xml:space="preserve">
+    <value>Home Assistant API</value>
+  </data>
+  <data name="Configuration_TabHotKey" xml:space="preserve">
+    <value>Hotkey</value>
+  </data>
+  <data name="Configuration_TabLocalStorage" xml:space="preserve">
+    <value>Local Storage</value>
+  </data>
+  <data name="Configuration_TabLogging" xml:space="preserve">
+    <value>Logging</value>
+  </data>
+  <data name="Configuration_TabMQTT" xml:space="preserve">
+    <value>MQTT</value>
+  </data>
+  <data name="Configuration_TabNotifications" xml:space="preserve">
+    <value>Notifications</value>
+  </data>
+  <data name="Configuration_TabService" xml:space="preserve">
+    <value>Satellite Service</value>
+  </data>
+  <data name="Configuration_TabStartup" xml:space="preserve">
+    <value>Startup</value>
+  </data>
+  <data name="Configuration_TabUpdates" xml:space="preserve">
+    <value>Updates</value>
+  </data>
+  <data name="Configuration_BtnAbout" xml:space="preserve">
+    <value>&amp;About</value>
+  </data>
+  <data name="Configuration_BtnHelp" xml:space="preserve">
+    <value>&amp;Help &amp;&amp; Contact</value>
+  </data>
+  <data name="Configuration_BtnStore" xml:space="preserve">
+    <value>&amp;Save Configuration</value>
+  </data>
+  <data name="Configuration_BtnClose" xml:space="preserve">
+    <value>Close &amp;Without Saving</value>
+  </data>
+  <data name="Configuration_Title" xml:space="preserve">
+    <value>Configuration</value>
+  </data>
+  <data name="ExitDialog_LblInfo1" xml:space="preserve">
+    <value>What would you like to do?</value>
+  </data>
+  <data name="ExitDialog_BtnRestart" xml:space="preserve">
+    <value>&amp;Restart</value>
+  </data>
+  <data name="ExitDialog_BtnHide" xml:space="preserve">
+    <value>&amp;Hide</value>
+  </data>
+  <data name="ExitDialog_BtnExit" xml:space="preserve">
+    <value>&amp;Exit</value>
+  </data>
+  <data name="ExitDialog_Title" xml:space="preserve">
+    <value>Exit Dialog</value>
+  </data>
+  <data name="Help_BtnClose" xml:space="preserve">
+    <value>&amp;Close</value>
+  </data>
+  <data name="Help_LblInfo1" xml:space="preserve">
+	  <value>If you are having trouble with HASS.Agent and require support
+with any sensors, commands, or for general support and feedback,
+there are few ways you can reach us:</value>
+  </data>
+  <data name="Help_LblAbout" xml:space="preserve">
+    <value>About</value>
+  </data>
+  <data name="Help_LblHAForum" xml:space="preserve">
+    <value>Home Assistant Forum</value>
+  </data>
+  <data name="Help_LblGitHub" xml:space="preserve">
+    <value>GitHub Issues</value>
+  </data>
+  <data name="Help_LblHAInfo" xml:space="preserve">
+	  <value>Bit of everything, with the addition that other
+HA users can help you out too!</value>
+  </data>
+  <data name="Help_LblGitHubInfo" xml:space="preserve">
+    <value>Report bugs, post feature requests, see latest changes, etc.</value>
+  </data>
+  <data name="Help_LblDiscordInfo" xml:space="preserve">
+	  <value>Get help with setting up and using HASS.Agent, 
+report bugs or get involved in general chit-chat!</value>
+  </data>
+  <data name="Help_LblWikiInfo" xml:space="preserve">
+    <value>Browse HASS.Agent documentation and usage examples.</value>
+  </data>
+  <data name="Help_Title" xml:space="preserve">
+    <value>Help</value>
+  </data>
+  <data name="Main_TsShow" xml:space="preserve">
+    <value>Show HASS.Agent</value>
+  </data>
+  <data name="Main_TsShowQuickActions" xml:space="preserve">
+    <value>Show Quick Actions</value>
+  </data>
+  <data name="Main_TsConfig" xml:space="preserve">
+    <value>Configuration</value>
+  </data>
+  <data name="Main_TsQuickItemsConfig" xml:space="preserve">
+    <value>Manage Quick Actions</value>
+  </data>
+  <data name="Main_TsLocalSensors" xml:space="preserve">
+    <value>Manage Local Sensors</value>
+  </data>
+  <data name="Main_TsCommands" xml:space="preserve">
+    <value>Manage Commands</value>
+  </data>
+  <data name="Main_CheckForUpdates" xml:space="preserve">
+    <value>Check for Updates</value>
+  </data>
+  <data name="Main_TsDonate" xml:space="preserve">
+    <value>Donate</value>
+  </data>
+  <data name="Main_TsHelp" xml:space="preserve">
+    <value>Help &amp;&amp; Contact</value>
+  </data>
+  <data name="Main_TsAbout" xml:space="preserve">
+    <value>About</value>
+  </data>
+  <data name="Main_TsExit" xml:space="preserve">
+    <value>Exit HASS.Agent</value>
+  </data>
+  <data name="Main_BtnHide" xml:space="preserve">
+    <value>&amp;Hide</value>
+  </data>
+  <data name="Main_GpControls" xml:space="preserve">
+    <value>Controls</value>
+  </data>
+  <data name="Main_BtnServiceManager" xml:space="preserve">
+    <value>S&amp;atellite Service</value>
+  </data>
+  <data name="Main_BtnAppSettings" xml:space="preserve">
+    <value>C&amp;onfiguration</value>
+  </data>
+  <data name="Main_BtnActionsManager" xml:space="preserve">
+    <value>&amp;Quick Actions</value>
+  </data>
+  <data name="Main_BtnCommandsManager" xml:space="preserve">
+    <value>Loading..</value>
+  </data>
+  <data name="Main_BtnSensorsManager" xml:space="preserve">
+    <value>Loading..</value>
+  </data>
+  <data name="Main_GpStatus" xml:space="preserve">
+    <value>System Status</value>
+  </data>
+  <data name="Main_LblService" xml:space="preserve">
+    <value>Satellite Service:</value>
+  </data>
+  <data name="Main_LblCommands" xml:space="preserve">
+    <value>Commands:</value>
+  </data>
+  <data name="Main_LblSensors" xml:space="preserve">
+    <value>Sensors:</value>
+  </data>
+  <data name="Main_LblQuickActions" xml:space="preserve">
+    <value>Quick Actions:</value>
+  </data>
+  <data name="Main_LblHomeAssistantApi" xml:space="preserve">
+    <value>Home Assistant API:</value>
+  </data>
+  <data name="Main_LblNotificationApi" xml:space="preserve">
+    <value>notification api:</value>
+  </data>
+  <data name="Onboarding_BtnNext" xml:space="preserve">
+    <value>&amp;Next</value>
+  </data>
+  <data name="Onboarding_BtnClose" xml:space="preserve">
+    <value>&amp;Close</value>
+  </data>
+  <data name="Onboarding_BtnPrevious" xml:space="preserve">
+    <value>&amp;Previous</value>
+  </data>
+  <data name="Onboarding_Onboarding" xml:space="preserve">
+    <value>HASS.Agent Onboarding</value>
+  </data>
+  <data name="UpdatePending_BtnDownload" xml:space="preserve">
+    <value>Fetching info, please wait..</value>
+  </data>
+  <data name="UpdatePending_LblNewReleaseInfo" xml:space="preserve">
+    <value>There's a new release available:</value>
+  </data>
+  <data name="UpdatePending_LblInfo1" xml:space="preserve">
+    <value>Release notes</value>
+  </data>
+  <data name="UpdatePending_BtnIgnore" xml:space="preserve">
+    <value>&amp;Ignore Update</value>
+  </data>
+  <data name="UpdatePending_LblRelease" xml:space="preserve">
+    <value>Release Page</value>
+  </data>
+  <data name="UpdatePending_Title" xml:space="preserve">
+    <value>HASS.Agent Update</value>
+  </data>
+  <data name="CommandsManager_CustomCommandDescription" xml:space="preserve">
+	  <value>Execute a custom command.
+
+These commands run without special elevation. To run elevated, create a Scheduled Task, and use 'schtasks /Run /TN "TaskName"' as the command to execute your task.
+
+Or enable 'run as low integrity' for even stricter execution.</value>
+  </data>
+  <data name="CommandsManager_CustomExecutorCommandDescription" xml:space="preserve">
+	  <value>Executes the command through the configured custom executor (in Configuration -&gt; External Tools).
+
+Your command is provided as an argument 'as is', so you have to supply your own quotes etc. if necessary.</value>
+  </data>
+  <data name="CommandsManager_HibernateCommandDescription" xml:space="preserve">
+    <value>Sets the machine in hibernation.</value>
+  </data>
+  <data name="CommandsManager_KeyCommandDescription" xml:space="preserve">
+	  <value>Simulates a single keypress.
+
+Click on the 'keycode' textbox and press the key you want simulated. The corresponding keycode will be entered for you.
+
+If you need more keys and/or modifiers like CTRL, use the MultipleKeys command.</value>
+  </data>
+  <data name="CommandsManager_LaunchUrlCommandDescription" xml:space="preserve">
+	  <value>Launches the provided URL, by default in your default browser.
+
+To use 'incognito', provide a specific browser in Configuration -&gt; External Tools.
+
+If you just want a window with a specific URL (not an entire browser), use a 'WebView' command.</value>
+  </data>
+  <data name="CommandsManager_LockCommandDescription" xml:space="preserve">
+    <value>Locks the current session.</value>
+  </data>
+  <data name="CommandsManager_LogOffCommandDescription" xml:space="preserve">
+    <value>Logs off the current session.</value>
+  </data>
+  <data name="CommandsManager_MediaMuteCommandDescription" xml:space="preserve">
+    <value>Simulates 'Mute' key.</value>
+  </data>
+  <data name="CommandsManager_MediaNextCommandDescription" xml:space="preserve">
+    <value>Simulates 'Media Next' key.</value>
+  </data>
+  <data name="CommandsManager_MediaPlayPauseCommandDescription" xml:space="preserve">
+    <value>Simulates 'Media Pause/Play' key.</value>
+  </data>
+  <data name="CommandsManager_MediaPreviousCommandDescription" xml:space="preserve">
+    <value>Simulates 'Media Previous' key.</value>
+  </data>
+  <data name="CommandsManager_MediaVolumeDownCommandDescription" xml:space="preserve">
+    <value>Simulates 'Volume Down' key.</value>
+  </data>
+  <data name="CommandsManager_MediaVolumeUpCommandDescription" xml:space="preserve">
+    <value>Simulates 'Volume Up' key.</value>
+  </data>
+  <data name="CommandsManager_MultipleKeysCommandDescription" xml:space="preserve">
+	  <value>Simulates pressing mulitple keys.
+
+You need to put [ ] between every key, otherwise HASS.Agent can't tell them apart. So say you want to press X TAB Y SHIFT-Z, it'd be [X] [{TAB}] [Y] [+Z].
+
+There are a few tricks you can use:
+
+- If you want a bracket pressed, escape it, so [ is [\[] and ] is [\]] 
+
+- Special keys go between { }, like {TAB} or {UP}
+
+- Put a + in front of a key to add SHIFT, ^ for CTRL and % for ALT. So, +C is SHIFT-C. Or, +(CD) is SHIFT-C and SHIFT-D, while +CD is SHIFT-C and D
+
+- For multiple presses, use {z 15}, which means Z will get pressed 15 times.
+
+More info: https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.sendkeys</value>
+  </data>
+  <data name="CommandsManager_PowershellCommandDescription" xml:space="preserve">
+	  <value>Execute a Powershell command or script.
+
+You can either provide the location of a script (*.ps1), or a single-line command.
+
+This will run without special elevation.</value>
+  </data>
+  <data name="CommandsManager_PublishAllSensorsCommandDescription" xml:space="preserve">
+	  <value>Resets all sensor checks, forcing all sensors to process and send their value.
+
+Useful for example if you want to force HASS.Agent to update all your sensors after a HA reboot.</value>
+  </data>
+  <data name="CommandsManager_RestartCommandDescription" xml:space="preserve">
+	  <value>Restarts the machine after one minute.
+
+Tip: Accidentally triggered? Run 'shutdown /a' to abort shutdown.</value>
+  </data>
+  <data name="CommandsManager_ShutdownCommandDescription" xml:space="preserve">
+	  <value>Shuts down the machine after one minute.
+
+Tip: Accidentally triggered? Run 'shutdown /a' to abort shutdown.</value>
+  </data>
+  <data name="CommandsManager_SleepCommandDescription" xml:space="preserve">
+	  <value>Puts the machine to sleep.
+
+Note: due to a limitation in Windows, this only works if hibernation is disabled, otherwise it will just hibernate.
+
+You can use something like NirCmd (http://www.nirsoft.net/utils/nircmd.html) to circumvent this.</value>
+  </data>
+  <data name="ConfigExternalTools_BtnExternalBrowserIncognitoTest_MessageBox1" xml:space="preserve">
+    <value>Please enter the location of your browser's binary! (.exe file)</value>
+  </data>
+  <data name="ConfigExternalTools_ConfigExternalTools_BtnExternalBrowserIncognitoTest_MessageBox2" xml:space="preserve">
+    <value>The browser binary provided could not be found, please ensure the path is correct and try again.</value>
+  </data>
+  <data name="ConfigExternalTools_BtnExternalBrowserIncognitoTest_MessageBox3" xml:space="preserve">
+	  <value>No incognito arguments were provided so the browser will likely launch normally.
+
+Do you want to continue?</value>
+  </data>
+  <data name="ConfigExternalTools_BtnExternalBrowserIncognitoTest_MessageBox4" xml:space="preserve">
+	  <value>Something went wrong while launching your browser in incognito mode!
+
+Please check the logs for more information.</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox1" xml:space="preserve">
+    <value>Please enter a valid API key!</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox2" xml:space="preserve">
+    <value>Please enter a value for your Home Assistant's URI.</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox3" xml:space="preserve">
+	  <value>Unable to connect, the following error was returned:
+
+{0}</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox4" xml:space="preserve">
+	  <value>Connection OK!
+
+Home Assistant version: {0}</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearImageCache_MessageBox1" xml:space="preserve">
+    <value>Image cache has been cleared!</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearImageCache_InfoText1" xml:space="preserve">
+    <value>Cleaning..</value>
+  </data>
+  <data name="ConfigNotifications_BtnSendTestNotification_MessageBox1" xml:space="preserve">
+    <value>Notifications are currently disabled, please enable them and restart the HASS.Agent, then try again.</value>
+  </data>
+  <data name="ConfigNotifications_BtnSendTestNotification_MessageBox2" xml:space="preserve">
+	  <value>The test notification should have appeared, if you did not receive it please check the logs or consult the documentation for troubleshooting tips.
+
+Note: This only tests locally whether notifications can be shown!</value>
+  </data>
+  <data name="ConfigNotifications_TestNotification" xml:space="preserve">
+    <value>This is a test notification!</value>
+  </data>
+  <data name="ConfigNotifications_BtnExecutePortReservation_Busy" xml:space="preserve">
+    <value>Executing, please wait..</value>
+  </data>
+  <data name="ConfigNotifications_BtnExecutePortReservation_MessageBox1" xml:space="preserve">
+	  <value>Something went wrong whilst reserving the port!
+
+Manual execution is required and a command has been copied to your clipboard, please open an elevated terminal and paste the command.
+
+Additionally, remember to change your Firewall Rules port!</value>
+  </data>
+  <data name="ConfigService_NotInstalled" xml:space="preserve">
+    <value>Not Installed</value>
+  </data>
+  <data name="ConfigService_Disabled" xml:space="preserve">
+    <value>Disabled</value>
+  </data>
+  <data name="ConfigService_Running" xml:space="preserve">
+    <value>Running</value>
+  </data>
+  <data name="ConfigService_Stopped" xml:space="preserve">
+    <value>Stopped</value>
+  </data>
+  <data name="ConfigService_Failed" xml:space="preserve">
+    <value>Failed</value>
+  </data>
+  <data name="ConfigService_BtnStopService_MessageBox1" xml:space="preserve">
+	  <value>Something went wrong whilst stopping the service, did you allow the UAC prompt?
+
+Check the HASS.Agent (not the service) logs for more information.</value>
+  </data>
+  <data name="ConfigService_BtnStartService_MessageBox1" xml:space="preserve">
+	  <value>The service is set to 'disabled', so it cannot be started.
+
+Please enable the service first and try again.</value>
+  </data>
+  <data name="ConfigService_BtnStartService_MessageBox2" xml:space="preserve">
+	  <value>Something went wrong whilst starting the service, did you allow the UAC prompt?
+
+Check the HASS.Agent (not the service) logs for more information.</value>
+  </data>
+  <data name="ConfigService_BtnDisableService_MessageBox1" xml:space="preserve">
+	  <value>Something went wrong whilst disabling the service, did you allow the UAC prompt?
+
+Check the HASS.Agent (not the service) logs for more information.</value>
+  </data>
+  <data name="ConfigService_BtnEnableService_MessageBox1" xml:space="preserve">
+	  <value>Something went wrong whilst enabling the service, did you allow the UAC prompt?
+
+Check the HASS.Agent (not the service) logs for more information.</value>
+  </data>
+  <data name="ConfigService_BtnShowLogs_MessageBox1" xml:space="preserve">
+	  <value>Something went wrong whilst reinstalling the service, did you allow the UAC prompt?
+
+Check the HASS.Agent (not the service) logs for more information.</value>
+  </data>
+  <data name="ConfigStartup_BtnSetStartOnLogin_MessageBox1" xml:space="preserve">
+    <value>Something went wrong whilst disabling Start-on-Login, please check the logs for more information.</value>
+  </data>
+  <data name="ConfigStartup_BtnSetStartOnLogin_MessageBox2" xml:space="preserve">
+    <value>Something went wrong whilst disabling Start-on-Login, please check the logs for more information.</value>
+  </data>
+  <data name="ConfigStartup_Enabled" xml:space="preserve">
+    <value>Enabled</value>
+  </data>
+  <data name="ConfigStartup_Disable" xml:space="preserve">
+    <value>Disable Start-on-Login</value>
+  </data>
+  <data name="ConfigStartup_Disabled" xml:space="preserve">
+    <value>Disabled</value>
+  </data>
+  <data name="ConfigStartup_Enable" xml:space="preserve">
+    <value>Enable Start-on-Login</value>
+  </data>
+  <data name="OnboardingStartup_Activated" xml:space="preserve">
+    <value>Start-on-Login has been activated!</value>
+  </data>
+  <data name="OnboardingStartup_EnableNow" xml:space="preserve">
+    <value>Do you want to enable Start-on-Login now?</value>
+  </data>
+  <data name="OnboardingStartup_AlreadyActivated" xml:space="preserve">
+    <value>Start-on-Login is already activated, all set!</value>
+  </data>
+  <data name="OnboardingStartup_Activating" xml:space="preserve">
+    <value>Activating Start-on-Login..</value>
+  </data>
+  <data name="OnboardingStartup_Failed" xml:space="preserve">
+    <value>Something went wrong. You can try again, or skip to the next page and retry after HASS.Agent's restart.</value>
+  </data>
+  <data name="OnboardingStartup_BtnSetLaunchOnLogin_2" xml:space="preserve">
+    <value>Enable Start-on-Login</value>
+  </data>
+  <data name="OnboardingApi_BtnTest_MessageBox1" xml:space="preserve">
+    <value>Please provide a valid API key.</value>
+  </data>
+  <data name="OnboardingApi_BtnTest_MessageBox2" xml:space="preserve">
+    <value>Please enter your Home Assistant's URI.</value>
+  </data>
+  <data name="OnboardingApi_BtnTest_MessageBox3" xml:space="preserve">
+	  <value>Unable to connect, the following error was returned:
+
+{0}</value>
+  </data>
+  <data name="OnboardingApi_BtnTest_MessageBox4" xml:space="preserve">
+	  <value>Connection OK!
+
+Home Assistant version: {0}</value>
+  </data>
+  <data name="OnboardingApi_BtnTest_Testing" xml:space="preserve">
+    <value>Testing..</value>
+  </data>
+  <data name="ServiceCommands_BtnStore_MessageBox1" xml:space="preserve">
+    <value>An error occurred whilst saving your commands, please check the logs for more information.</value>
+  </data>
+  <data name="ServiceCommands_BtnStore_Storing" xml:space="preserve">
+    <value>Storing and registering, please wait..</value>
+  </data>
+  <data name="ServiceConnect_Connecting" xml:space="preserve">
+    <value>Connecting with satellite service, please wait..</value>
+  </data>
+  <data name="ServiceConnect_Failed" xml:space="preserve">
+    <value>Connecting to the service has failed!</value>
+  </data>
+  <data name="ServiceConnect_FailedMessage" xml:space="preserve">
+	  <value>The service hasn't been found! You can install and manage it from the configuration panel.
+
+When it's up and running, come back here to configure the commands and sensors.</value>
+  </data>
+  <data name="ServiceConnect_CommunicationFailed" xml:space="preserve">
+    <value>Communicating with the service has failed!</value>
+  </data>
+  <data name="ServiceConnect_CommunicationFailedMessage" xml:space="preserve">
+	  <value>Unable to communicate with the service. Check the logs for more info.
+
+You can open the logs and manage the service from the configuration panel.</value>
+  </data>
+  <data name="ServiceConnect_Unauthorized" xml:space="preserve">
+    <value>Unauthorized</value>
+  </data>
+  <data name="ServiceConnect_UnauthorizedMessage" xml:space="preserve">
+	  <value>You are not authorized to contact the service.
+
+If you have the correct auth ID, you can set it now and try again.</value>
+  </data>
+  <data name="ServiceConnect_SettingsFailed" xml:space="preserve">
+    <value>Fetching settings failed!</value>
+  </data>
+  <data name="ServiceConnect_SettingsFailedMessage" xml:space="preserve">
+	  <value>The service returned an error while requesting its settings. Check the logs for more info.
+
+You can open the logs and manage the service from the configuration panel.</value>
+  </data>
+  <data name="ServiceConnect_MqttFailed" xml:space="preserve">
+    <value>Fetching MQTT settings failed!</value>
+  </data>
+  <data name="ServiceConnect_MqttFailedMessage" xml:space="preserve">
+	  <value>The service returned an error while requesting its MQTT settings. Check the logs for more info.
+
+You can open the logs and manage the service from the configuration panel.</value>
+  </data>
+  <data name="ServiceConnect_CommandsFailed" xml:space="preserve">
+    <value>Fetching configured commands failed!</value>
+  </data>
+  <data name="ServiceConnect_CommandsFailedMessage" xml:space="preserve">
+	  <value>The service returned an error while requesting its configured commands. Check the logs for more info.
+
+You can open the logs and manage the service from the configuration panel.</value>
+  </data>
+  <data name="ServiceConnect_SensorsFailed" xml:space="preserve">
+    <value>Fetching configured sensors failed!</value>
+  </data>
+  <data name="ServiceConnect_SensorsFailedMessage" xml:space="preserve">
+	  <value>The service returned an error while requesting its configured sensors. Check the logs for more info.
+
+You can open the logs and manage the service from the configuration panel.</value>
+  </data>
+  <data name="ServiceGeneral_TbAuthId_MessageBox1" xml:space="preserve">
+	  <value>Storing an empty auth ID will allow all HASS.Agent to access the service.
+
+Are you sure you want this?</value>
+  </data>
+  <data name="ServiceGeneral_SavingFailedMessageBox" xml:space="preserve">
+    <value>An error occurred whilst saving, check the logs for more information.</value>
+  </data>
+  <data name="ServiceGeneral_BtnStoreDeviceName_MessageBox1" xml:space="preserve">
+    <value>Please provide a device name!</value>
+  </data>
+  <data name="ServiceGeneral_BtnStoreCustomExecutor_MessageBox1" xml:space="preserve">
+    <value>Please select an executor first. (Tip: Double click to Browse)</value>
+  </data>
+  <data name="ServiceGeneral_BtnStoreCustomExecutor_MessageBox2" xml:space="preserve">
+    <value>The selected executor could not be found, please ensure the path provided is correct and try again.</value>
+  </data>
+  <data name="ServiceGeneral_LblAuthIdInfo_MessageBox1" xml:space="preserve">
+	  <value>Set an auth ID if you don't want every instance of HASS.Agent on this PC to connect with the satellite service.
+
+Only the instances that have the correct ID, can connect.
+
+Leave empty to allow all to connect.</value>
+  </data>
+  <data name="ServiceGeneral_LblDeviceNameInfo_MessageBox1" xml:space="preserve">
+	  <value>This is the name with which the satellite service registers itself on Home Assistant.
+
+By default, it's your PC's name plus '-satellite'.</value>
+  </data>
+  <data name="ServiceGeneral_LblDisconGraceInfo_MessageBox1" xml:space="preserve">
+    <value>The amount of time the satellite service will wait before reporting a lost connection to the MQTT broker.</value>
+  </data>
+  <data name="ServiceMqtt_StatusError" xml:space="preserve">
+    <value>Error fetching status, please check logs for information.</value>
+  </data>
+  <data name="ServiceMqtt_BtnStore_MessageBox1" xml:space="preserve">
+    <value>An error occurred whilst saving the configuration, please check the logs for more information.</value>
+  </data>
+  <data name="ServiceMqtt_BtnStore_Storing" xml:space="preserve">
+    <value>Storing and registering, please wait..</value>
+  </data>
+  <data name="ServiceSensors_BtnStore_MessageBox1" xml:space="preserve">
+    <value>An error occurred whilst saving the sensors, please check the logs for more information.</value>
+  </data>
+  <data name="ServiceSensors_BtnStore_Storing" xml:space="preserve">
+    <value>Storing and registering, please wait..</value>
+  </data>
+  <data name="PortReservation_ProcessPostUpdate_MessageBox1" xml:space="preserve">
+    <value>Not all steps completed succesfully. Please consult the logs for more information.</value>
+  </data>
+  <data name="PostUpdate_ProcessPostUpdate_MessageBox1" xml:space="preserve">
+    <value>Not all steps completed succesfully. Please consult the logs for more information.</value>
+  </data>
+  <data name="Restart_ProcessRestart_MessageBox1" xml:space="preserve">
+	  <value>HASS.Agent is still active after {0} seconds. Please close all instances and restart manually.
+
+Check the logs for more info, and optionally inform the developers.</value>
+  </data>
+  <data name="ServiceReinstall_ProcessReinstall_MessageBox1" xml:space="preserve">
+    <value>Not all steps completed successfully, please check the logs for more information.</value>
+  </data>
+  <data name="ServiceSetState_Enabled" xml:space="preserve">
+    <value>Enable Satellite Service</value>
+  </data>
+  <data name="ServiceSetState_Disabled" xml:space="preserve">
+    <value>Disable Satellite Service</value>
+  </data>
+  <data name="ServiceSetState_Started" xml:space="preserve">
+    <value>Start Satellite Service</value>
+  </data>
+  <data name="ServiceSetState_Stopped" xml:space="preserve">
+    <value>Stop Satellite Service</value>
+  </data>
+  <data name="ServiceSetState_ProcessState_MessageBox1" xml:space="preserve">
+	  <value>Something went wrong while processing the desired service state.
+
+Please consult the logs for more information.</value>
+  </data>
+  <data name="CommandMqttTopic_BtnCopyClipboard_Copied" xml:space="preserve">
+    <value>Topic copied to clipboard!</value>
+  </data>
+  <data name="CommandsConfig_BtnStore_Storing" xml:space="preserve">
+    <value>Storing and registering, please wait..</value>
+  </data>
+  <data name="CommandsConfig_BtnStore_MessageBox1" xml:space="preserve">
+    <value>An error occurred whilst saving commands, please check the logs for more information.</value>
+  </data>
+  <data name="CommandsMod_Title_NewCommand" xml:space="preserve">
+    <value>New Command</value>
+  </data>
+  <data name="CommandsMod_Title_ModCommand" xml:space="preserve">
+    <value>Mod Command</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox1" xml:space="preserve">
+    <value>Please select a command type!</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox2" xml:space="preserve">
+    <value>Please select a valid command type!</value>
+  </data>
+  <data name="CommandsMod_MessageBox_EntityType" xml:space="preserve">
+    <value>Select a valid entity type first.</value>
+  </data>
+  <data name="CommandsMod_MessageBox_Name" xml:space="preserve">
+    <value>Please provide a name!</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox3" xml:space="preserve">
+    <value>A command with that name already exists, are you sure you want to continue?</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox4" xml:space="preserve">
+	  <value>If a command is not provided, you may only use this entity with an 'action' value via Home Assistant, running it as-is will have no action.
+
+Are you sure you want to proceed?</value>
+  </data>
+  <data name="CommandsMod_MessageBox_Action" xml:space="preserve">
+	  <value>If you don't enter a command or script, you can only use this entity with an 'action' value through Home Assistant. Running it as-is won't do anything.
+
+Are you sure you want this?</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox5" xml:space="preserve">
+    <value>Please enter a key code!</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox6" xml:space="preserve">
+    <value>Checking keys failed: {0}</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox7" xml:space="preserve">
+	  <value>If a URL is not provided, you may only use this entity with an 'action' value via Home Assistant, running it as-is will have no action.
+
+Are you sure you want to proceed?</value>
+  </data>
+  <data name="CommandsMod_LblSetting_Command" xml:space="preserve">
+    <value>Command</value>
+  </data>
+  <data name="CommandsMod_LblSetting_CommandScript" xml:space="preserve">
+    <value>Command or Script</value>
+  </data>
+  <data name="CommandsMod_LblSetting_KeyCode" xml:space="preserve">
+    <value>Keycode</value>
+  </data>
+  <data name="CommandsMod_LblSetting_KeyCodes" xml:space="preserve">
+    <value>Keycodes</value>
+  </data>
+  <data name="CommandsMod_CbCommandSpecific_Incognito" xml:space="preserve">
+    <value>Launch in Incognito Mode</value>
+  </data>
+  <data name="CommandsMod_LblInfo_Browser" xml:space="preserve">
+	  <value>Browser: Default
+
+Please configure a custom browser to enable incognito mode.</value>
+  </data>
+  <data name="CommandsMod_LblSetting_Url" xml:space="preserve">
+    <value>URL</value>
+  </data>
+  <data name="CommandsMod_LblInfo_BrowserSpecific" xml:space="preserve">
+    <value>Browser: {0}</value>
+  </data>
+  <data name="CommandsMod_LblInfo_Executor" xml:space="preserve">
+	  <value>Executor: None
+
+Please configure an executor or your command will not run.</value>
+  </data>
+  <data name="CommandsMod_LblInfo_ExecutorSpecific" xml:space="preserve">
+    <value>Executor: {0}</value>
+  </data>
+  <data name="CommandsMod_LblIntegrityInfo_InfoMsg1" xml:space="preserve">
+    <value>Low integrity means your command will be executed with restricted privileges.</value>
+  </data>
+  <data name="CommandsMod_LblIntegrityInfo_InfoMsg2" xml:space="preserve">
+    <value>This means it will only be able to save and modify files in certain locations,</value>
+  </data>
+  <data name="CommandsMod_LblIntegrityInfo_InfoMsg3" xml:space="preserve">
+    <value>such as the '%USERPROFILE%\AppData\LocalLow' folder or</value>
+  </data>
+  <data name="CommandsMod_LblIntegrityInfo_InfoMsg4" xml:space="preserve">
+    <value>the 'HKEY_CURRENT_USER\Software\AppDataLow' registry key.</value>
+  </data>
+  <data name="CommandsMod_LblIntegrityInfo_InfoMsg5" xml:space="preserve">
+    <value>You should test your command to make sure it's not influenced by this!</value>
+  </data>
+  <data name="CommandsMod_SpecificClient" xml:space="preserve">
+    <value>{0} only!</value>
+  </data>
+  <data name="CommandsMod_LblMqttTopic_MessageBox1" xml:space="preserve">
+    <value>The MQTT manager hasn't been configured properly, or hasn't yet completed its startup.</value>
+  </data>
+  <data name="QuickActions_CheckHassManager_MessageBox1" xml:space="preserve">
+    <value>Unable to fetch your entities because of missing config, please enter the required values in the config screen.</value>
+  </data>
+  <data name="QuickActions_MessageBox_EntityFailed" xml:space="preserve">
+    <value>There was an error trying to fetch your entities!</value>
+  </data>
+  <data name="QuickActionsMod_Title_New" xml:space="preserve">
+    <value>New Quick Action</value>
+  </data>
+  <data name="QuickActionsMod_Title_Mod" xml:space="preserve">
+    <value>Mod Quick Action</value>
+  </data>
+  <data name="QuickActionsMod_CheckHassManager_MessageBox1" xml:space="preserve">
+    <value>Unable to fetch your entities because of missing config, please enter the required values in the config screen.</value>
+  </data>
+  <data name="QuickActionsMod_MessageBox_Entities" xml:space="preserve">
+    <value>There was an error trying to fetch your entities.</value>
+  </data>
+  <data name="QuickActionsMod_BtnStore_MessageBox1" xml:space="preserve">
+    <value>Please select an entity!</value>
+  </data>
+  <data name="QuickActionsMod_BtnStore_MessageBox2" xml:space="preserve">
+    <value>Please select an domain!</value>
+  </data>
+  <data name="QuickActionsMod_BtnStore_MessageBox3" xml:space="preserve">
+    <value>Unknown action, please select a valid one.</value>
+  </data>
+  <data name="SensorsConfig_BtnStore_Storing" xml:space="preserve">
+    <value>Storing and registering, please wait..</value>
+  </data>
+  <data name="SensorsConfig_BtnStore_MessageBox1" xml:space="preserve">
+    <value>An error occurred whilst saving the sensors, please check the logs for more information.</value>
+  </data>
+  <data name="SensorsMod_Title_New" xml:space="preserve">
+    <value>New Sensor</value>
+  </data>
+  <data name="SensorsMod_Title_Mod" xml:space="preserve">
+    <value>Mod Sensor</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_WindowName" xml:space="preserve">
+    <value>Window Name</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_Wmi" xml:space="preserve">
+    <value>WMI Query</value>
+  </data>
+  <data name="SensorsMod_LblSetting2_Wmi" xml:space="preserve">
+    <value>WMI Scope (optional)</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_Category" xml:space="preserve">
+    <value>Category</value>
+  </data>
+  <data name="SensorsMod_LblSetting2_Counter" xml:space="preserve">
+    <value>Counter</value>
+  </data>
+  <data name="SensorsMod_LblSetting3_Instance" xml:space="preserve">
+    <value>Instance (optional)</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_Process" xml:space="preserve">
+    <value>Process</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_Service" xml:space="preserve">
+    <value>Service</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox1" xml:space="preserve">
+    <value>Please select a sensor type!</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox2" xml:space="preserve">
+    <value>Please select a valid sensor type!</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox3" xml:space="preserve">
+    <value>Please provide a name!</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox4" xml:space="preserve">
+    <value>A single-value sensor already exists with that name, are you sure you want to proceed?</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox5" xml:space="preserve">
+    <value>A multi-value sensor already exists with that name, are you sure you want to proceed?</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox6" xml:space="preserve">
+    <value>Please provide an interval between 1 and 43200 (12 hours)!</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox7" xml:space="preserve">
+    <value>Please enter a window name!</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox8" xml:space="preserve">
+    <value>Please enter a query!</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox9" xml:space="preserve">
+    <value>Please enter a category and instance!</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox10" xml:space="preserve">
+    <value>Please enter the name of a process!</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox11" xml:space="preserve">
+    <value>Please enter the name of a service!</value>
+  </data>
+  <data name="SensorsMod_SpecificClient" xml:space="preserve">
+    <value>{0} only!</value>
+  </data>
+  <data name="Configuration_ProcessChanges_MessageBox1" xml:space="preserve">
+	  <value>You've changed your device's name.
+
+All your sensors and commands will now be unpublished, and HASS.Agent will restart afterwards to republish them.
+
+Don't worry, they'll keep their current names, so your automations or scripts will keep working.
+
+Note: the name will get 'sanitized', which means everything except letters, digits and whitespace get replaced by an underscore. This is required by HA.</value>
+  </data>
+  <data name="Configuration_ProcessChanges_MessageBox2" xml:space="preserve">
+	  <value>You've changed the local API's port. This new port needs to be reserved.
+
+You'll get an UAC request to do so, please approve.</value>
+  </data>
+  <data name="Configuration_ProcessChanges_MessageBox3" xml:space="preserve">
+	  <value>Something went wrong!
+
+Please manually execute the required command. It has been copied onto your clipboard, you just need to paste it into an elevated command prompt.
+
+Remember to change your firewall rule's port as well.</value>
+  </data>
+  <data name="Configuration_ProcessChanges_MessageBox4" xml:space="preserve">
+	  <value>The port has succesfully been reserved!
+
+HASS.Agent will now restart to activate the new configuration.</value>
+  </data>
+  <data name="Configuration_MessageBox_RestartManually" xml:space="preserve">
+	  <value>Something went wrong while preparing to restart.
+Please restart manually.</value>
+  </data>
+  <data name="Configuration_ProcessChanges_MessageBox5" xml:space="preserve">
+	  <value>Your configuration has been saved. Most changes require HASS.Agent to restart before they take effect.
+
+Do you want to restart now?</value>
+  </data>
+  <data name="Main_Load_MessageBox1" xml:space="preserve">
+	  <value>Something went wrong while loading your settings.
+
+Check appsettings.json in the 'config' subfolder, or just delete it to start fresh.</value>
+  </data>
+  <data name="Main_Load_MessageBox2" xml:space="preserve">
+	  <value>There was an error launching HASS.Agent.
+Please check the logs and make a bug report on GitHub.</value>
+  </data>
+  <data name="Main_BtnSensorsManage_Ready" xml:space="preserve">
+	  <value>&amp;Sensors</value>
+  </data>
+  <data name="Main_BtnCommandsManager_Ready" xml:space="preserve">
+    <value>&amp;Commands</value>
+  </data>
+  <data name="Main_Checking" xml:space="preserve">
+    <value>Checking..</value>
+  </data>
+  <data name="Main_CheckForUpdate_MessageBox1" xml:space="preserve">
+    <value>You're running the latest version: {0}{1}</value>
+  </data>
+  <data name="UpdatePending_NewBetaRelease" xml:space="preserve">
+    <value>There's a new BETA release available:</value>
+  </data>
+  <data name="UpdatePending_Title_Beta" xml:space="preserve">
+    <value>HASS.Agent BETA Update</value>
+  </data>
+  <data name="UpdatePending_LblUpdateQuestion_Download" xml:space="preserve">
+    <value>Do you want to &amp;download and launch the installer?</value>
+  </data>
+  <data name="UpdatePending_LblUpdateQuestion_Navigate" xml:space="preserve">
+    <value>Do you want to &amp;navigate to the release page?</value>
+  </data>
+  <data name="UpdatePending_InstallUpdate" xml:space="preserve">
+    <value>Install Update</value>
+  </data>
+  <data name="UpdatePending_InstallBetaRelease" xml:space="preserve">
+    <value>Install Beta Release</value>
+  </data>
+  <data name="UpdatePending_OpenReleasePage" xml:space="preserve">
+    <value>Open Release Page</value>
+  </data>
+  <data name="UpdatePending_OpenBetaReleasePage" xml:space="preserve">
+    <value>Open Beta Release Page</value>
+  </data>
+  <data name="UpdatePending_LblUpdateQuestion_Processing" xml:space="preserve">
+    <value>Processing request, please wait..</value>
+  </data>
+  <data name="UpdatePending_BtnDownload_Processing" xml:space="preserve">
+    <value>Processing..</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_Start" xml:space="preserve">
+    <value>HASS.Agent Onboarding: Start [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_Startup" xml:space="preserve">
+    <value>HASS.Agent Onboarding: Startup [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_Notifications" xml:space="preserve">
+    <value>HASS.Agent Onboarding: Notifications [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_Integration" xml:space="preserve">
+    <value>HASS.Agent Onboarding: Integration [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_Api" xml:space="preserve">
+    <value>HASS.Agent Onboarding: API [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_Mqtt" xml:space="preserve">
+    <value>HASS.Agent Onboarding: MQTT [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_HotKey" xml:space="preserve">
+    <value>HASS.Agent Onboarding: HotKey [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_Updates" xml:space="preserve">
+    <value>HASS.Agent Onboarding: Updates [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_Completed" xml:space="preserve">
+    <value>HASS.Agent Onboarding: Completed [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_ConfirmBeforeClose_MessageBox1" xml:space="preserve">
+	  <value>Are you sure you want to abort the onboarding process?
+
+Your progress will not be saved, and it will not be shown again on next launch.</value>
+  </data>
+  <data name="UpdateManager_GetLatestVersionInfo_Error" xml:space="preserve">
+    <value>Error fetching info, please check logs for more information.</value>
+  </data>
+  <data name="UpdateManager_DownloadAndExecuteUpdate_MessageBox1" xml:space="preserve">
+	  <value>Unable to prepare downloading the update, check the logs for more info.
+
+The release page will now open instead.</value>
+  </data>
+  <data name="UpdateManager_DownloadAndExecuteUpdate_MessageBox2" xml:space="preserve">
+	  <value>Unable to download the update, check the logs for more info.
+
+The release page will now open instead.</value>
+  </data>
+  <data name="UpdateManager_DownloadAndExecuteUpdate_MessageBox3" xml:space="preserve">
+	  <value>The downloaded file FAILED the certificate check.
+
+This could be a technical error, but also a tampered file!
+
+Please check the logs, and post a ticket with the findings.</value>
+  </data>
+  <data name="UpdateManager_DownloadAndExecuteUpdate_MessageBox4" xml:space="preserve">
+	  <value>Unable to launch the installer (did you approve the UAC prompt?), check the logs for more info.
+
+The release page will now open instead.</value>
+  </data>
+  <data name="HassApiManager_ToolTip_ConnectionSetupFailed" xml:space="preserve">
+    <value>HASS API: Connection setup failed.</value>
+  </data>
+  <data name="HassApiManager_ToolTip_InitialConnectionFailed" xml:space="preserve">
+    <value>HASS API: Initial connection failed.</value>
+  </data>
+  <data name="HassApiManager_ToolTip_ConnectionFailed" xml:space="preserve">
+    <value>HASS API: Connection failed.</value>
+  </data>
+  <data name="HassApiManager_CheckHassConfig_CertNotFound" xml:space="preserve">
+    <value>Client certificate file not found.</value>
+  </data>
+  <data name="HassApiManager_CheckHassConfig_UnableToConnect" xml:space="preserve">
+    <value>Unable to connect, check URI.</value>
+  </data>
+  <data name="HassApiManager_CheckHassConfig_ConfigFailed" xml:space="preserve">
+    <value>Unable to fetch configuration, please check API key.</value>
+  </data>
+  <data name="HassApiManager_ConnectionFailed" xml:space="preserve">
+    <value>Unable to connect, please check URI and configuration.</value>
+  </data>
+  <data name="HassApiManager_ToolTip_QuickActionFailed" xml:space="preserve">
+    <value>quick action: action failed, check the logs for info</value>
+  </data>
+  <data name="HassApiManager_ToolTip_QuickActionFailedOnEntity" xml:space="preserve">
+    <value>quick action: action failed, entity not found</value>
+  </data>
+  <data name="MqttManager_ToolTip_ConnectionError" xml:space="preserve">
+    <value>MQTT: Error while connecting</value>
+  </data>
+  <data name="MqttManager_ToolTip_ConnectionFailed" xml:space="preserve">
+    <value>MQTT: Failed to connect</value>
+  </data>
+  <data name="MqttManager_ToolTip_Disconnected" xml:space="preserve">
+    <value>MQTT: Disconnected</value>
+  </data>
+  <data name="NotifierManager_Initialize_MessageBox1" xml:space="preserve">
+	  <value>Error trying to bind the API to port {0}.
+
+Make sure no other instance of HASS.Agent is running and the port is available and registered.</value>
+  </data>
+  <data name="SensorsManager_ActiveWindowSensorDescription" xml:space="preserve">
+    <value>Provides the title of the current active window.</value>
+  </data>
+  <data name="SensorsManager_AudioSensorsDescription" xml:space="preserve">
+	  <value>Provides information various aspects of your device's audio:
+
+Current peak volume level (can be used as a simple 'is something playing' value).
+
+Default audio device: name, state and volume.
+
+Summary of your audio sessions: application name, muted state, volume and current peak volume.</value>
+  </data>
+  <data name="SensorsManager_BatterySensorsDescription" xml:space="preserve">
+    <value>Provides a sensor with the current charging status, estimated amount of minutes on a full charge, remaining charge as a percentage, remaining charge in minutes and the powerline status.</value>
+  </data>
+  <data name="SensorsManager_CpuLoadSensorDescription" xml:space="preserve">
+    <value>Provides the current load of the first CPU as a percentage.</value>
+  </data>
+  <data name="SensorsManager_CurrentClockSpeedSensorDescription" xml:space="preserve">
+    <value>Provides the current clockspeed of the first CPU.</value>
+  </data>
+  <data name="SensorsManager_CurrentVolumeSensorDescription" xml:space="preserve">
+	  <value>Provides the current volume level as a percentage.
+
+Currently takes the volume of your default device.</value>
+  </data>
+  <data name="SensorsManager_DisplaySensorsDescription" xml:space="preserve">
+    <value>Provides a sensor with the amount of displays, name of the primary display, and per display its name, resolution and bits per pixel.</value>
+  </data>
+  <data name="SensorsManager_DummySensorDescription" xml:space="preserve">
+    <value>Dummy sensor for testing purposes, sends a random integer value between 0 and 100.</value>
+  </data>
+  <data name="SensorsManager_GpuLoadSensorDescription" xml:space="preserve">
+    <value>Provides the current load of the first GPU as a percentage.</value>
+  </data>
+  <data name="SensorsManager_GpuTemperatureSensorDescription" xml:space="preserve">
+    <value>NOTE: This is a non-functioning sensor.
+
+Due to the security concerns regarding Libre Hardware Monitor (library allowing HASS.Agent to access GPU temperature data) this sensor is left for backward compatibility reasons and will always return 0.
+Please see documentation for alternative options.</value>
+  </data>
+  <data name="SensorsManager_LastActiveSensorDescription" xml:space="preserve">
+    <value>Provides a datetime value containing the last moment the user provided any input.</value>
+  </data>
+  <data name="SensorsManager_LastBootSensorDescription" xml:space="preserve">
+	  <value>Provides a datetime value containing the last moment the system (re)booted.
+
+Important: Windows' FastBoot option can throw this value off, because that's a form of hibernation. You can disable it through Power Options -&gt; 'Choose what the power buttons do' -&gt; uncheck 'Turn on fast start-up'. It doesn't make much difference for modern machines with SSDs, but disabling makes sure you get a clean state after rebooting.</value>
+  </data>
+  <data name="SensorsManager_LastSystemStateChangeSensorDescription" xml:space="preserve">
+	  <value>Provides the last system state change:
+
+ApplicationStarted, Logoff, SystemShutdown, Resume, Suspend, ConsoleConnect, ConsoleDisconnect, RemoteConnect, RemoteDisconnect, SessionLock, SessionLogoff, SessionLogon, SessionRemoteControl and SessionUnlock.</value>
+  </data>
+  <data name="SensorsManager_LoggedUserSensorDescription" xml:space="preserve">
+	  <value>Returns the name of the currently logged user.
+
+This will only show active users, and falls back to 'Empty' if there are none. If there are multiple, the first will be used.</value>
+  </data>
+  <data name="SensorsManager_LoggedUsersSensorDescription" xml:space="preserve">
+	  <value>Returns a json-formatted list of currently logged users.
+
+This will also contain users that aren't active. If you only want the current active user, use the LoggedUser sensor instead.</value>
+  </data>
+  <data name="SensorsManager_MemoryUsageSensorDescription" xml:space="preserve">
+    <value>Provides the amount of used memory as a percentage.</value>
+  </data>
+  <data name="SensorsManager_MicrophoneActiveSensorDescription" xml:space="preserve">
+	  <value>Provides a bool value based on whether the microphone is currently being used.
+
+Note: if used in the satellite service, it won't detect userspace applications.</value>
+  </data>
+  <data name="SensorsManager_NamedWindowSensorDescription" xml:space="preserve">
+    <value>Provides an ON/OFF value based on whether the window is currently open (doesn't have to be active).</value>
+  </data>
+  <data name="SensorsManager_NetworkSensorsDescription" xml:space="preserve">
+	  <value>Provides card info, configuration, transfer- &amp; package statistics and addresses (ip, mac, dhcp, dns) of the selected network card(s).
+
+This is a multi-value sensor.</value>
+  </data>
+  <data name="SensorsManager_PerformanceCounterSensorDescription" xml:space="preserve">
+	  <value>Provides the values of a performance counter.
+
+For example, the built-in CPU load sensor uses these values:
+
+Category: Processor
+Counter: % Processor Time
+Instance: _Total
+
+You can explore the counters through Windows' 'perfmon.exe' tool.</value>
+  </data>
+  <data name="SensorsManager_ProcessActiveSensorDescription" xml:space="preserve">
+	  <value>Provides the number of active instances of the process.
+
+Note: don't add the extension (eg. notepad.exe becomes notepad).</value>
+  </data>
+  <data name="SensorsManager_ServiceStateSensorDescription" xml:space="preserve">
+	  <value>Returns the state of the provided service: NotFound, Stopped, StartPending, StopPending, Running, ContinuePending, PausePending or Paused.
+
+Make sure to provide the 'Service name', not the 'Display name'.</value>
+  </data>
+  <data name="SensorsManager_SessionStateSensorDescription" xml:space="preserve">
+	  <value>Provides the current session state:
+
+Locked, Unlocked or Unknown.
+
+Use a LastSystemStateChangeSensor to monitor session state changes.</value>
+  </data>
+  <data name="SensorsManager_StorageSensorsDescription" xml:space="preserve">
+    <value>Provides the labels, total size (MB), available space (MB), used space (MB) and file system of all present non-removable disks.</value>
+  </data>
+  <data name="SensorsManager_UserNotificationStateSensorDescription" xml:space="preserve">
+	  <value>Provides the current user state:
+
+NotPresent, Busy, RunningDirect3dFullScreen, PresentationMode, AcceptsNotifications, QuietTime or RunningWindowsStoreApp.
+
+Can for instance be used to determine whether to send notifications or TTS messages.</value>
+  </data>
+  <data name="SensorsManager_WebcamActiveSensorDescription" xml:space="preserve">
+	  <value>Provides a bool value based on whether the webcam is currently being used.
+
+Note: if used in the satellite service, it won't detect userspace applications.</value>
+  </data>
+  <data name="SensorsManager_WindowsUpdatesSensorsDescription" xml:space="preserve">
+	  <value>Provides a sensor with the amount of pending driver updates, a sensor with the amount of pending software updates, a sensor containing all pending driver updates information (title, kb article id's, hidden, type and categories) and a sensor containing the same for pending software updates.
+
+This is a costly request, so the recommended interval is 15 minutes (900 seconds). But it's capped at 10 minutes, if you provide a lower value, you'll get the last known list.</value>
+  </data>
+  <data name="SensorsManager_WmiQuerySensorDescription" xml:space="preserve">
+    <value>Provides the result of the WMI query.</value>
+  </data>
+  <data name="SettingsManager_LoadAppSettings_MessageBox1" xml:space="preserve">
+	  <value>Error loading settings:
+
+{0}</value>
+  </data>
+  <data name="SettingsManager_StoreInitialSettings_MessageBox1" xml:space="preserve">
+	  <value>Error storing initial settings:
+
+{0}</value>
+  </data>
+  <data name="SettingsManager_StoreAppSettings_MessageBox1" xml:space="preserve">
+	  <value>Error storing settings:
+
+{0}</value>
+  </data>
+  <data name="StoredCommands_Load_MessageBox1" xml:space="preserve">
+	  <value>Error loading commands:
+
+{0}</value>
+  </data>
+  <data name="StoredCommands_Store_MessageBox1" xml:space="preserve">
+	  <value>Error storing commands:
+
+{0}</value>
+  </data>
+  <data name="StoredQuickActions_Load_MessageBox1" xml:space="preserve">
+	  <value>Error loading quick actions:
+
+{0}</value>
+  </data>
+  <data name="StoredQuickActions_Store_MessageBox1" xml:space="preserve">
+	  <value>Error storing quick actions:
+
+{0}</value>
+  </data>
+  <data name="StoredSensors_Load_MessageBox1" xml:space="preserve">
+	  <value>Error loading sensors:
+
+{0}</value>
+  </data>
+  <data name="StoredSensors_Store_MessageBox1" xml:space="preserve">
+	  <value>Error storing sensors:
+
+{0}</value>
+  </data>
+  <data name="Main_LblMqtt" xml:space="preserve">
+    <value>MQTT:</value>
+  </data>
+  <data name="Help_LblWiki" xml:space="preserve">
+    <value>Wiki</value>
+  </data>
+  <data name="Configuration_BtnStore_Busy" xml:space="preserve">
+    <value>Busy, please wait..</value>
+  </data>
+  <data name="ConfigGeneral_LblInterfaceLangauge" xml:space="preserve">
+    <value>Interface &amp;Language</value>
+  </data>
+  <data name="About_LblOr" xml:space="preserve">
+    <value>or</value>
+  </data>
+  <data name="OnboardingManager_BtnNext_Finish" xml:space="preserve">
+    <value>Finish</value>
+  </data>
+  <data name="OnboardingWelcome_LblInterfaceLangauge" xml:space="preserve">
+    <value>Interface &amp;Language</value>
+  </data>
+  <data name="ServiceMqtt_SetMqttStatus_ConfigError" xml:space="preserve">
+    <value>Configuration missing</value>
+  </data>
+  <data name="ServiceMqtt_SetMqttStatus_Connected" xml:space="preserve">
+    <value>Connected</value>
+  </data>
+  <data name="ServiceMqtt_SetMqttStatus_Connecting" xml:space="preserve">
+    <value>Connecting..</value>
+  </data>
+  <data name="ServiceMqtt_SetMqttStatus_Disconnected" xml:space="preserve">
+    <value>Disconnected</value>
+  </data>
+  <data name="ServiceMqtt_SetMqttStatus_Error" xml:space="preserve">
+    <value>Error</value>
+  </data>
+  <data name="CommandType_CustomCommand" xml:space="preserve">
+    <value>Custom</value>
+  </data>
+  <data name="CommandType_CustomExecutorCommand" xml:space="preserve">
+    <value>CustomExecutor</value>
+  </data>
+  <data name="CommandType_HibernateCommand" xml:space="preserve">
+    <value>Hibernate</value>
+  </data>
+  <data name="CommandType_KeyCommand" xml:space="preserve">
+    <value>Key</value>
+  </data>
+  <data name="CommandType_LaunchUrlCommand" xml:space="preserve">
+    <value>LaunchUrl</value>
+  </data>
+  <data name="CommandType_LockCommand" xml:space="preserve">
+    <value>Lock</value>
+  </data>
+  <data name="CommandType_LogOffCommand" xml:space="preserve">
+    <value>LogOff</value>
+  </data>
+  <data name="CommandType_MediaMuteCommand" xml:space="preserve">
+    <value>MediaMute</value>
+  </data>
+  <data name="CommandType_MediaNextCommand" xml:space="preserve">
+    <value>MediaNext</value>
+  </data>
+  <data name="CommandType_MediaPlayPauseCommand" xml:space="preserve">
+    <value>MediaPlayPause</value>
+  </data>
+  <data name="CommandType_MediaPreviousCommand" xml:space="preserve">
+    <value>MediaPrevious</value>
+  </data>
+  <data name="CommandType_MediaVolumeDownCommand" xml:space="preserve">
+    <value>MediaVolumeDown</value>
+  </data>
+  <data name="CommandType_MediaVolumeUpCommand" xml:space="preserve">
+    <value>MediaVolumeUp</value>
+  </data>
+  <data name="CommandType_MultipleKeysCommand" xml:space="preserve">
+    <value>MultipleKeys</value>
+  </data>
+  <data name="CommandType_PowershellCommand" xml:space="preserve">
+    <value>Powershell</value>
+  </data>
+  <data name="CommandType_PublishAllSensorsCommand" xml:space="preserve">
+    <value>PublishAllSensors</value>
+  </data>
+  <data name="CommandType_RestartCommand" xml:space="preserve">
+    <value>Restart</value>
+  </data>
+  <data name="CommandType_ShutdownCommand" xml:space="preserve">
+    <value>Shutdown</value>
+  </data>
+  <data name="CommandType_SleepCommand" xml:space="preserve">
+    <value>Sleep</value>
+  </data>
+  <data name="UserNotificationState_AcceptsNotifications" xml:space="preserve">
+    <value>AcceptsNotifications</value>
+  </data>
+  <data name="UserNotificationState_Busy" xml:space="preserve">
+    <value>Busy</value>
+  </data>
+  <data name="UserNotificationState_NotPresent" xml:space="preserve">
+    <value>NotPresent</value>
+  </data>
+  <data name="UserNotificationState_PresentationMode" xml:space="preserve">
+    <value>PresentationMode</value>
+  </data>
+  <data name="UserNotificationState_QuietTime" xml:space="preserve">
+    <value>QuietTime</value>
+  </data>
+  <data name="UserNotificationState_RunningDirect3dFullScreen" xml:space="preserve">
+    <value>RunningDirect3dFullScreen</value>
+  </data>
+  <data name="UserNotificationState_RunningWindowsStoreApp" xml:space="preserve">
+    <value>RunningWindowsStoreApp</value>
+  </data>
+  <data name="SystemStateEvent_ConsoleConnect" xml:space="preserve">
+    <value>ConsoleConnect</value>
+  </data>
+  <data name="SystemStateEvent_ConsoleDisconnect" xml:space="preserve">
+    <value>ConsoleDisconnect</value>
+  </data>
+  <data name="SystemStateEvent_HassAgentSatelliteServiceStarted" xml:space="preserve">
+    <value>HassAgentSatelliteServiceStarted</value>
+  </data>
+  <data name="SystemStateEvent_HassAgentStarted" xml:space="preserve">
+    <value>HassAgentStarted</value>
+  </data>
+  <data name="SystemStateEvent_Logoff" xml:space="preserve">
+    <value>Logoff</value>
+  </data>
+  <data name="SystemStateEvent_RemoteConnect" xml:space="preserve">
+    <value>RemoteConnect</value>
+  </data>
+  <data name="SystemStateEvent_RemoteDisconnect" xml:space="preserve">
+    <value>RemoteDisconnect</value>
+  </data>
+  <data name="SystemStateEvent_Resume" xml:space="preserve">
+    <value>Resume</value>
+  </data>
+  <data name="SystemStateEvent_SessionLock" xml:space="preserve">
+    <value>SessionLock</value>
+  </data>
+  <data name="SystemStateEvent_SessionLogoff" xml:space="preserve">
+    <value>SessionLogoff</value>
+  </data>
+  <data name="SystemStateEvent_SessionLogon" xml:space="preserve">
+    <value>SessionLogon</value>
+  </data>
+  <data name="SystemStateEvent_SessionRemoteControl" xml:space="preserve">
+    <value>SessionRemoteControl</value>
+  </data>
+  <data name="SystemStateEvent_SessionUnlock" xml:space="preserve">
+    <value>SessionUnlock</value>
+  </data>
+  <data name="SystemStateEvent_Suspend" xml:space="preserve">
+    <value>Suspend</value>
+  </data>
+  <data name="SystemStateEvent_SystemShutdown" xml:space="preserve">
+    <value>SystemShutdown</value>
+  </data>
+  <data name="SensorType_ActiveWindowSensor" xml:space="preserve">
+    <value>ActiveWindow</value>
+  </data>
+  <data name="SensorType_AudioSensors" xml:space="preserve">
+    <value>Audio</value>
+  </data>
+  <data name="SensorType_BatterySensors" xml:space="preserve">
+    <value>Battery</value>
+  </data>
+  <data name="SensorType_CpuLoadSensor" xml:space="preserve">
+    <value>CpuLoad</value>
+  </data>
+  <data name="SensorType_CurrentClockSpeedSensor" xml:space="preserve">
+    <value>CurrentClockSpeed</value>
+  </data>
+  <data name="SensorType_CurrentVolumeSensor" xml:space="preserve">
+    <value>CurrentVolume</value>
+  </data>
+  <data name="SensorType_DisplaySensors" xml:space="preserve">
+    <value>Display</value>
+  </data>
+  <data name="SensorType_DummySensor" xml:space="preserve">
+    <value>Dummy</value>
+  </data>
+  <data name="SensorType_GpuLoadSensor" xml:space="preserve">
+    <value>GpuLoad</value>
+  </data>
+  <data name="SensorType_GpuTemperatureSensor" xml:space="preserve">
+    <value>GpuTemperature</value>
+  </data>
+  <data name="SensorType_LastActiveSensor" xml:space="preserve">
+    <value>LastActive</value>
+  </data>
+  <data name="SensorType_LastBootSensor" xml:space="preserve">
+    <value>LastBoot</value>
+  </data>
+  <data name="SensorType_LastSystemStateChangeSensor" xml:space="preserve">
+    <value>LastSystemStateChange</value>
+  </data>
+  <data name="SensorType_LoggedUserSensor" xml:space="preserve">
+    <value>LoggedUser</value>
+  </data>
+  <data name="SensorType_LoggedUsersSensor" xml:space="preserve">
+    <value>LoggedUsers</value>
+  </data>
+  <data name="SensorType_MemoryUsageSensor" xml:space="preserve">
+    <value>MemoryUsage</value>
+  </data>
+  <data name="SensorType_MicrophoneActiveSensor" xml:space="preserve">
+    <value>MicrophoneActive</value>
+  </data>
+  <data name="SensorType_NamedWindowSensor" xml:space="preserve">
+    <value>NamedWindow</value>
+  </data>
+  <data name="SensorType_NetworkSensors" xml:space="preserve">
+    <value>Network</value>
+  </data>
+  <data name="SensorType_PerformanceCounterSensor" xml:space="preserve">
+    <value>PerformanceCounter</value>
+  </data>
+  <data name="SensorType_ProcessActiveSensor" xml:space="preserve">
+    <value>ProcessActive</value>
+  </data>
+  <data name="SensorType_ServiceStateSensor" xml:space="preserve">
+    <value>ServiceState</value>
+  </data>
+  <data name="SensorType_SessionStateSensor" xml:space="preserve">
+    <value>SessionState</value>
+  </data>
+  <data name="SensorType_StorageSensors" xml:space="preserve">
+    <value>Storage</value>
+  </data>
+  <data name="SensorType_UserNotificationStateSensor" xml:space="preserve">
+    <value>UserNotification</value>
+  </data>
+  <data name="SensorType_WebcamActiveSensor" xml:space="preserve">
+    <value>WebcamActive</value>
+  </data>
+  <data name="SensorType_WindowsUpdatesSensors" xml:space="preserve">
+    <value>WindowsUpdates</value>
+  </data>
+  <data name="SensorType_WmiQuerySensor" xml:space="preserve">
+    <value>WmiQuery</value>
+  </data>
+  <data name="HassDomain_Automation" xml:space="preserve">
+    <value>Automation</value>
+  </data>
+  <data name="HassDomain_Climate" xml:space="preserve">
+    <value>Climate</value>
+  </data>
+  <data name="HassDomain_Cover" xml:space="preserve">
+    <value>Cover</value>
+  </data>
+  <data name="HassDomain_InputBoolean" xml:space="preserve">
+    <value>InputBoolean</value>
+  </data>
+  <data name="HassDomain_Light" xml:space="preserve">
+    <value>Light</value>
+  </data>
+  <data name="HassDomain_MediaPlayer" xml:space="preserve">
+    <value>MediaPlayer</value>
+  </data>
+  <data name="HassDomain_Scene" xml:space="preserve">
+    <value>Scene</value>
+  </data>
+  <data name="HassDomain_Script" xml:space="preserve">
+    <value>Script</value>
+  </data>
+  <data name="HassDomain_Switch" xml:space="preserve">
+    <value>Switch</value>
+  </data>
+  <data name="HassAction_Close" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="HassAction_Off" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="HassAction_On" xml:space="preserve">
+    <value>On</value>
+  </data>
+  <data name="HassAction_Open" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="HassAction_Pause" xml:space="preserve">
+    <value>Pause</value>
+  </data>
+  <data name="HassAction_Play" xml:space="preserve">
+    <value>Play</value>
+  </data>
+  <data name="HassAction_Stop" xml:space="preserve">
+    <value>Stop</value>
+  </data>
+  <data name="HassAction_Toggle" xml:space="preserve">
+    <value>Toggle</value>
+  </data>
+  <data name="CommandEntityType_Button" xml:space="preserve">
+    <value>Button</value>
+  </data>
+  <data name="CommandEntityType_Light" xml:space="preserve">
+    <value>Light</value>
+  </data>
+  <data name="CommandEntityType_Lock" xml:space="preserve">
+    <value>Lock</value>
+  </data>
+  <data name="CommandEntityType_Siren" xml:space="preserve">
+    <value>Siren</value>
+  </data>
+  <data name="CommandEntityType_Switch" xml:space="preserve">
+    <value>Switch</value>
+  </data>
+  <data name="ComponentStatus_Connecting" xml:space="preserve">
+    <value>Connecting..</value>
+  </data>
+  <data name="ComponentStatus_Disabled" xml:space="preserve">
+    <value>Disabled</value>
+  </data>
+  <data name="ComponentStatus_Failed" xml:space="preserve">
+    <value>Failed</value>
+  </data>
+  <data name="ComponentStatus_Loading" xml:space="preserve">
+    <value>Loading..</value>
+  </data>
+  <data name="ComponentStatus_Ok" xml:space="preserve">
+	  <value>Running</value>
+  </data>
+  <data name="ComponentStatus_Stopped" xml:space="preserve">
+    <value>Stopped</value>
+  </data>
+  <data name="LockState_Locked" xml:space="preserve">
+    <value>Locked</value>
+  </data>
+  <data name="LockState_Unknown" xml:space="preserve">
+    <value>Unknown</value>
+  </data>
+  <data name="LockState_Unlocked" xml:space="preserve">
+    <value>Unlocked</value>
+  </data>
+  <data name="SensorType_GeoLocationSensor" xml:space="preserve">
+    <value>GeoLocation</value>
+  </data>
+  <data name="SensorsMod_All" xml:space="preserve">
+    <value>All</value>
+  </data>
+  <data name="SensorsMod_BtnTest" xml:space="preserve">
+    <value>&amp;Test</value>
+  </data>
+  <data name="SensorsMod_BtnTest_PerformanceCounter" xml:space="preserve">
+    <value>Test Performance Counter</value>
+  </data>
+  <data name="SensorsMod_BtnTest_Wmi" xml:space="preserve">
+    <value>Test WMI Query</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_Network" xml:space="preserve">
+    <value>Network Card</value>
+  </data>
+  <data name="SensorsMod_TestPerformanceCounter_MessageBox1" xml:space="preserve">
+    <value>Enter a category and counter first.</value>
+  </data>
+  <data name="SensorsMod_TestPerformanceCounter_MessageBox2" xml:space="preserve">
+	  <value>Test succesfully executed, result value:
+
+{0}</value>
+  </data>
+  <data name="SensorsMod_TestPerformanceCounter_MessageBox3" xml:space="preserve">
+	  <value>The test failed to execute:
+
+{0}
+
+Do you want to open the logs folder?</value>
+  </data>
+  <data name="SensorsMod_TestWmi_MessageBox1" xml:space="preserve">
+    <value>Enter a WMI query first.</value>
+  </data>
+  <data name="SensorsMod_TestWmi_MessageBox2" xml:space="preserve">
+	  <value>Query succesfully executed, result value:
+
+{0}</value>
+  </data>
+  <data name="SensorsMod_TestWmi_MessageBox3" xml:space="preserve">
+	  <value>The query failed to execute:
+
+{0}
+
+Do you want to open the logs folder?</value>
+  </data>
+  <data name="SensorsMod_WmiTestFailed" xml:space="preserve">
+	  <value>It looks like your scope is malformed, it should probably start like this:
+
+\\.\ROOT\
+
+The scope you entered:
+
+{0}
+
+Tip: make sure you haven't switched the scope and query fields around.
+
+Do you still want to use the current values?</value>
+  </data>
+  <data name="SystemStateEvent_ApplicationStarted" xml:space="preserve">
+    <value>ApplicationStarted</value>
+  </data>
+  <data name="ServiceGeneral_LblInfo2" xml:space="preserve">
+    <value>You can use the satellite service to run sensors and commands without having to be logged in. Not all types are available, for instance the 'LaunchUrl' command can only be added as a regular command.</value>
+  </data>
+  <data name="SensorsConfig_ClmValue" xml:space="preserve">
+    <value>Last Known Value</value>
+  </data>
+  <data name="LocalApiManager_Initialize_MessageBox1" xml:space="preserve">
+	  <value>Error trying to bind the API to port {0}.
+
+Make sure no other instance of HASS.Agent is running and the port is available and registered.</value>
+  </data>
+  <data name="CommandType_SendWindowToFrontCommand" xml:space="preserve">
+    <value>SendWindowToFront</value>
+  </data>
+  <data name="CommandType_WebViewCommand" xml:space="preserve">
+    <value>WebView</value>
+  </data>
+  <data name="CommandsManager_WebViewCommandDescription" xml:space="preserve">
+	  <value>Shows a window with the provided URL.
+
+This differs from the 'LaunchUrl' command in that it doesn't load a full-fledged browser, just the provided URL in its own window.
+
+You can use this to for instance quickly show Home Assistant's dashboard.
+
+By default, it stores cookies indefinitely so you only have to log in once.</value>
+  </data>
+  <data name="HassDomain_HASSAgentCommands" xml:space="preserve">
+    <value>HASS.Agent Commands</value>
+  </data>
+  <data name="CommandsManager_CommandsManager_SendWindowToFrontCommandDescription" xml:space="preserve">
+	  <value>Looks for the specified process, and tries to send its main window to the front.
+
+If the application is minimized, it'll get restored.
+
+Example: if you want to send VLC to the foreground, use 'vlc'.</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox8" xml:space="preserve">
+	  <value>If you do not configure the command, you may only use this entity with an 'action' value via Home Assistant and it will appear using the default settings, running it as-is will have no action.
+
+Are you sure you want to do this?</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearAudioCache" xml:space="preserve">
+    <value>Clear Audio Cache</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearAudioCache_InfoText1" xml:space="preserve">
+    <value>Cleaning..</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearAudioCache_MessageBox1" xml:space="preserve">
+    <value>The audio cache has been cleared!</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearWebViewCache" xml:space="preserve">
+    <value>Clear WebView Cache</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearWebViewCache_InfoText1" xml:space="preserve">
+    <value>Cleaning..</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearWebViewCache_MessageBox1" xml:space="preserve">
+    <value>The WebView cache has been cleared!</value>
+  </data>
+  <data name="Main_CheckDpiScalingFactor_MessageBox1" xml:space="preserve">
+	  <value>It looks like you're using an alternative scaling. This may result in some parts of HASS.Agent not looking as intended.
+
+Please report any unusable aspects on GitHub. Thanks!
+
+Note: this message only shows once.</value>
+  </data>
+  <data name="WebViewCommandConfig_SetStoredVariables_MessageBox1" xml:space="preserve">
+    <value>Unable to load the stored command settings, resetting to default.</value>
+  </data>
+  <data name="CommandsMod_BtnConfigureCommand" xml:space="preserve">
+    <value>Configure Command &amp;Parameters</value>
+  </data>
+  <data name="ConfigLocalApi_BtnExecutePortReservation" xml:space="preserve">
+    <value>Execute Port &amp;Reservation</value>
+  </data>
+  <data name="ConfigLocalApi_CbLocalApiActive" xml:space="preserve">
+    <value>&amp;Enable Local API</value>
+  </data>
+  <data name="ConfigLocalApi_LblInfo1" xml:space="preserve">
+	  <value>HASS.Agent has its own local API, so Home Assistant can send requests (for instance to send a notification). You can configure it globally here, and afterwards you can configure the dependent sections (currently notifications and mediaplayer).
+
+Note: this is not required for the new integration to function. Only enable and use it if you don't use MQTT.</value>
+  </data>
+  <data name="ConfigLocalApi_LblInfo2" xml:space="preserve">
+    <value>To be able to listen to the requests, HASS.Agent needs to have its port reserved and opened in your firewall. You can use this button to have it done for you.</value>
+  </data>
+  <data name="ConfigLocalApi_LblPort" xml:space="preserve">
+    <value>&amp;Port</value>
+  </data>
+  <data name="ConfigLocalStorage_LblAudioCacheLocation" xml:space="preserve">
+    <value>Audio Cache Location</value>
+  </data>
+  <data name="ConfigLocalStorage_LblImageCacheDays" xml:space="preserve">
+    <value>days</value>
+  </data>
+  <data name="ConfigLocalStorage_LblImageCacheLocation" xml:space="preserve">
+    <value>Image Cache Location</value>
+  </data>
+  <data name="ConfigLocalStorage_LblKeepAudio" xml:space="preserve">
+    <value>Keep audio for</value>
+  </data>
+  <data name="ConfigLocalStorage_LblKeepImages" xml:space="preserve">
+    <value>Keep images for</value>
+  </data>
+  <data name="ConfigLocalStorage_LblKeepWebView" xml:space="preserve">
+    <value>Clear cache every</value>
+  </data>
+  <data name="ConfigLocalStorage_LblWebViewCacheLocation" xml:space="preserve">
+    <value>WebView Cache Location</value>
+  </data>
+  <data name="ConfigMediaPlayer_BtnMediaPlayerReadme" xml:space="preserve">
+    <value>Media Player &amp;Documentation</value>
+  </data>
+  <data name="ConfigMediaPlayer_CbEnableMediaPlayer" xml:space="preserve">
+    <value>&amp;Enable Media Player Functionality</value>
+  </data>
+  <data name="ConfigMediaPlayer_LblInfo1" xml:space="preserve">
+    <value>HASS.Agent can act as a media player for Home Assistant, so you'll be able to see and control any media that's playing, and send text-to-speech. If you have MQTT enabled, your device will automatically get added. Otherwise, manually configure the integration to use the local API.</value>
+  </data>
+  <data name="ConfigMediaPlayer_LblInfo2" xml:space="preserve">
+	  <value>If something is not working, make sure you try the following steps:
+
+- Install the HASS.Agent integration
+- Restart Home Assistant
+- Make sure HASS.Agent is active with MQTT enabled!
+- Your device should get detected and added as an entity automatically
+- Optionally: manually add it using the local API</value>
+  </data>
+  <data name="ConfigMediaPlayer_LblLocalApiDisabled" xml:space="preserve">
+    <value>The local API is disabled however the media player requires it in order to function.</value>
+  </data>
+  <data name="ConfigMqtt_CbMqttTls" xml:space="preserve">
+    <value>&amp;TLS</value>
+  </data>
+  <data name="ConfigNotifications_LblLocalApiDisabled" xml:space="preserve">
+    <value>The local API is disabled however the media player requires it in order to function.</value>
+  </data>
+  <data name="ConfigTrayIcon_BtnShowWebViewPreview" xml:space="preserve">
+    <value>Show &amp;Preview</value>
+  </data>
+  <data name="ConfigTrayIcon_CbDefaultMenu" xml:space="preserve">
+    <value>Show &amp;Default Menu</value>
+  </data>
+  <data name="ConfigTrayIcon_CbShowWebView" xml:space="preserve">
+    <value>Show &amp;WebView</value>
+  </data>
+  <data name="ConfigTrayIcon_CbWebViewKeepLoaded" xml:space="preserve">
+    <value>&amp;Keep page loaded in the background</value>
+  </data>
+  <data name="ConfigTrayIcon_LblInfo1" xml:space="preserve">
+    <value>Control the behaviour of the tray icon when it is right-clicked.</value>
+  </data>
+  <data name="ConfigTrayIcon_LblInfo2" xml:space="preserve">
+    <value>(This uses extra resources, but reduces loading time.)</value>
+  </data>
+  <data name="ConfigTrayIcon_LblWebViewSize" xml:space="preserve">
+    <value>Size (px)</value>
+  </data>
+  <data name="ConfigTrayIcon_LblWebViewUrl" xml:space="preserve">
+    <value>&amp;WebView URL (For instance, your Home Assistant Dashboard URL)</value>
+  </data>
+  <data name="Configuration_TablLocalApi" xml:space="preserve">
+    <value>Local API</value>
+  </data>
+  <data name="Configuration_TabMediaPlayer" xml:space="preserve">
+    <value>Media Player</value>
+  </data>
+  <data name="Configuration_TabTrayIcon" xml:space="preserve">
+    <value>Tray Icon</value>
+  </data>
+  <data name="HelperFunctions_InputLanguageCheckDiffers_ErrorMsg1" xml:space="preserve">
+    <value>Your input language '{0}' is known to collide with the default CTRL-ALT-Q hotkey. Please set your own.</value>
+  </data>
+  <data name="HelperFunctions_InputLanguageCheckDiffers_ErrorMsg2" xml:space="preserve">
+    <value>Your input language '{0}' is unknown, and might collide with the default CTRL-ALT-Q hotkey. Please check to be sure. If it does, consider opening a ticket on GitHub so it can be added to the list.</value>
+  </data>
+  <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg1" xml:space="preserve">
+    <value>No keys found</value>
+  </data>
+  <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg2" xml:space="preserve">
+    <value>brackets missing, start and close all keys with [ ]</value>
+  </data>
+  <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg3" xml:space="preserve">
+    <value>Error while parsing keys, please check the logs for more information.</value>
+  </data>
+  <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg4" xml:space="preserve">
+    <value>The number of open brackets ('[') does not correspond to the number of closed brackets. (']')! ({0} to {1})</value>
+  </data>
+  <data name="Help_LblDocumentation" xml:space="preserve">
+    <value>Documentation</value>
+  </data>
+  <data name="Help_LblDocumentationInfo" xml:space="preserve">
+    <value>Documentation and Usage Examples</value>
+  </data>
+  <data name="Main_BtnCheckForUpdate" xml:space="preserve">
+    <value>Check for &amp;Updates</value>
+  </data>
+  <data name="Main_LblLocalApi" xml:space="preserve">
+    <value>Local API:</value>
+  </data>
+  <data name="Main_TsSatelliteService" xml:space="preserve">
+    <value>Manage Satellite Service</value>
+  </data>
+  <data name="OnboardingIntegrations_LblInfo1" xml:space="preserve">
+	  <value>To use notifications, you need to install and configure the HASS.Agent-notifier integration in
+Home Assistant.
+
+This is very easy using HACS, but you can also install manually. Visit the link below for more
+information.</value>
+  </data>
+  <data name="OnboardingIntegrations_LblInfo2" xml:space="preserve">
+	  <value>Make sure you follow these steps:
+
+- Install the HASS.Agent-Notifier and / or HASS.Agent-MediaPlayer integration
+- Restart Home Assistant
+-Configure a notifier and / or media_player entity
+-Restart Home Assistant</value>
+  </data>
+  <data name="OnboardingIntegrations_LblInfo3" xml:space="preserve">
+    <value>The same goes for the media player, this integration allows you to control your device as a media_player entity, see what's playing and send text-to-speech.</value>
+  </data>
+  <data name="OnboardingIntegrations_LblMediaPlayerIntegration" xml:space="preserve">
+    <value>HASS.Agent-MediaPlayer GitHub Page</value>
+  </data>
+  <data name="OnboardingIntegrations_LblNotifierIntegration" xml:space="preserve">
+    <value>HASS.Agent-Integration GitHub Page</value>
+  </data>
+  <data name="OnboardingLocalApi_CbEnableLocalApi" xml:space="preserve">
+    <value>Yes, &amp;enable the local API on port</value>
+  </data>
+  <data name="OnboardingLocalApi_CbEnableMediaPlayer" xml:space="preserve">
+    <value>Enable &amp;Media Player and text-to-speech (TTS)</value>
+  </data>
+  <data name="OnboardingLocalApi_CbEnableNotifications" xml:space="preserve">
+    <value>Enable &amp;Notifications</value>
+  </data>
+  <data name="OnboardingLocalApi_LblInfo1" xml:space="preserve">
+	  <value>HASS.Agent has its own internal API, so Home Assistant can send requests (like notifications or text-to-speech).
+
+Do you want to enable it?</value>
+  </data>
+  <data name="OnboardingLocalApi_LblInfo2" xml:space="preserve">
+    <value>You can choose what modules you want to enable. They require HA integrations, but don't worry, the next page will give you more info on how to set them up.</value>
+  </data>
+  <data name="OnboardingLocalApi_LblTip1" xml:space="preserve">
+    <value>Note: 5115 is the default port, only change it if you changed it in Home Assistant.</value>
+  </data>
+  <data name="OnboardingMqtt_CbMqttTls" xml:space="preserve">
+    <value>&amp;TLS</value>
+  </data>
+  <data name="OnboardingWelcome_Store_MessageBox1" xml:space="preserve">
+	  <value>Your device name contained some characters that are not allowed by HA (only letters, digits and whitespace).
+
+The final name is: {0}
+
+Do you want to use that version?</value>
+  </data>
+  <data name="Onboarding_Title" xml:space="preserve">
+    <value>HASS.Agent Onboarding</value>
+  </data>
+  <data name="ServiceGeneral_LblAuthStored" xml:space="preserve">
+    <value>stored!</value>
+  </data>
+  <data name="ServiceMqtt_CbMqttTls" xml:space="preserve">
+    <value>&amp;TLS</value>
+  </data>
+  <data name="WebViewCommandConfig_BtnSave" xml:space="preserve">
+    <value>&amp;Save</value>
+  </data>
+  <data name="WebViewCommandConfig_CbCenterScreen" xml:space="preserve">
+    <value>&amp;Always show centered in screen</value>
+  </data>
+  <data name="WebViewCommandConfig_CbShowTitleBar" xml:space="preserve">
+    <value>Show the window's &amp;title bar</value>
+  </data>
+  <data name="WebViewCommandConfig_CbTopMost" xml:space="preserve">
+    <value>Set window as 'Always on &amp;Top'</value>
+  </data>
+  <data name="WebViewCommandConfig_LblInfo1" xml:space="preserve">
+    <value>Drag and resize this window to set the size and location of your webview command.</value>
+  </data>
+  <data name="WebViewCommandConfig_LblLocation" xml:space="preserve">
+    <value>Location</value>
+  </data>
+  <data name="WebViewCommandConfig_LblSize" xml:space="preserve">
+    <value>Size</value>
+  </data>
+  <data name="WebViewCommandConfig_LblTip1" xml:space="preserve">
+    <value>Tip: Press ESCAPE to close a WebView.</value>
+  </data>
+  <data name="WebViewCommandConfig_LblUrl" xml:space="preserve">
+    <value>&amp;URL</value>
+  </data>
+  <data name="WebViewCommandConfig_Title" xml:space="preserve">
+    <value>WebView Configuration</value>
+  </data>
+  <data name="WebView_Title" xml:space="preserve">
+    <value>WebView</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox9" xml:space="preserve">
+	  <value>The keycode you have provided is not a valid number!
+
+Please ensure the keycode field is in focus and press the key you want simulated, the keycode should then be generated for you.</value>
+  </data>
+  <data name="ConfigGeneral_CbEnableDeviceNameSanitation" xml:space="preserve">
+    <value>Enable Device Name &amp;Sanitation</value>
+  </data>
+  <data name="ConfigGeneral_CbEnableStateNotifications" xml:space="preserve">
+    <value>Enable State Notifications</value>
+  </data>
+  <data name="ConfigGeneral_LblInfo5" xml:space="preserve">
+    <value>HASS.Agent will sanitize your device name to make sure HA will accept it, you can overrule this rule below if you're sure that your name will be accepted as-is.</value>
+  </data>
+  <data name="ConfigGeneral_LblInfo6" xml:space="preserve">
+    <value>HASS.Agent sends notifications when the state of a module changes, you can adjust whether or not you want to receive these notifications below.</value>
+  </data>
+  <data name="Configuration_ProcessChanges_MessageBox6" xml:space="preserve">
+	  <value>You've changed your device's name.
+
+All your sensors and commands will now be unpublished and published again after the HASS.Agent restarts.
+
+Don't worry! they'll keep their current names so your automations and scripts will continue to work.
+
+Note: You disabled sanitation, so make sure your device name is accepted by Home Assistant.</value>
+  </data>
+  <data name="SensorType_PrintersSensors" xml:space="preserve">
+    <value>Printers</value>
+  </data>
+  <data name="CommandType_MonitorSleepCommand" xml:space="preserve">
+    <value>MonitorSleep</value>
+  </data>
+  <data name="CommandType_MonitorWakeCommand" xml:space="preserve">
+    <value>MonitorWake</value>
+  </data>
+  <data name="MonitorPowerEvent_PowerOn" xml:space="preserve">
+    <value>PowerOn</value>
+  </data>
+  <data name="MonitorPowerEvent_PowerOff" xml:space="preserve">
+    <value>PowerOff</value>
+  </data>
+  <data name="MonitorPowerEvent_Dimmed" xml:space="preserve">
+    <value>Dimmed</value>
+  </data>
+  <data name="MonitorPowerEvent_Unknown" xml:space="preserve">
+    <value>Unknown</value>
+  </data>
+  <data name="SensorType_MonitorPowerStateSensor" xml:space="preserve">
+    <value>MonitorPowerState</value>
+  </data>
+  <data name="SensorType_PowershellSensor" xml:space="preserve">
+    <value>PowershellSensor</value>
+  </data>
+  <data name="CommandType_SetVolumeCommand" xml:space="preserve">
+    <value>SetVolume</value>
+  </data>
+  <data name="WindowState_Maximized" xml:space="preserve">
+    <value>Maximized</value>
+  </data>
+  <data name="WindowState_Minimized" xml:space="preserve">
+    <value>Minimized</value>
+  </data>
+  <data name="WindowState_Normal" xml:space="preserve">
+    <value>Normal</value>
+  </data>
+  <data name="WindowState_Unknown" xml:space="preserve">
+    <value>Unknown</value>
+  </data>
+  <data name="WindowState_Hidden" xml:space="preserve">
+    <value>Hidden</value>
+  </data>
+  <data name="SensorType_WindowStateSensor" xml:space="preserve">
+    <value>WindowState</value>
+  </data>
+  <data name="SensorType_WebcamProcessSensor" xml:space="preserve">
+    <value>WebcamProcess</value>
+  </data>
+  <data name="SensorType_MicrophoneProcessSensor" xml:space="preserve">
+    <value>MicrophoneProcess</value>
+  </data>
+  <data name="CommandsManager_MonitorSleepCommandDescription" xml:space="preserve">
+    <value>Puts all monitors in sleep (low power) mode.</value>
+  </data>
+  <data name="CommandsManager_MonitorWakeCommandDescription" xml:space="preserve">
+    <value>Tries to wake up all monitors by simulating a 'arrow up' keypress.</value>
+  </data>
+  <data name="CommandsManager_SetVolumeCommandDescription" xml:space="preserve">
+    <value>Sets the volume of the current default audiodevice to the specified level.</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox10" xml:space="preserve">
+    <value>Please enter a value between 0-100 as the desired volume level!</value>
+  </data>
+  <data name="CommandsMod_CommandsMod" xml:space="preserve">
+    <value>Command</value>
+  </data>
+  <data name="CommandsMod_MessageBox_Action2" xml:space="preserve">
+	  <value>If you don't enter a volume value, you can only use this entity with an 'action' value through Home Assistant. Running it as-is won't do anything.
+
+Are you sure you want this?</value>
+  </data>
+  <data name="CommandsMod_MessageBox_Sanitize" xml:space="preserve">
+	  <value>The name you provided contains unsupported characters and won't work. The suggested version is:
+
+{0}
+
+Do you want to use this version?</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox5" xml:space="preserve">
+	  <value>The API token you have provided doesn't appear to be valid, please ensure you selected the entire token (Don't use CTRL + A or double-click). A valid API key contains three sections, separated by two dots.
+
+Are you sure you want to use this key anyway?</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox6" xml:space="preserve">
+	  <value>The URI you have provided does not appear to be valid, a valid URI may look like either of the following:
+- http://homeassistant.local:8123
+- http://192.168.0.1:8123
+
+Are you sure you want to use this URI anyway?</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_BtnTestApi_Testing" xml:space="preserve">
+    <value>Testing..</value>
+  </data>
+  <data name="ConfigMediaPlayer_LblConnectivityDisabled" xml:space="preserve">
+    <value>both the local API and MQTT are disabled, but the integration needs at least one for it to work</value>
+  </data>
+  <data name="ConfigMqtt_CbEnableMqtt" xml:space="preserve">
+    <value>Enable MQTT</value>
+  </data>
+  <data name="ConfigMqtt_LblMqttDisabledWarning" xml:space="preserve">
+    <value>If MQTT is not enabled, commands and sensors will not work!</value>
+  </data>
+  <data name="ConfigNotifications_LblConnectivityDisabled" xml:space="preserve">
+    <value>both the local API and MQTT are disabled, but the integration needs at least one for it to work</value>
+  </data>
+  <data name="ConfigService_BtnManageService" xml:space="preserve">
+    <value>&amp;Manage Service</value>
+  </data>
+  <data name="ConfigService_BtnManageService_MessageBox1" xml:space="preserve">
+	  <value>The service is currently stopped and cannot be configured.
+
+Please start the service first in order to configure it.</value>
+  </data>
+  <data name="ConfigService_LblInfo5" xml:space="preserve">
+    <value>If you want to manage the service (add commands and sensor, change settings) you can do so here, or by using the 'satellite service' button on the main window.</value>
+  </data>
+  <data name="ConfigTrayIcon_CbWebViewShowMenuOnLeftClick" xml:space="preserve">
+    <value>Show default menu on mouse left-click</value>
+  </data>
+  <data name="Configuration_CheckValues_MessageBox1" xml:space="preserve">
+	  <value>Your Home Assistant API token doesn't look right. Make sure you selected the entire token (don't use CTRL+A or doubleclick).
+It should contain three sections (seperated by two dots).
+
+Are you sure you want to use it like this?</value>
+  </data>
+  <data name="Configuration_CheckValues_MessageBox2" xml:space="preserve">
+	  <value>Your Home Assistant URI doesn't look right. It should look something like 'http://homeassistant.local:8123' or 'https://192.168.0.1:8123'.
+
+Are you sure you want to use it like this?</value>
+  </data>
+  <data name="Configuration_CheckValues_MessageBox3" xml:space="preserve">
+	  <value>Your MQTT broker URI doesn't look right. It should look something like 'homeassistant.local' or '192.168.0.1'.
+
+Are you sure you want to use it like this?</value>
+  </data>
+  <data name="Donate_BtnClose" xml:space="preserve">
+    <value>&amp;Close</value>
+  </data>
+  <data name="Donate_CbHideDonateButton" xml:space="preserve">
+    <value>I already donated, hide the button on the main window.</value>
+  </data>
+  <data name="Donate_LblInfo" xml:space="preserve">
+	  <value>HASS.Agent is completely free, and will always stay that way without restrictions!
+
+However, developing and maintaining this tool (and everything that surrounds it, like support and the docs) takes up a lot of time. 
+
+Like most developers, I run on caffeïne - so if you can spare it, a cup of coffee is always very much appreciated!</value>
+  </data>
+  <data name="Donate_Title" xml:space="preserve">
+    <value>Donate</value>
+  </data>
+  <data name="Main_NotifyIcon_MouseClick_MessageBox1" xml:space="preserve">
+    <value>No URL has been set! Please configure the webview through Configuration -&gt; Tray Icon.</value>
+  </data>
+  <data name="Main_TsCheckForUpdates" xml:space="preserve">
+    <value>Check for Updates</value>
+  </data>
+  <data name="OnboardingApi_BtnTest_MessageBox5" xml:space="preserve">
+	  <value>The API token you have provided doesn't appear to be valid, please ensure you selected the entire token (Don't use CTRL + A or double-click). A valid API key contains three sections, separated by two dots.
+
+Are you sure you want to use this key anyway?</value>
+  </data>
+  <data name="OnboardingApi_BtnTest_MessageBox6" xml:space="preserve">
+	  <value>The URI you have provided does not appear to be valid, a valid URI may look like either of the following:
+- http://homeassistant.local:8123
+- http://192.168.0.1:8123
+
+Are you sure you want to use this URI anyway?</value>
+  </data>
+  <data name="OnboardingDone_LblInfo6" xml:space="preserve">
+    <value>Currently, we (HASS.Agent Team maintaining the fork) do not accept donations in any form :)
+Please however feel free to donate to the original author of HASS.Agent - Sam! Wherever they currently are, cup of coffee might brighten their day.</value>
+  </data>
+  <data name="OnboardingDone_LblTip2" xml:space="preserve">
+    <value>Tip: Other donation methods are available on the About Window.</value>
+  </data>
+  <data name="OnboardingIntegrations_CbEnableMediaPlayer" xml:space="preserve">
+    <value>Enable &amp;Media Player (including text-to-speech)</value>
+  </data>
+  <data name="OnboardingIntegrations_CbEnableNotifications" xml:space="preserve">
+    <value>Enable &amp;Notifications</value>
+  </data>
+  <data name="OnboardingMqtt_CbEnableMqtt" xml:space="preserve">
+    <value>Enable MQTT</value>
+  </data>
+  <data name="PostUpdate_PostUpdate" xml:space="preserve">
+    <value>HASS.Agent Post Update</value>
+  </data>
+  <data name="SensorsManager_BluetoothDevicesSensorDescription" xml:space="preserve">
+	  <value>Provides a sensor with the amount of bluetooth devices found.
+
+The devices and their connected state are added as attributes.</value>
+  </data>
+  <data name="SensorsManager_BluetoothLeDevicesSensorDescription" xml:space="preserve">
+	  <value>Provides a sensors with the amount of bluetooth LE devices found.
+
+The devices and their connected state are added as attributes.
+
+Only shows devices that were seen since the last report, ie. when the sensor publishes, the list clears.</value>
+  </data>
+  <data name="SensorsManager_GeoLocationSensorDescription" xml:space="preserve">
+	  <value>Returns your current latitude, longitude and altitude as a comma-seperated value.
+
+Make sure Windows' location services are enabled!
+
+Depending on your Windows version, this can be found in the new control panel -&gt; 'privacy and security' -&gt; 'location'.</value>
+  </data>
+  <data name="SensorsManager_MicrophoneProcessSensorDescription" xml:space="preserve">
+	  <value>Provides the name of the process that's currently using the microphone.
+
+Note: if used in the satellite service, it won't detect userspace applications.</value>
+  </data>
+  <data name="SensorsManager_MonitorPowerStateSensorDescription" xml:space="preserve">
+	  <value>Provides the last monitor power state change:
+
+Dimmed, PowerOff, PowerOn and Unkown.</value>
+  </data>
+  <data name="SensorsManager_PowershellSensorDescription" xml:space="preserve">
+	  <value>Returns the result of the provided Powershell command or script.
+
+Converts the outcome to text.</value>
+  </data>
+  <data name="SensorsManager_PrintersSensorsDescription" xml:space="preserve">
+    <value>Provides information about all installed printers and their queues.</value>
+  </data>
+  <data name="SensorsManager_WebcamProcessSensorDescription" xml:space="preserve">
+	  <value>Provides the name of the process that's currently using the webcam.
+
+Note: if used in the satellite service, it won't detect userspace applications.</value>
+  </data>
+  <data name="SensorsManager_WindowStateSensorDescription" xml:space="preserve">
+	  <value>Provides the current state of the process' window:
+
+Hidden, Maximized, Minimized, Normal and Unknown.</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_Powershell" xml:space="preserve">
+    <value>powershell command or script</value>
+  </data>
+  <data name="SensorsMod_MessageBox_Sanitize" xml:space="preserve">
+	  <value>The name you provided contains unsupported characters and won't work. The suggested version is:
+
+{0}
+
+Do you want to use this version?</value>
+  </data>
+  <data name="SensorsMod_SensorsMod_BtnTest_Powershell" xml:space="preserve">
+    <value>Test Command/Script</value>
+  </data>
+  <data name="SensorsMod_TestPowershell_MessageBox1" xml:space="preserve">
+    <value>Please enter a command or script!</value>
+  </data>
+  <data name="SensorsMod_TestPowershell_MessageBox2" xml:space="preserve">
+	  <value>Test succesfully executed, result value:
+
+{0}</value>
+  </data>
+  <data name="SensorsMod_TestPowershell_MessageBox3" xml:space="preserve">
+	  <value>The test failed to execute:
+
+{0}
+
+Do you want to open the logs folder?</value>
+  </data>
+  <data name="SensorType_BluetoothDevicesSensor" xml:space="preserve">
+    <value>BluetoothDevices</value>
+  </data>
+  <data name="SensorType_BluetoothLeDevicesSensor" xml:space="preserve">
+    <value>BluetoothLeDevices</value>
+  </data>
+  <data name="ServiceControllerManager_Error_Fatal" xml:space="preserve">
+    <value>Fatal error, please check logs for information!</value>
+  </data>
+  <data name="ServiceControllerManager_Error_Timeout" xml:space="preserve">
+    <value>Timeout expired</value>
+  </data>
+  <data name="ServiceControllerManager_Error_Unknown" xml:space="preserve">
+    <value>unknown reason</value>
+  </data>
+  <data name="ServiceHelper_ChangeStartMode_Error1" xml:space="preserve">
+    <value>unable to open Service Manager</value>
+  </data>
+  <data name="ServiceHelper_ChangeStartMode_Error2" xml:space="preserve">
+    <value>unable to open service</value>
+  </data>
+  <data name="ServiceHelper_ChangeStartMode_Error3" xml:space="preserve">
+    <value>Error configuring startup mode, please check the logs for more information.</value>
+  </data>
+  <data name="ServiceHelper_ChangeStartMode_Error4" xml:space="preserve">
+    <value>Error setting startup mode, please check the logs for more information.</value>
+  </data>
+  <data name="WebView_InitializeAsync_MessageBox1" xml:space="preserve">
+	  <value>Microsoft's WebView2 runtime isn't found on your machine. Usually this is handled by the installer, but you can install it manually.
+
+Do you want to download the runtime installer?</value>
+  </data>
+  <data name="WebView_InitializeAsync_MessageBox2" xml:space="preserve">
+    <value>Something went wrong while initializing the WebView! Please check your logs and open a GitHub issue for further assistance.</value>
+  </data>
+  <data name="QuickActionsMod_ClmDomain" xml:space="preserve">
+	  <value>domain</value>
+  </data>
+  <data name="CommandType_RadioCommand" xml:space="preserve">
+    <value>RadioCommand</value>
+  </data>
+  <data name="SensorType_InternalDeviceSensor" xml:space="preserve">
+    <value>InternalDeviceSensor</value>
+  </data>
+  <data name="SensorType_ActiveDesktopSensor" xml:space="preserve">
+    <value>ActiveDesktop</value>
+  </data>
+  <data name="CommandType_SetApplicationVolumeCommand" xml:space="preserve">
+    <value>SetApplicationVolume</value>
+  </data>
+  <data name="CommandType_SetAudioOutputCommand" xml:space="preserve">
+    <value>SetAudioOutputCommand</value>
+  </data>
+  <data name="SensorType_ScreenshotSensor" xml:space="preserve">
+    <value>Screenshot</value>
+  </data>
+  <data name="CommandType_SetAudioInputCommand" xml:space="preserve">
+    <value>SetAudioInputCommand</value>
+  </data>
+  <data name="CommandType_TrayWebViewCommand" xml:space="preserve">
+    <value>TrayWebView</value>
+  </data>
+  <data name="HassAction_Trigger" xml:space="preserve">
+    <value>Trigger</value>
+  </data>
+  <data name="HassAction_Press" xml:space="preserve">
+    <value>Press</value>
+  </data>
+  <data name="HassDomain_Button" xml:space="preserve">
+    <value>Button</value>
+  </data>
+  <data name="SensorType_NamedActiveWindowSensor" xml:space="preserve">
+    <value>NamedActiveWindow</value>
+  </data>
+  <data name="SensorsManager_NamedActiveWindowSensorDescription" xml:space="preserve">
+    <value>Provides an ON/OFF value based on whether the focused window name contains configured string.</value>
+  </data>
+  <data name="SensorType_AccentColorSensor" xml:space="preserve">
+    <value>AccentColor</value>
+  </data>
+  <data name="HassDomain_InputButton" xml:space="preserve">
+    <value>InputButton</value>
+  </data>
+  <data name="HassDomain_Fan" xml:space="preserve">
+    <value>Fan</value>
+  </data>
+  <data name="CommandsManager_WinformsSleepCommandDescription" xml:space="preserve">
+    <value>Puts the machine to sleep using WinForms API.
+
+Note: due to "Modern Sleep" the sleep commands might behave differently depending on the device OEM and OS configuration.</value>
+  </data>
+  <data name="CommandType_WinformsSleepCommand" xml:space="preserve">
+    <value>WinformsSleep</value>
+  </data>
+  <data name="CommandType_MonitorSleepPowerPlanCommand" xml:space="preserve">
+    <value>MonitorSleepPowerPlan</value>
+  </data>
+  <data name="CommandsManager_MonitorSleepPowerPlanCommandDescription" xml:space="preserve">
+    <value>Puts all monitors in sleep (low power) mode using alternative approach of power plan modification.
+Should provide better experience with new systems with "modern S0ix sleep" and not put the system to sleep.</value>
+  </data>
+</root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.zh-CN.resx
@@ -12,7 +12,7 @@
     
     Example:
     
-    ... ado.net/XML headers & schema ...
+    ... ado.net/XML headers &amp; schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
     <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
@@ -147,7 +147,7 @@
     <value>提示：双击以浏览</value>
   </data>
   <data name="ConfigExternalTools_BtnExternalBrowserIncognitoTest" xml:space="preserve">
-    <value>测试(&T)</value>
+    <value>测试(&amp;T)</value>
   </data>
   <data name="ConfigGeneral_LblInfo4" xml:space="preserve">
     <value>HASS.Agent 在通知您与 MQTT 或 HA 的 API 断开连接之前会等待一个宽限期。
@@ -157,7 +157,7 @@
     <value>秒</value>
   </data>
   <data name="ConfigGeneral_LblDisconGracePeriod" xml:space="preserve">
-    <value>断开连接宽限期(&P)</value>
+    <value>断开连接宽限期(&amp;P)</value>
   </data>
   <data name="ConfigGeneral_LblInfo3" xml:space="preserve">
     <value>重要提示：如果您更改此值，HASS.Agent 将取消发布所有传感器和命令，并强制重启自身，以便它们可以在新设备名称下重新发布。
@@ -171,19 +171,19 @@
     <value>此页面包含常规配置设置，如需更多设置，您可以浏览左侧的选项卡。</value>
   </data>
   <data name="ConfigGeneral_LblDeviceName" xml:space="preserve">
-    <value>设备名称(&N)</value>
+    <value>设备名称(&amp;N)</value>
   </data>
   <data name="ConfigHomeAssistantApi_LblTip1" xml:space="preserve">
     <value>提示：双击此字段以浏览</value>
   </data>
   <data name="ConfigHomeAssistantApi_LblClientCertificate" xml:space="preserve">
-    <value>客户端证书(&C)</value>
+    <value>客户端证书(&amp;C)</value>
   </data>
   <data name="ConfigHomeAssistantApi_CbHassAutoClientCertificate" xml:space="preserve">
-    <value>使用自动客户端证书选择(&A)</value>
+    <value>使用自动客户端证书选择(&amp;A)</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi" xml:space="preserve">
-    <value>测试连接(&T)</value>
+    <value>测试连接(&amp;T)</value>
   </data>
   <data name="ConfigHomeAssistantApi_LblInfo1" xml:space="preserve">
     <value>为了解您配置了哪些实体以及发送快捷操作，HASS.Agent 使用
@@ -194,13 +194,13 @@ Home Assistant 的 API。
 并导航到页面底部，直到您看到"创建令牌"按钮。</value>
   </data>
   <data name="ConfigHomeAssistantApi_LblApiToken" xml:space="preserve">
-    <value>API 令牌(&A)</value>
+    <value>API 令牌(&amp;A)</value>
   </data>
   <data name="ConfigHomeAssistantApi_LblServerUri" xml:space="preserve">
-    <value>服务器 URI(&U)</value>
+    <value>服务器 URI(&amp;U)</value>
   </data>
   <data name="ConfigHotKey_BtnClearHotKey" xml:space="preserve">
-    <value>清除(&C)</value>
+    <value>清除(&amp;C)</value>
   </data>
   <data name="ConfigHotKey_LblInfo1" xml:space="preserve">
     <value>调出快捷操作的一种简单方式是使用全局热键。
@@ -208,10 +208,10 @@ Home Assistant 的 API。
 这样，无论您在机器上做什么，都可以随时与 Home Assistant 交互。</value>
   </data>
   <data name="ConfigHotKey_CbEnableQuickActionsHotkey" xml:space="preserve">
-    <value>启用快捷操作热键(&E)</value>
+    <value>启用快捷操作热键(&amp;E)</value>
   </data>
   <data name="ConfigHotKey_LblHotkeyCombo" xml:space="preserve">
-    <value>热键组合(&H)</value>
+    <value>热键组合(&amp;H)</value>
   </data>
   <data name="ConfigLocalStorage_BtnClearImageCache" xml:space="preserve">
     <value>清除图像缓存</value>
@@ -237,10 +237,10 @@ Home Assistant 的 API。
 HASS.Agent 本身有问题或开发者要求时使用。</value>
   </data>
   <data name="ConfigLogging_CbExtendedLogging" xml:space="preserve">
-    <value>启用扩展日志记录(&E)</value>
+    <value>启用扩展日志记录(&amp;E)</value>
   </data>
   <data name="ConfigLogging_BtnShowLogs" xml:space="preserve">
-    <value>打开日志文件夹(&O)</value>
+    <value>打开日志文件夹(&amp;O)</value>
   </data>
   <data name="ConfigMqtt_LblTip3" xml:space="preserve">
     <value>提示：双击这些字段以浏览</value>
@@ -252,13 +252,13 @@ HASS.Agent 本身有问题或开发者要求时使用。</value>
     <value>根证书</value>
   </data>
   <data name="ConfigMqtt_CbUseRetainFlag" xml:space="preserve">
-    <value>使用保留标志(&R)</value>
+    <value>使用保留标志(&amp;R)</value>
   </data>
   <data name="ConfigMqtt_CbAllowUntrustedCertificates" xml:space="preserve">
-    <value>允许不受信任的证书(&A)</value>
+    <value>允许不受信任的证书(&amp;A)</value>
   </data>
   <data name="ConfigMqtt_BtnMqttClearConfig" xml:space="preserve">
-    <value>清除配置(&C)</value>
+    <value>清除配置(&amp;C)</value>
   </data>
   <data name="ConfigMqtt_LblTip1" xml:space="preserve">
     <value>（如果不确定，保持默认）</value>
@@ -304,13 +304,13 @@ HASS.Agent 本身有问题或开发者要求时使用。</value>
     <value>HASS.Agent 可以接收来自 Home Assistant 的通知，使用文本、图像和操作。如果您已启用 MQTT，您的设备将自动被添加。否则，请手动配置集成以使用本地 API。</value>
   </data>
   <data name="ConfigNotifications_BtnNotificationsReadme" xml:space="preserve">
-    <value>通知文档(&D)</value>
+    <value>通知文档(&amp;D)</value>
   </data>
   <data name="ConfigNotifications_LblPort" xml:space="preserve">
     <value>端口</value>
   </data>
   <data name="ConfigNotifications_CbAcceptNotifications" xml:space="preserve">
-    <value>接受通知(&A)</value>
+    <value>接受通知(&amp;A)</value>
   </data>
   <data name="ConfigNotifications_BtnSendTestNotification" xml:space="preserve">
     <value>显示测试通知</value>
@@ -319,7 +319,7 @@ HASS.Agent 本身有问题或开发者要求时使用。</value>
     <value>执行端口预留</value>
   </data>
   <data name="ConfigNotifications_CbNotificationsIgnoreImageCertErrors" xml:space="preserve">
-    <value>忽略图像的证书错误(&I)</value>
+    <value>忽略图像的证书错误(&amp;I)</value>
   </data>
   <data name="ConfigService_LblInfo1" xml:space="preserve">
     <value>卫星服务允许您在没有用户登录时运行传感器和命令。 
@@ -329,19 +329,19 @@ HASS.Agent 本身有问题或开发者要求时使用。</value>
     <value>服务状态：</value>
   </data>
   <data name="ConfigService_BtnStartService" xml:space="preserve">
-    <value>启动服务(&T)</value>
+    <value>启动服务(&amp;T)</value>
   </data>
   <data name="ConfigService_BtnDisableService" xml:space="preserve">
-    <value>禁用服务(&D)</value>
+    <value>禁用服务(&amp;D)</value>
   </data>
   <data name="ConfigService_BtnStopService" xml:space="preserve">
-    <value>停止服务(&S)</value>
+    <value>停止服务(&amp;S)</value>
   </data>
   <data name="ConfigService_BtnEnableService" xml:space="preserve">
-    <value>启用服务(&E)</value>
+    <value>启用服务(&amp;E)</value>
   </data>
   <data name="ConfigService_BtnReinstallService" xml:space="preserve">
-    <value>重新安装服务(&R)</value>
+    <value>重新安装服务(&amp;R)</value>
   </data>
   <data name="ConfigService_LblInfo2" xml:space="preserve">
     <value>如果您不配置服务，它将不会执行任何操作。不过，您也可以选择禁用它。
@@ -352,7 +352,7 @@ HASS.Agent 本身有问题或开发者要求时使用。</value>
 您的配置和实体不会被删除。</value>
   </data>
   <data name="ConfigService_BtnShowLogs" xml:space="preserve">
-    <value>打开服务日志文件夹(&L)</value>
+    <value>打开服务日志文件夹(&amp;L)</value>
   </data>
   <data name="ConfigService_LblInfo4" xml:space="preserve">
     <value>如果重新安装后服务仍然失败，请提交工单并发送最新日志的内容。</value>
@@ -364,13 +364,13 @@ HASS.Agent 本身有问题或开发者要求时使用。</value>
 HASS.Agent 即可。</value>
   </data>
   <data name="ConfigStartup_BtnSetStartOnLogin" xml:space="preserve">
-    <value>启用登录时启动(&E)</value>
+    <value>启用登录时启动(&amp;E)</value>
   </data>
   <data name="ConfigStartup_LblStartOnLoginStatusInfo" xml:space="preserve">
     <value>登录时启动状态：</value>
   </data>
   <data name="ConfigUpdates_CbBetaUpdates" xml:space="preserve">
-    <value>通知我测试版发布(&B)</value>
+    <value>通知我测试版发布(&amp;B)</value>
   </data>
   <data name="ConfigUpdates_LblInfo2" xml:space="preserve">
     <value>当有新更新可用时，HASS.Agent 可以下载安装程序并为您启动它。
@@ -378,7 +378,7 @@ HASS.Agent 即可。</value>
 在运行之前将检查下载文件的证书，您仍然可以查看发布说明并手动批准更新。</value>
   </data>
   <data name="ConfigUpdates_CbExecuteUpdater" xml:space="preserve">
-    <value>自动下载未来更新(&D)</value>
+    <value>自动下载未来更新(&amp;D)</value>
   </data>
   <data name="ConfigUpdates_LblInfo1" xml:space="preserve">
     <value>如果启用，HASS.Agent 将在后台检查更新。
@@ -387,7 +387,7 @@ HASS.Agent 即可。</value>
 新版本已准备好安装。</value>
   </data>
   <data name="ConfigUpdates_CbUpdates" xml:space="preserve">
-    <value>当有新版本可用时通知我(&R)</value>
+    <value>当有新版本可用时通知我(&amp;R)</value>
   </data>
   <data name="OnboardingWelcome_LblInfo1" xml:space="preserve">
     <value>欢迎使用 HASS.Agent！看起来这是您第一次启动代理。
@@ -399,10 +399,10 @@ HASS.Agent 即可。</value>
     <value>设备名称用于在 Home Assistant 中标识您的机器，它也用作您的命令和传感器的建议前缀。</value>
   </data>
   <data name="OnboardingWelcome_LblDeviceName" xml:space="preserve">
-    <value>设备名称(&N)</value>
+    <value>设备名称(&amp;N)</value>
   </data>
   <data name="OnboardingStartup_BtnSetLaunchOnLogin" xml:space="preserve">
-    <value>是的，在系统登录时启动 HASS.Agent(&S)</value>
+    <value>是的，在系统登录时启动 HASS.Agent(&amp;S)</value>
   </data>
   <data name="OnboardingStartup_LblInfo1" xml:space="preserve">
     <value>HASS.Agent 可以随您的系统启动，这使得您的设备和 Home Assistant 之间的任何传感器和数据传输在您登录时立即开始。
@@ -441,10 +441,10 @@ HASS.Agent 即可。</value>
 信息。</value>
   </data>
   <data name="OnboardingApi_LblApiToken" xml:space="preserve">
-    <value>API 令牌(&T)</value>
+    <value>API 令牌(&amp;T)</value>
   </data>
   <data name="OnboardingApi_LblServerUri" xml:space="preserve">
-    <value>服务器 URI(&U)（这样就很好）</value>
+    <value>服务器 URI(&amp;U)（这样就很好）</value>
   </data>
   <data name="OnboardingApi_LblInfo1" xml:space="preserve">
     <value>为了解您配置了哪些实体以及发送快捷操作，HASS.Agent 使用
@@ -455,7 +455,7 @@ Home Assistant 的 API。
 并导航到页面底部，直到您看到"创建令牌"按钮。</value>
   </data>
   <data name="OnboardingApi_BtnTest" xml:space="preserve">
-    <value>测试连接(&C)</value>
+    <value>测试连接(&amp;C)</value>
   </data>
   <data name="OnboardingApi_LblTip1" xml:space="preserve">
     <value>提示：可以在配置窗口中找到专用设置。</value>
@@ -488,7 +488,7 @@ Home Assistant 的 API。
     <value>提示：可以在配置窗口中找到专用设置。</value>
   </data>
   <data name="OnboardingHotKey_LblHotkeyCombo" xml:space="preserve">
-    <value>热键组合(&H)</value>
+    <value>热键组合(&amp;H)</value>
   </data>
   <data name="OnboardingHotKey_LblInfo1" xml:space="preserve">
     <value>调出快捷操作的一种简单方式是使用全局热键。
@@ -497,7 +497,7 @@ Home Assistant 的 API。
 </value>
   </data>
   <data name="OnboardingHotKey_BtnClear" xml:space="preserve">
-    <value>清除(&C)</value>
+    <value>清除(&amp;C)</value>
   </data>
   <data name="OnboardingUpdates_LblInfo1" xml:space="preserve">
     <value>如果启用，HASS.Agent 将在后台检查更新。
@@ -511,7 +511,7 @@ Home Assistant 的 API。
     <value>Yes, notify me on new &amp;updates</value>
   </data>
   <data name="OnboardingUpdates_CbExecuteUpdater" xml:space="preserve">
-    <value>是的，为我下载并启动安装程序(&D)</value>
+    <value>是的，为我下载并启动安装程序(&amp;D)</value>
   </data>
   <data name="OnboardingUpdates_LblInfo2" xml:space="preserve">
     <value>当有新更新可用时，HASS.Agent 可以下载安装程序并为您启动它。
@@ -544,25 +544,25 @@ Home Assistant 的 API。
     <value>类型</value>
   </data>
   <data name="ServiceCommands_BtnRemove" xml:space="preserve">
-    <value>移除(&R)</value>
+    <value>移除(&amp;R)</value>
   </data>
   <data name="ServiceCommands_BtnModify" xml:space="preserve">
-    <value>修改(&M)</value>
+    <value>修改(&amp;M)</value>
   </data>
   <data name="ServiceCommands_BtnAdd" xml:space="preserve">
-    <value>添加新项(&A)</value>
+    <value>添加新项(&amp;A)</value>
   </data>
   <data name="ServiceCommands_BtnStore" xml:space="preserve">
-    <value>发送并激活命令(&S)</value>
+    <value>发送并激活命令(&amp;S)</value>
   </data>
   <data name="ServiceCommands_LblStored" xml:space="preserve">
     <value>命令已存储！</value>
   </data>
   <data name="ServiceConnect_BtnRetryAuthId" xml:space="preserve">
-    <value>应用(&A)</value>
+    <value>应用(&amp;A)</value>
   </data>
   <data name="ServiceConnect_LblRetryAuthId" xml:space="preserve">
-    <value>身份验证 ID(&I)</value>
+    <value>身份验证 ID(&amp;I)</value>
   </data>
   <data name="ServiceConnect_LblAuthenticate" xml:space="preserve">
     <value>身份验证</value>
@@ -580,25 +580,25 @@ Home Assistant 的 API。
     <value>此页面包含常规配置设置，如需 MQTT 设置、命令和传感器，请浏览上方不同的选项卡。</value>
   </data>
   <data name="ServiceGeneral_LblAuthId" xml:space="preserve">
-    <value>身份验证 ID(&I)</value>
+    <value>身份验证 ID(&amp;I)</value>
   </data>
   <data name="ServiceGeneral_LblDeviceName" xml:space="preserve">
-    <value>设备名称(&N)</value>
+    <value>设备名称(&amp;N)</value>
   </data>
   <data name="ServiceGeneral_LblTip1" xml:space="preserve">
     <value>提示：双击这些字段以浏览</value>
   </data>
   <data name="ServiceGeneral_LblCustomExecBinary" xml:space="preserve">
-    <value>自定义执行器可执行文件(&B)</value>
+    <value>自定义执行器可执行文件(&amp;B)</value>
   </data>
   <data name="ServiceGeneral_LblCustomExecName" xml:space="preserve">
-    <value>自定义执行器名称(&E)</value>
+    <value>自定义执行器名称(&amp;E)</value>
   </data>
   <data name="ServiceGeneral_LblSeconds" xml:space="preserve">
     <value>秒</value>
   </data>
   <data name="ServiceGeneral_LblDisconGrace" xml:space="preserve">
-    <value>断开连接宽限期(&P)</value>
+    <value>断开连接宽限期(&amp;P)</value>
   </data>
   <data name="ServiceGeneral_Apply" xml:space="preserve">
     <value>应用</value>
@@ -628,13 +628,13 @@ Home Assistant 的 API。
     <value>根证书</value>
   </data>
   <data name="ServiceMqtt_CbUseRetainFlag" xml:space="preserve">
-    <value>使用保留标志(&R)</value>
+    <value>使用保留标志(&amp;R)</value>
   </data>
   <data name="ServiceMqtt_CbAllowUntrustedCertificates" xml:space="preserve">
-    <value>允许不受信任的证书(&A)</value>
+    <value>允许不受信任的证书(&amp;A)</value>
   </data>
   <data name="ServiceMqtt_BtnMqttClearConfig" xml:space="preserve">
-    <value>清除配置(&C)</value>
+    <value>清除配置(&amp;C)</value>
   </data>
   <data name="ServiceMqtt_LblTip1" xml:space="preserve">
     <value>（如果不确定，保持默认）</value>
@@ -659,10 +659,10 @@ Home Assistant 的 API。
     <value>代理 IP 地址或主机名</value>
   </data>
   <data name="ServiceMqtt_BtnStore" xml:space="preserve">
-    <value>发送并激活配置(&S)</value>
+    <value>发送并激活配置(&amp;S)</value>
   </data>
   <data name="ServiceMqtt_BtnCopy" xml:space="preserve">
-    <value>从 HASS.Agent 复制(&H)</value>
+    <value>从 HASS.Agent 复制(&amp;H)</value>
   </data>
   <data name="ServiceMqtt_LblStored" xml:space="preserve">
     <value>配置已存储！</value>
@@ -683,16 +683,16 @@ Home Assistant 的 API。
     <value>刷新</value>
   </data>
   <data name="ServiceSensors_BtnRemove" xml:space="preserve">
-    <value>移除(&R)</value>
+    <value>移除(&amp;R)</value>
   </data>
   <data name="ServiceSensors_BtnAdd" xml:space="preserve">
-    <value>添加新项(&A)</value>
+    <value>添加新项(&amp;A)</value>
   </data>
   <data name="ServiceSensors_BtnModify" xml:space="preserve">
-    <value>修改(&M)</value>
+    <value>修改(&amp;M)</value>
   </data>
   <data name="ServiceSensors_BtnStore" xml:space="preserve">
-    <value>发送并激活传感器(&S)</value>
+    <value>发送并激活传感器(&amp;S)</value>
   </data>
   <data name="ServiceSensors_LblStored" xml:space="preserve">
     <value>传感器已存储！</value>
@@ -755,13 +755,13 @@ Home Assistant 的 API。
     <value>HASS.Agent 配置卫星服务</value>
   </data>
   <data name="CommandMqttTopic_BtnClose" xml:space="preserve">
-    <value>关闭(&C)</value>
+    <value>关闭(&amp;C)</value>
   </data>
   <data name="CommandMqttTopic_LblInfo1" xml:space="preserve">
     <value>这是您可以发布操作命令的 MQTT 主题：</value>
   </data>
   <data name="CommandMqttTopic_BtnCopyClipboard" xml:space="preserve">
-    <value>复制到剪贴板(&T)</value>
+    <value>复制到剪贴板(&amp;T)</value>
   </data>
   <data name="CommandMqttTopic_LblHelp" xml:space="preserve">
     <value>帮助和示例</value>
@@ -770,16 +770,16 @@ Home Assistant 的 API。
     <value>MQTT 操作主题</value>
   </data>
   <data name="CommandsConfig_BtnRemove" xml:space="preserve">
-    <value>移除(&R)</value>
+    <value>移除(&amp;R)</value>
   </data>
   <data name="CommandsConfig_BtnModify" xml:space="preserve">
-    <value>修改(&M)</value>
+    <value>修改(&amp;M)</value>
   </data>
   <data name="CommandsConfig_BtnAdd" xml:space="preserve">
-    <value>添加新项(&A)</value>
+    <value>添加新项(&amp;A)</value>
   </data>
   <data name="CommandsConfig_BtnStore" xml:space="preserve">
-    <value>存储并激活命令(&S)</value>
+    <value>存储并激活命令(&amp;S)</value>
   </data>
   <data name="CommandsConfig_ClmName" xml:space="preserve">
     <value>名称</value>
@@ -797,19 +797,19 @@ Home Assistant 的 API。
     <value>命令配置</value>
   </data>
   <data name="CommandsMod_BtnStore" xml:space="preserve">
-    <value>存储命令(&S)</value>
+    <value>存储命令(&amp;S)</value>
   </data>
   <data name="CommandsMod_LblSetting" xml:space="preserve">
-    <value>配置(&C)</value>
+    <value>配置(&amp;C)</value>
   </data>
   <data name="CommandsMod_LblName" xml:space="preserve">
-    <value>名称(&N)</value>
+    <value>名称(&amp;N)</value>
   </data>
   <data name="CommandsMod_LblDescription" xml:space="preserve">
     <value>描述</value>
   </data>
   <data name="CommandsMod_CbRunAsLowIntegrity" xml:space="preserve">
-    <value>以"低完整性"运行(&R)</value>
+    <value>以"低完整性"运行(&amp;R)</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo" xml:space="preserve">
     <value>这是什么？</value>
@@ -830,7 +830,7 @@ Home Assistant 的 API。
     <value>仅 HASS.Agent！</value>
   </data>
   <data name="CommandsMod_LblEntityType" xml:space="preserve">
-    <value>实体类型(&E)</value>
+    <value>实体类型(&amp;E)</value>
   </data>
   <data name="CommandsMod_LblMqttTopic" xml:space="preserve">
     <value>显示 MQTT 操作主题</value>
@@ -848,19 +848,19 @@ Home Assistant 的 API。
     <value>快捷操作</value>
   </data>
   <data name="QuickActionsConfig_BtnStore" xml:space="preserve">
-    <value>存储快捷操作(&S)</value>
+    <value>存储快捷操作(&amp;S)</value>
   </data>
   <data name="QuickActionsConfig_BtnAdd" xml:space="preserve">
-    <value>添加新项(&A)</value>
+    <value>添加新项(&amp;A)</value>
   </data>
   <data name="QuickActionsConfig_BtnModify" xml:space="preserve">
-    <value>修改(&M)</value>
+    <value>修改(&amp;M)</value>
   </data>
   <data name="QuickActionsConfig_BtnRemove" xml:space="preserve">
-    <value>移除(&R)</value>
+    <value>移除(&amp;R)</value>
   </data>
   <data name="QuickActionsConfig_BtnPreview" xml:space="preserve">
-    <value>预览(&P)</value>
+    <value>预览(&amp;P)</value>
   </data>
   <data name="QuickActionsConfig_ClmDomain" xml:space="preserve">
     <value>域</value>
@@ -2536,7 +2536,7 @@ NotPresent、Busy、RunningDirect3dFullScreen、PresentationMode、AcceptsNotifi
     <value>全部</value>
   </data>
   <data name="SensorsMod_BtnTest" xml:space="preserve">
-    <value>测试(&T)</value>
+    <value>测试(&amp;T)</value>
   </data>
   <data name="SensorsMod_BtnTest_PerformanceCounter" xml:space="preserve">
     <value>测试性能计数器</value>
@@ -2663,13 +2663,13 @@ NotPresent、Busy、RunningDirect3dFullScreen、PresentationMode、AcceptsNotifi
     <value>无法加载存储的命令设置，将重置为默认值。</value>
   </data>
   <data name="CommandsMod_BtnConfigureCommand" xml:space="preserve">
-    <value>配置命令参数(&P)</value>
+    <value>配置命令参数(&amp;P)</value>
   </data>
   <data name="ConfigLocalApi_BtnExecutePortReservation" xml:space="preserve">
-    <value>执行端口保留(&R)</value>
+    <value>执行端口保留(&amp;R)</value>
   </data>
   <data name="ConfigLocalApi_CbLocalApiActive" xml:space="preserve">
-    <value>启用本地 API(&E)</value>
+    <value>启用本地 API(&amp;E)</value>
   </data>
   <data name="ConfigLocalApi_LblInfo1" xml:space="preserve">
     <value>HASS.Agent 有自己的本地 API，因此 Home Assistant 可以发送请求（例如发送通知）。你可以在此处全局配置它，然后配置相关部分（目前是通知和媒体播放器）。
@@ -2680,7 +2680,7 @@ NotPresent、Busy、RunningDirect3dFullScreen、PresentationMode、AcceptsNotifi
     <value>为了能够监听请求，HASS.Agent 需要在你的防火墙中保留并打开其端口。你可以使用此按钮自动完成此操作。</value>
   </data>
   <data name="ConfigLocalApi_LblPort" xml:space="preserve">
-    <value>端口(&P)</value>
+    <value>端口(&amp;P)</value>
   </data>
   <data name="ConfigLocalStorage_LblAudioCacheLocation" xml:space="preserve">
     <value>音频缓存位置</value>
@@ -2704,10 +2704,10 @@ NotPresent、Busy、RunningDirect3dFullScreen、PresentationMode、AcceptsNotifi
     <value>WebView 缓存位置</value>
   </data>
   <data name="ConfigMediaPlayer_BtnMediaPlayerReadme" xml:space="preserve">
-    <value>媒体播放器文档(&D)</value>
+    <value>媒体播放器文档(&amp;D)</value>
   </data>
   <data name="ConfigMediaPlayer_CbEnableMediaPlayer" xml:space="preserve">
-    <value>启用媒体播放器功能(&E)</value>
+    <value>启用媒体播放器功能(&amp;E)</value>
   </data>
   <data name="ConfigMediaPlayer_LblInfo1" xml:space="preserve">
     <value>HASS.Agent 可以作为 Home Assistant 的媒体播放器，因此你将能够查看和控制任何正在播放的媒体，并发送文本转语音。如果你启用了 MQTT，你的设备将被自动添加。否则，请手动配置集成以使用本地 API。</value>
@@ -2725,22 +2725,22 @@ NotPresent、Busy、RunningDirect3dFullScreen、PresentationMode、AcceptsNotifi
     <value>本地 API 已禁用，但媒体播放器需要它才能运行。</value>
   </data>
   <data name="ConfigMqtt_CbMqttTls" xml:space="preserve">
-    <value>TLS(&T)</value>
+    <value>TLS(&amp;T)</value>
   </data>
   <data name="ConfigNotifications_LblLocalApiDisabled" xml:space="preserve">
     <value>本地 API 已禁用，但媒体播放器需要它才能运行。</value>
   </data>
   <data name="ConfigTrayIcon_BtnShowWebViewPreview" xml:space="preserve">
-    <value>显示预览(&P)</value>
+    <value>显示预览(&amp;P)</value>
   </data>
   <data name="ConfigTrayIcon_CbDefaultMenu" xml:space="preserve">
-    <value>显示默认菜单(&D)</value>
+    <value>显示默认菜单(&amp;D)</value>
   </data>
   <data name="ConfigTrayIcon_CbShowWebView" xml:space="preserve">
-    <value>显示 WebView(&W)</value>
+    <value>显示 WebView(&amp;W)</value>
   </data>
   <data name="ConfigTrayIcon_CbWebViewKeepLoaded" xml:space="preserve">
-    <value>在后台保持页面加载(&K)</value>
+    <value>在后台保持页面加载(&amp;K)</value>
   </data>
   <data name="ConfigTrayIcon_LblInfo1" xml:space="preserve">
     <value>控制右键单击托盘图标时的行为。</value>
@@ -2752,7 +2752,7 @@ NotPresent、Busy、RunningDirect3dFullScreen、PresentationMode、AcceptsNotifi
     <value>大小 (px)</value>
   </data>
   <data name="ConfigTrayIcon_LblWebViewUrl" xml:space="preserve">
-    <value>WebView URL(&W)（例如，你的 Home Assistant 仪表板 URL）</value>
+    <value>WebView URL(&amp;W)（例如，你的 Home Assistant 仪表板 URL）</value>
   </data>
   <data name="Configuration_TablLocalApi" xml:space="preserve">
     <value>本地 API</value>
@@ -2788,7 +2788,7 @@ NotPresent、Busy、RunningDirect3dFullScreen、PresentationMode、AcceptsNotifi
     <value>文档和使用示例</value>
   </data>
   <data name="Main_BtnCheckForUpdate" xml:space="preserve">
-    <value>检查更新(&U)</value>
+    <value>检查更新(&amp;U)</value>
   </data>
   <data name="Main_LblLocalApi" xml:space="preserve">
     <value>本地 API：</value>
@@ -2819,13 +2819,13 @@ NotPresent、Busy、RunningDirect3dFullScreen、PresentationMode、AcceptsNotifi
     <value>HASS.Agent-Integration GitHub 页面</value>
   </data>
   <data name="OnboardingLocalApi_CbEnableLocalApi" xml:space="preserve">
-    <value>是，启用本地 API 端口(&E)</value>
+    <value>是，启用本地 API 端口(&amp;E)</value>
   </data>
   <data name="OnboardingLocalApi_CbEnableMediaPlayer" xml:space="preserve">
-    <value>启用媒体播放器和文本转语音(TTS)(&M)</value>
+    <value>启用媒体播放器和文本转语音(TTS)(&amp;M)</value>
   </data>
   <data name="OnboardingLocalApi_CbEnableNotifications" xml:space="preserve">
-    <value>启用通知(&N)</value>
+    <value>启用通知(&amp;N)</value>
   </data>
   <data name="OnboardingLocalApi_LblInfo1" xml:space="preserve">
     <value>HASS.Agent 有自己的内部 API，因此 Home Assistant 可以发送请求（如通知或文本转语音）。
@@ -2839,7 +2839,7 @@ NotPresent、Busy、RunningDirect3dFullScreen、PresentationMode、AcceptsNotifi
     <value>注意：5115 是默认端口，只有在 Home Assistant 中更改过才需要修改。</value>
   </data>
   <data name="OnboardingMqtt_CbMqttTls" xml:space="preserve">
-    <value>TLS(&T)</value>
+    <value>TLS(&amp;T)</value>
   </data>
   <data name="OnboardingWelcome_Store_MessageBox1" xml:space="preserve">
     <value>你的设备名称包含一些 HA 不允许的字符（只允许字母、数字和空格）。
@@ -2855,19 +2855,19 @@ NotPresent、Busy、RunningDirect3dFullScreen、PresentationMode、AcceptsNotifi
     <value>已存储！</value>
   </data>
   <data name="ServiceMqtt_CbMqttTls" xml:space="preserve">
-    <value>TLS(&T)</value>
+    <value>TLS(&amp;T)</value>
   </data>
   <data name="WebViewCommandConfig_BtnSave" xml:space="preserve">
-    <value>保存(&S)</value>
+    <value>保存(&amp;S)</value>
   </data>
   <data name="WebViewCommandConfig_CbCenterScreen" xml:space="preserve">
-    <value>始终在屏幕居中显示(&A)</value>
+    <value>始终在屏幕居中显示(&amp;A)</value>
   </data>
   <data name="WebViewCommandConfig_CbShowTitleBar" xml:space="preserve">
-    <value>显示窗口标题栏(&T)</value>
+    <value>显示窗口标题栏(&amp;T)</value>
   </data>
   <data name="WebViewCommandConfig_CbTopMost" xml:space="preserve">
-    <value>将窗口设置为'始终置顶'(&T)</value>
+    <value>将窗口设置为'始终置顶'(&amp;T)</value>
   </data>
   <data name="WebViewCommandConfig_LblInfo1" xml:space="preserve">
     <value>拖动并调整此窗口的大小，以设置你的 WebView 命令的大小和位置。</value>
@@ -2882,7 +2882,7 @@ NotPresent、Busy、RunningDirect3dFullScreen、PresentationMode、AcceptsNotifi
     <value>提示：按 ESCAPE 键关闭 WebView。</value>
   </data>
   <data name="WebViewCommandConfig_LblUrl" xml:space="preserve">
-    <value>URL(&U)</value>
+    <value>URL(&amp;U)</value>
   </data>
   <data name="WebViewCommandConfig_Title" xml:space="preserve">
     <value>WebView 配置</value>
@@ -2896,7 +2896,7 @@ NotPresent、Busy、RunningDirect3dFullScreen、PresentationMode、AcceptsNotifi
 请确保键码字段处于焦点状态，然后按下你想要模拟的键，系统将为你生成键码。</value>
   </data>
   <data name="ConfigGeneral_CbEnableDeviceNameSanitation" xml:space="preserve">
-    <value>启用设备名称清理(&S)</value>
+    <value>启用设备名称清理(&amp;S)</value>
   </data>
   <data name="ConfigGeneral_CbEnableStateNotifications" xml:space="preserve">
     <value>启用状态通知</value>
@@ -3025,7 +3025,7 @@ NotPresent、Busy、RunningDirect3dFullScreen、PresentationMode、AcceptsNotifi
     <value>本地 API 和 MQTT 均已禁用，但集成需要至少启用一个才能工作</value>
   </data>
   <data name="ConfigService_BtnManageService" xml:space="preserve">
-    <value>管理服务(&M)</value>
+    <value>管理服务(&amp;M)</value>
   </data>
   <data name="ConfigService_BtnManageService_MessageBox1" xml:space="preserve">
     <value>服务当前已停止，无法配置。
@@ -3055,7 +3055,7 @@ NotPresent、Busy、RunningDirect3dFullScreen、PresentationMode、AcceptsNotifi
 你确定要这样使用它吗？</value>
   </data>
   <data name="Donate_BtnClose" xml:space="preserve">
-    <value>关闭(&C)</value>
+    <value>关闭(&amp;C)</value>
   </data>
   <data name="Donate_CbHideDonateButton" xml:space="preserve">
     <value>我已经捐赠，在主窗口上隐藏按钮。</value>
@@ -3096,10 +3096,10 @@ NotPresent、Busy、RunningDirect3dFullScreen、PresentationMode、AcceptsNotifi
     <value>提示：其他捐赠方式可在"关于"窗口中找到。</value>
   </data>
   <data name="OnboardingIntegrations_CbEnableMediaPlayer" xml:space="preserve">
-    <value>启用媒体播放器(&M)（包括文本转语音）</value>
+    <value>启用媒体播放器(&amp;M)（包括文本转语音）</value>
   </data>
   <data name="OnboardingIntegrations_CbEnableNotifications" xml:space="preserve">
-    <value>启用通知(&N)</value>
+    <value>启用通知(&amp;N)</value>
   </data>
   <data name="OnboardingMqtt_CbEnableMqtt" xml:space="preserve">
     <value>启用 MQTT</value>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.zh-CN.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -118,2079 +118,2078 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ConfigExternalTools_LblInfo1" xml:space="preserve">
-    <value>This page allows you to configure bindings with external tools.</value>
+    <value>此页面允许您配置与外部工具的绑定。</value>
   </data>
   <data name="ConfigExternalTools_LblBrowserName" xml:space="preserve">
-    <value>Browser Name</value>
+    <value>浏览器名称</value>
   </data>
   <data name="ConfigExternalTools_LblInfo2" xml:space="preserve">
-	  <value>By default HASS.Agent will launch URLs using your default browser. You can also configure
-a specific browser to be used instead along with launch arguments to run in private mode.</value>
+    <value>默认情况下，HASS.Agent 将使用您的默认浏览器打开 URL。您也可以配置
+一个特定的浏览器来替代使用，并附带启动参数以隐私模式运行。</value>
   </data>
   <data name="ConfigExternalTools_LblBrowserBinary" xml:space="preserve">
-    <value>Browser Binary</value>
+    <value>浏览器可执行文件</value>
   </data>
   <data name="ConfigExternalTools_LblLaunchIncogArg" xml:space="preserve">
-    <value>Additional Launch Arguments</value>
+    <value>额外的启动参数</value>
   </data>
   <data name="ConfigExternalTools_LblCustomExecutorBinary" xml:space="preserve">
-    <value>Custom Executor Binary</value>
+    <value>自定义执行器可执行文件</value>
   </data>
   <data name="ConfigExternalTools_LblInfo3" xml:space="preserve">
-	  <value>You can configure the HASS.Agent to use a specific interpreter such as Perl or Python.
-Use the 'custom executor' command to launch this executor.</value>
+    <value>您可以将 HASS.Agent 配置为使用特定的解释器，例如 Perl 或 Python。
+使用"自定义执行器"命令来启动此执行器。</value>
   </data>
   <data name="ConfigExternalTools_LblCustomExecutorName" xml:space="preserve">
-    <value>Custom Executor Name</value>
+    <value>自定义执行器名称</value>
   </data>
   <data name="ConfigExternalTools_LblTip1" xml:space="preserve">
-    <value>Tip: Double-click to Browse</value>
+    <value>提示：双击以浏览</value>
   </data>
   <data name="ConfigExternalTools_BtnExternalBrowserIncognitoTest" xml:space="preserve">
-    <value>&amp;Test</value>
+    <value>测试(&T)</value>
   </data>
   <data name="ConfigGeneral_LblInfo4" xml:space="preserve">
-	  <value>HASS.Agent will wait a grace period before notifying you of disconnects from MQTT or HA's API.
-You can set the amount of seconds to wait in this grace period below.</value>
+    <value>HASS.Agent 在通知您与 MQTT 或 HA 的 API 断开连接之前会等待一个宽限期。
+您可以在下方设置此宽限期内等待的秒数。</value>
   </data>
   <data name="ConfigGeneral_LblDisconGraceSeconds" xml:space="preserve">
-    <value>Seconds</value>
+    <value>秒</value>
   </data>
   <data name="ConfigGeneral_LblDisconGracePeriod" xml:space="preserve">
-    <value>Disconnected Grace &amp;Period</value>
+    <value>断开连接宽限期(&P)</value>
   </data>
   <data name="ConfigGeneral_LblInfo3" xml:space="preserve">
-	  <value>IMPORTANT: if you change this value, HASS.Agent will unpublish all your sensors, commands and force a restart of itself so they can be republished under the new device name.
-Your automations and scripts will keep working.</value>
+    <value>重要提示：如果您更改此值，HASS.Agent 将取消发布所有传感器和命令，并强制重启自身，以便它们可以在新设备名称下重新发布。
+您的自动化和脚本将继续工作。</value>
   </data>
   <data name="ConfigGeneral_LblInfo2" xml:space="preserve">
-	  <value>The device name is used to identify your machine on Home Assistant.
-It is also used as a prefix for your command/sensor names (this can be changed per entity).</value>
+    <value>设备名称用于在 Home Assistant 中标识您的机器。
+它还用作您的命令/传感器名称的前缀（可以按实体更改）。</value>
   </data>
   <data name="ConfigGeneral_LblInfo1" xml:space="preserve">
-    <value>This page contains general configuration settings, for more settings you can browse the tabs on the left.</value>
+    <value>此页面包含常规配置设置，如需更多设置，您可以浏览左侧的选项卡。</value>
   </data>
   <data name="ConfigGeneral_LblDeviceName" xml:space="preserve">
-    <value>Device &amp;Name</value>
+    <value>设备名称(&N)</value>
   </data>
   <data name="ConfigHomeAssistantApi_LblTip1" xml:space="preserve">
-    <value>Tip: Double-click this field to browse</value>
+    <value>提示：双击此字段以浏览</value>
   </data>
   <data name="ConfigHomeAssistantApi_LblClientCertificate" xml:space="preserve">
-    <value>Client &amp;Certificate</value>
+    <value>客户端证书(&C)</value>
   </data>
   <data name="ConfigHomeAssistantApi_CbHassAutoClientCertificate" xml:space="preserve">
-    <value>Use &amp;automatic client certificate selection</value>
+    <value>使用自动客户端证书选择(&A)</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi" xml:space="preserve">
-    <value>&amp;Test Connection</value>
+    <value>测试连接(&T)</value>
   </data>
   <data name="ConfigHomeAssistantApi_LblInfo1" xml:space="preserve">
-	  <value>To learn which entities you have configured and to send quick actions, HASS.Agent uses
-Home Assistant's API.
+    <value>为了解您配置了哪些实体以及发送快捷操作，HASS.Agent 使用
+Home Assistant 的 API。
 
-Please provide a long-lived access token and the address of your Home Assistant instance.
-You can get a token in Home Assistant by clicking your profile picture at the bottom-left
-and navigating to the bottom of the page until you see the 'CREATE TOKEN' button.</value>
+请提供一个长期有效的访问令牌和您的 Home Assistant 实例地址。
+您可以在 Home Assistant 中点击左下角的个人资料图片，
+并导航到页面底部，直到您看到"创建令牌"按钮。</value>
   </data>
   <data name="ConfigHomeAssistantApi_LblApiToken" xml:space="preserve">
-    <value>&amp;API Token</value>
+    <value>API 令牌(&A)</value>
   </data>
   <data name="ConfigHomeAssistantApi_LblServerUri" xml:space="preserve">
-    <value>Server &amp;URI</value>
+    <value>服务器 URI(&U)</value>
   </data>
   <data name="ConfigHotKey_BtnClearHotKey" xml:space="preserve">
-    <value>&amp;Clear</value>
+    <value>清除(&C)</value>
   </data>
   <data name="ConfigHotKey_LblInfo1" xml:space="preserve">
-	  <value>An easy way to pull up your quick actions is to use a global hotkey.
+    <value>调出快捷操作的一种简单方式是使用全局热键。
 
-This way, whatever you're doing on your machine, you can always interact with Home Assistant.</value>
+这样，无论您在机器上做什么，都可以随时与 Home Assistant 交互。</value>
   </data>
   <data name="ConfigHotKey_CbEnableQuickActionsHotkey" xml:space="preserve">
-    <value>&amp;Enable Quick Actions Hotkey</value>
+    <value>启用快捷操作热键(&E)</value>
   </data>
   <data name="ConfigHotKey_LblHotkeyCombo" xml:space="preserve">
-    <value>&amp;Hotkey Combination</value>
+    <value>热键组合(&H)</value>
   </data>
   <data name="ConfigLocalStorage_BtnClearImageCache" xml:space="preserve">
-    <value>Clear Image Cache</value>
+    <value>清除图像缓存</value>
   </data>
   <data name="ConfigLocalStorage_BtnOpenImageCache" xml:space="preserve">
-    <value>Open Folder</value>
+    <value>打开文件夹</value>
   </data>
   <data name="ConfigLocalStorage_LblCacheLocations" xml:space="preserve">
-    <value>Image Cache Location</value>
+    <value>图像缓存位置</value>
   </data>
   <data name="ConfigLocalStorage_LblCacheDays" xml:space="preserve">
-    <value>days</value>
+    <value>天</value>
   </data>
   <data name="ConfigLocalStorage_LblInfo1" xml:space="preserve">
-	  <value>Some items like images shown in notifications have to be temporarily stored locally. You can
-configure the amount of days they should be kept before HASS.Agent deletes them.
+    <value>某些项目（如通知中显示的图像）需要临时存储在本地。您可以
+配置 HASS.Agent 删除它们之前保留的天数。
 
-Enter '0' to keep them permanently.</value>
+输入"0"以永久保留它们。</value>
   </data>
   <data name="ConfigLogging_LblInfo1" xml:space="preserve">
-	  <value>Extended logging provides more verbose and in-depth logging, in case the default logging isn't
-sufficient. Please note that enabling this can cause the logfiles to grow large, and should only be
-used when you suspect something's wrong with HASS.Agent itself or when asked by the
-developers.</value>
+    <value>扩展日志记录提供更详细和深入的日志，以防默认日志记录
+不够用。请注意，启用此功能可能会导致日志文件变大，并且仅应在您怀疑
+HASS.Agent 本身有问题或开发者要求时使用。</value>
   </data>
   <data name="ConfigLogging_CbExtendedLogging" xml:space="preserve">
-    <value>&amp;Enable Extended Logging</value>
+    <value>启用扩展日志记录(&E)</value>
   </data>
   <data name="ConfigLogging_BtnShowLogs" xml:space="preserve">
-    <value>&amp;Open Logs Folder</value>
+    <value>打开日志文件夹(&O)</value>
   </data>
   <data name="ConfigMqtt_LblTip3" xml:space="preserve">
-    <value>Tip: Double-click these fields to browse</value>
+    <value>提示：双击这些字段以浏览</value>
   </data>
   <data name="ConfigMqtt_LblClientCert" xml:space="preserve">
-    <value>Client Certificate</value>
+    <value>客户端证书</value>
   </data>
   <data name="ConfigMqtt_LblRootCert" xml:space="preserve">
-    <value>Root Certificate</value>
+    <value>根证书</value>
   </data>
   <data name="ConfigMqtt_CbUseRetainFlag" xml:space="preserve">
-    <value>Use &amp;Retain Flag</value>
+    <value>使用保留标志(&R)</value>
   </data>
   <data name="ConfigMqtt_CbAllowUntrustedCertificates" xml:space="preserve">
-    <value>&amp;Allow Untrusted Certificates</value>
+    <value>允许不受信任的证书(&A)</value>
   </data>
   <data name="ConfigMqtt_BtnMqttClearConfig" xml:space="preserve">
-    <value>&amp;Clear Configuration</value>
+    <value>清除配置(&C)</value>
   </data>
   <data name="ConfigMqtt_LblTip1" xml:space="preserve">
-    <value>(leave default if unsure)</value>
+    <value>（如果不确定，保持默认）</value>
   </data>
   <data name="ConfigMqtt_LblInfo1" xml:space="preserve">
-	  <value>Commands and sensors use MQTT, as well as notifications and media player functions when using the new integration. 
+    <value>命令和传感器使用 MQTT，使用新集成时通知和媒体播放器功能也使用它。 
 
-Please provide credentials for your broker, if you're using the HA Mosquitto addon, you can probably use the preset address.
+请为您的代理提供凭据，如果您使用 HA Mosquitto 插件，您可能可以使用预设地址。
 
-Note: these settings (excluding the Client ID) will also be applied to the satellite service.</value>
+注意：这些设置（不包括客户端 ID）也将应用于卫星服务。</value>
   </data>
   <data name="ConfigMqtt_LblDiscoPrefix" xml:space="preserve">
-    <value>Discovery Prefix</value>
+    <value>发现前缀</value>
   </data>
   <data name="ConfigMqtt_LblBrokerPassword" xml:space="preserve">
-    <value>Password</value>
+    <value>密码</value>
   </data>
   <data name="ConfigMqtt_LblBrokerUsername" xml:space="preserve">
-    <value>Username</value>
+    <value>用户名</value>
   </data>
   <data name="ConfigMqtt_LblBrokerPort" xml:space="preserve">
-    <value>Port</value>
+    <value>端口</value>
   </data>
   <data name="ConfigMqtt_LblBrokerIp" xml:space="preserve">
-    <value>Broker IP Address or Hostname</value>
+    <value>代理 IP 地址或主机名</value>
   </data>
   <data name="ConfigMqtt_LblTip2" xml:space="preserve">
-    <value>(leave empty to auto generate)</value>
+    <value>（留空以自动生成）</value>
   </data>
   <data name="ConfigMqtt_LblClientId" xml:space="preserve">
-    <value>Client ID</value>
+    <value>客户端 ID</value>
   </data>
   <data name="ConfigNotifications_LblInfo2" xml:space="preserve">
-	  <value>If something is not working, make sure you try the following steps:
+    <value>如果某些功能不正常，请确保您尝试以下步骤：
 
-- Install the HASS.Agent integration
-- Restart Home Assistant
-- Make sure HASS.Agent is active with MQTT enabled!
-- Your device should get detected and added as an entity automatically
-- Optionally: manually add it using the local API</value>
+- 安装 HASS.Agent 集成
+- 重启 Home Assistant
+- 确保 HASS.Agent 处于活动状态且 MQTT 已启用！
+- 您的设备应被自动检测并添加为实体
+- 可选：使用本地 API 手动添加</value>
   </data>
   <data name="ConfigNotifications_LblInfo1" xml:space="preserve">
-    <value>HASS.Agent can receive notifications from Home Assistant, using text, images and actions. If you have MQTT enabled, your device will automatically get added. Otherwise, manually configure the integration to use the local API.</value>
+    <value>HASS.Agent 可以接收来自 Home Assistant 的通知，使用文本、图像和操作。如果您已启用 MQTT，您的设备将自动被添加。否则，请手动配置集成以使用本地 API。</value>
   </data>
   <data name="ConfigNotifications_BtnNotificationsReadme" xml:space="preserve">
-    <value>Notifications &amp;Documentation</value>
+    <value>通知文档(&D)</value>
   </data>
   <data name="ConfigNotifications_LblPort" xml:space="preserve">
-    <value>Port</value>
+    <value>端口</value>
   </data>
   <data name="ConfigNotifications_CbAcceptNotifications" xml:space="preserve">
-    <value>&amp;Accept Notifications</value>
+    <value>接受通知(&A)</value>
   </data>
   <data name="ConfigNotifications_BtnSendTestNotification" xml:space="preserve">
-    <value>Show Test Notification</value>
+    <value>显示测试通知</value>
   </data>
   <data name="ConfigNotifications_BtnExecutePortReservation" xml:space="preserve">
-    <value>Execute Port Reservation</value>
+    <value>执行端口预留</value>
   </data>
   <data name="ConfigNotifications_CbNotificationsIgnoreImageCertErrors" xml:space="preserve">
-    <value>&amp;Ignore certificate errors for images</value>
+    <value>忽略图像的证书错误(&I)</value>
   </data>
   <data name="ConfigService_LblInfo1" xml:space="preserve">
-	  <value>The satellite service allows you to run sensors and commands even when no user's logged in. 
-Use the 'satellite service' button on the main window to manage it.</value>
+    <value>卫星服务允许您在没有用户登录时运行传感器和命令。 
+使用主窗口上的"卫星服务"按钮来管理它。</value>
   </data>
   <data name="ConfigService_LblServiceStatusInfo" xml:space="preserve">
-    <value>Service Status:</value>
+    <value>服务状态：</value>
   </data>
   <data name="ConfigService_BtnStartService" xml:space="preserve">
-    <value>S&amp;tart Service</value>
+    <value>启动服务(&T)</value>
   </data>
   <data name="ConfigService_BtnDisableService" xml:space="preserve">
-    <value>&amp;Disable Service</value>
+    <value>禁用服务(&D)</value>
   </data>
   <data name="ConfigService_BtnStopService" xml:space="preserve">
-    <value>&amp;Stop Service</value>
+    <value>停止服务(&S)</value>
   </data>
   <data name="ConfigService_BtnEnableService" xml:space="preserve">
-    <value>&amp;Enable Service</value>
+    <value>启用服务(&E)</value>
   </data>
   <data name="ConfigService_BtnReinstallService" xml:space="preserve">
-    <value>&amp;Reinstall Service</value>
+    <value>重新安装服务(&R)</value>
   </data>
   <data name="ConfigService_LblInfo2" xml:space="preserve">
-	  <value>If you do not configure the service, it won't do anything. However, you can still decide to disable it as well.
-The installer will leave the disabled service alone(if you remove the service, the installer will reinstall it).</value>
+    <value>如果您不配置服务，它将不会执行任何操作。不过，您也可以选择禁用它。
+安装程序将保留已禁用的服务（如果您删除了服务，安装程序将重新安装它）。</value>
   </data>
   <data name="ConfigService_LblInfo3" xml:space="preserve">
-	  <value>You can try reinstalling the service if it's not working correctly.
-Your configuration and entities won't be removed.</value>
+    <value>如果服务无法正常工作，您可以尝试重新安装服务。
+您的配置和实体不会被删除。</value>
   </data>
   <data name="ConfigService_BtnShowLogs" xml:space="preserve">
-    <value>Open Service &amp;Logs Folder</value>
+    <value>打开服务日志文件夹(&L)</value>
   </data>
   <data name="ConfigService_LblInfo4" xml:space="preserve">
-    <value>If the service still fails after reinstalling, please open a ticket and send the content of the latest log.</value>
+    <value>如果重新安装后服务仍然失败，请提交工单并发送最新日志的内容。</value>
   </data>
   <data name="ConfigStartup_LblInfo1" xml:space="preserve">
-	  <value>HASS.Agent can start when you login by creating an entry in your user profile's registry.
+    <value>HASS.Agent 可以通过在您的用户配置文件的注册表中创建条目，在您登录时启动。
 
-Since HASS.Agent is user based, if you want to launch for another user, just install and config
-HASS.Agent there.</value>
+由于 HASS.Agent 基于用户，如果您想为其他用户启动，只需在该用户处安装和配置
+HASS.Agent 即可。</value>
   </data>
   <data name="ConfigStartup_BtnSetStartOnLogin" xml:space="preserve">
-    <value>&amp;Enable Start-on-Login</value>
+    <value>启用登录时启动(&E)</value>
   </data>
   <data name="ConfigStartup_LblStartOnLoginStatusInfo" xml:space="preserve">
-    <value>Start-on-Login Status:</value>
+    <value>登录时启动状态：</value>
   </data>
   <data name="ConfigUpdates_CbBetaUpdates" xml:space="preserve">
-    <value>Notify me of &amp;beta releases</value>
+    <value>通知我测试版发布(&B)</value>
   </data>
   <data name="ConfigUpdates_LblInfo2" xml:space="preserve">
-	  <value>When a new update is available, HASS.Agent can download the installer and launch it for you.
+    <value>当有新更新可用时，HASS.Agent 可以下载安装程序并为您启动它。
 
-The certificate of the downloaded file will get checked before running,you will still get to review the release notes and manually approve the update.</value>
+在运行之前将检查下载文件的证书，您仍然可以查看发布说明并手动批准更新。</value>
   </data>
   <data name="ConfigUpdates_CbExecuteUpdater" xml:space="preserve">
-    <value>Automatically &amp;download future updates</value>
+    <value>自动下载未来更新(&D)</value>
   </data>
   <data name="ConfigUpdates_LblInfo1" xml:space="preserve">
-	  <value>HASS.Agent checks for updates in the background if enabled.
+    <value>如果启用，HASS.Agent 将在后台检查更新。
 
-You will be sent a push notification if a new update is discovered, letting you know a
-new version is ready to be installed.</value>
+如果发现新更新，您将收到推送通知，告知您有
+新版本已准备好安装。</value>
   </data>
   <data name="ConfigUpdates_CbUpdates" xml:space="preserve">
-    <value>Notify me when a new &amp;release is available</value>
+    <value>当有新版本可用时通知我(&R)</value>
   </data>
   <data name="OnboardingWelcome_LblInfo1" xml:space="preserve">
-	  <value>Welcome to the HASS.Agent! It looks like this is the first time you are launching the agent.
+    <value>欢迎使用 HASS.Agent！看起来这是您第一次启动代理。
 
-To assist you with a first time setup, proceed with the configuration steps below
-or alternatively, click 'Close'.</value>
+为了帮助您完成首次设置，请按照下面的配置步骤操作，
+或者点击"关闭"。</value>
   </data>
   <data name="OnboardingWelcome_LblInfo2" xml:space="preserve">
-    <value>The device name is used to identify your machine on Home Assistant, it is also used as a suggested prefix for your commands and sensors.</value>
+    <value>设备名称用于在 Home Assistant 中标识您的机器，它也用作您的命令和传感器的建议前缀。</value>
   </data>
   <data name="OnboardingWelcome_LblDeviceName" xml:space="preserve">
-    <value>Device &amp;Name</value>
+    <value>设备名称(&N)</value>
   </data>
   <data name="OnboardingStartup_BtnSetLaunchOnLogin" xml:space="preserve">
-    <value>Yes, &amp;start HASS.Agent on System Login</value>
+    <value>是的，在系统登录时启动 HASS.Agent(&S)</value>
   </data>
   <data name="OnboardingStartup_LblInfo1" xml:space="preserve">
-	  <value>HASS.Agent can start with your system, this allows for any sensors and data transmission between your device and Home Assistant to begin as soon as you login.
+    <value>HASS.Agent 可以随您的系统启动，这使得您的设备和 Home Assistant 之间的任何传感器和数据传输在您登录时立即开始。
 
-This setting can be changed any time later in the HASS.Agent configuration window.</value>
+此设置可以稍后在 HASS.Agent 配置窗口中随时更改。</value>
   </data>
   <data name="OnboardingStartup_LblCreateInfo" xml:space="preserve">
-    <value>Fetching current state, please wait..</value>
+    <value>正在获取当前状态，请稍候..</value>
   </data>
   <data name="OnboardingNotifications_LblTip1" xml:space="preserve">
-    <value>Note: 5115 is the default port, only change it if you changed it in Home Assistant.</value>
+    <value>注意：5115 是默认端口，只有在 Home Assistant 中更改过才需要更改它。</value>
   </data>
   <data name="OnboardingNotifications_CbAcceptNotifications" xml:space="preserve">
-    <value>Yes, accept notifications on port</value>
+    <value>是的，在端口上接受通知</value>
   </data>
   <data name="OnboardingNotifications_LblInfo1" xml:space="preserve">
-	  <value>HASS.Agent can receive notifications from Home Assistant, using text and/or images.
+    <value>HASS.Agent 可以接收来自 Home Assistant 的通知，使用文本和/或图像。
 
-Do you want to enable this function?</value>
+您想启用此功能吗？</value>
   </data>
   <data name="OnboardingIntegration_LblIntegration" xml:space="preserve">
-    <value>HASS.Agent-Notifier GitHub Page</value>
+    <value>HASS.Agent-Notifier GitHub 页面</value>
   </data>
   <data name="OnboardingIntegration_LblInfo2" xml:space="preserve">
-	  <value>Make sure you follow these steps:
+    <value>确保您按照以下步骤操作：
 
-- Install HASS.Agent-Notifier integration
-- Restart Home Assistant
-- Configure a notifier entity
-- Restart Home Assistant</value>
+- 安装 HASS.Agent-Notifier 集成
+- 重启 Home Assistant
+- 配置通知器实体
+- 重启 Home Assistant</value>
   </data>
   <data name="OnboardingIntegration_LblInfo1" xml:space="preserve">
-	  <value>To use notifications, you need to install and configure the HASS.Agent-notifier integration in
-Home Assistant.
+    <value>要使用通知，您需要在 Home Assistant 中安装和配置 HASS.Agent-notifier 集成。
 
-This is very easy using HACS but may also be installed manually, visit the link below for more
-information.</value>
+使用 HACS 非常简单，也可以手动安装，请访问下面的链接获取更多
+信息。</value>
   </data>
   <data name="OnboardingApi_LblApiToken" xml:space="preserve">
-    <value>API &amp;Token</value>
+    <value>API 令牌(&T)</value>
   </data>
   <data name="OnboardingApi_LblServerUri" xml:space="preserve">
-    <value>Server &amp;URI (should be ok like this)</value>
+    <value>服务器 URI(&U)（这样就很好）</value>
   </data>
   <data name="OnboardingApi_LblInfo1" xml:space="preserve">
-	  <value>To learn which entities you have configured and to send quick actions, HASS.Agent uses
-Home Assistant's API.
+    <value>为了解您配置了哪些实体以及发送快捷操作，HASS.Agent 使用
+Home Assistant 的 API。
 
-Please provide a long-lived access token and the address of your Home Assistant instance.
-You can get a token in Home Assistant by clicking your profile picture at the bottom-left
-and navigating to the bottom of the page until you see the 'CREATE TOKEN' button.</value>
+请提供一个长期有效的访问令牌和您的 Home Assistant 实例地址。
+您可以在 Home Assistant 中点击左下角的个人资料图片，
+并导航到页面底部，直到您看到"创建令牌"按钮。</value>
   </data>
   <data name="OnboardingApi_BtnTest" xml:space="preserve">
-    <value>Test &amp;Connection</value>
+    <value>测试连接(&C)</value>
   </data>
   <data name="OnboardingApi_LblTip1" xml:space="preserve">
-    <value>Tip: Specialized settings can be found in the Configuration Window.</value>
+    <value>提示：可以在配置窗口中找到专用设置。</value>
   </data>
   <data name="OnboardingMqtt_LblPassword" xml:space="preserve">
-    <value>Password</value>
+    <value>密码</value>
   </data>
   <data name="OnboardingMqtt_LblUsername" xml:space="preserve">
-    <value>Username</value>
+    <value>用户名</value>
   </data>
   <data name="OnboardingMqtt_LblPort" xml:space="preserve">
-    <value>Port</value>
+    <value>端口</value>
   </data>
   <data name="OnboardingMqtt_LblIpAdress" xml:space="preserve">
-    <value>IP Address or Hostname</value>
+    <value>IP 地址或主机名</value>
   </data>
   <data name="OnboardingMqtt_LblInfo1" xml:space="preserve">
-	  <value>Commands and sensors are sent through MQTT. The notifications- and media player integration also make use of them.
+    <value>命令和传感器通过 MQTT 发送。通知和媒体播放器集成也使用它们。
 
-Tip: if you're using the HA addon, you can probably use the preset address - just provide credentials.
+提示：如果您使用 HA 插件，您可能可以使用预设地址 - 只需提供凭据。
 </value>
   </data>
   <data name="OnboardingMqtt_LblDiscoveryPrefix" xml:space="preserve">
-    <value>Discovery Prefix</value>
+    <value>发现前缀</value>
   </data>
   <data name="OnboardingMqtt_LblTip1" xml:space="preserve">
-    <value>(leave default if not sure)</value>
+    <value>（如果不确定，保持默认）</value>
   </data>
   <data name="OnboardingMqtt_LblTip2" xml:space="preserve">
-    <value>Tip: Specialized settings can be found in the Configuration Window.</value>
+    <value>提示：可以在配置窗口中找到专用设置。</value>
   </data>
   <data name="OnboardingHotKey_LblHotkeyCombo" xml:space="preserve">
-    <value>&amp;Hotkey Combination</value>
+    <value>热键组合(&H)</value>
   </data>
   <data name="OnboardingHotKey_LblInfo1" xml:space="preserve">
-	  <value>An easy way to pull up your quick actions is to use a global hotkey.
+    <value>调出快捷操作的一种简单方式是使用全局热键。
 
-This way, whatever you're doing on your machine, you can always interact with Home Assistant.
+这样，无论您在机器上做什么，都可以随时与 Home Assistant 交互。
 </value>
   </data>
   <data name="OnboardingHotKey_BtnClear" xml:space="preserve">
-    <value>&amp;Clear</value>
+    <value>清除(&C)</value>
   </data>
   <data name="OnboardingUpdates_LblInfo1" xml:space="preserve">
-	  <value>HASS.Agent checks for updates in the background if enabled.
+    <value>如果启用，HASS.Agent 将在后台检查更新。
 
-You will be sent a push notification if a new update is discovered, letting you know a
-new version is ready to be installed.
+如果发现新更新，您将收到推送通知，告知您有
+新版本已准备好安装。
 
-Do you want to enable this automatic update checks?</value>
+您想启用此自动更新检查吗？</value>
   </data>
   <data name="OnboardingUpdates_CbNofityOnUpdate" xml:space="preserve">
     <value>Yes, notify me on new &amp;updates</value>
   </data>
   <data name="OnboardingUpdates_CbExecuteUpdater" xml:space="preserve">
-    <value>Yes, &amp;download and launch the installer for me</value>
+    <value>是的，为我下载并启动安装程序(&D)</value>
   </data>
   <data name="OnboardingUpdates_LblInfo2" xml:space="preserve">
-	  <value>When a new update is available, HASS.Agent can download the installer and launch it for you.
+    <value>当有新更新可用时，HASS.Agent 可以下载安装程序并为您启动它。
 
-The certificate of the downloaded file will get checked before running,you will still get to review the release notes and manually approve the update.</value>
+在运行之前将检查下载文件的证书，您仍然可以查看发布说明并手动批准更新。</value>
   </data>
   <data name="OnboardingDone_LblGitHub" xml:space="preserve">
-    <value>HASS.Agent GitHub page</value>
+    <value>HASS.Agent GitHub 页面</value>
   </data>
   <data name="OnboardingDone_LblInfo3" xml:space="preserve">
-	  <value>There's a lot more to tinker with, so make sure you take a look at the Configuration Window!
+    <value>还有更多内容可以探索，所以一定要看看配置窗口！
 
 
-Thank you for using HASS.Agent, hopefully it'll be useful for you :-)
+感谢您使用 HASS.Agent，希望它对您有用 :-)
 </value>
   </data>
   <data name="OnboardingDone_LblInfo2" xml:space="preserve">
-    <value>HASS.Agent will now restart to apply your configuration changes.</value>
+    <value>HASS.Agent 现在将重启以应用您的配置更改。</value>
   </data>
   <data name="OnboardingDone_LblInfo1" xml:space="preserve">
-    <value>Yay, done!</value>
+    <value>太好了，完成了！</value>
   </data>
   <data name="ServiceCommands_LblLowIntegrity" xml:space="preserve">
-    <value>Low Integrity</value>
+    <value>低完整性</value>
   </data>
   <data name="ServiceCommands_ClmName" xml:space="preserve">
-    <value>Name</value>
+    <value>名称</value>
   </data>
   <data name="ServiceCommands_ClmType" xml:space="preserve">
-    <value>Type</value>
+    <value>类型</value>
   </data>
   <data name="ServiceCommands_BtnRemove" xml:space="preserve">
-    <value>&amp;Remove</value>
+    <value>移除(&R)</value>
   </data>
   <data name="ServiceCommands_BtnModify" xml:space="preserve">
-    <value>&amp;Modify</value>
+    <value>修改(&M)</value>
   </data>
   <data name="ServiceCommands_BtnAdd" xml:space="preserve">
-    <value>&amp;Add New</value>
+    <value>添加新项(&A)</value>
   </data>
   <data name="ServiceCommands_BtnStore" xml:space="preserve">
-    <value>&amp;Send &amp;&amp; Activate Commands</value>
+    <value>发送并激活命令(&S)</value>
   </data>
   <data name="ServiceCommands_LblStored" xml:space="preserve">
-    <value>commands stored!</value>
+    <value>命令已存储！</value>
   </data>
   <data name="ServiceConnect_BtnRetryAuthId" xml:space="preserve">
-    <value>&amp;Apply</value>
+    <value>应用(&A)</value>
   </data>
   <data name="ServiceConnect_LblRetryAuthId" xml:space="preserve">
-    <value>Auth &amp;ID</value>
+    <value>身份验证 ID(&I)</value>
   </data>
   <data name="ServiceConnect_LblAuthenticate" xml:space="preserve">
-    <value>Authenticate</value>
+    <value>身份验证</value>
   </data>
   <data name="ServiceConnect_LblConnect" xml:space="preserve">
-    <value>Connect with service</value>
+    <value>与服务连接</value>
   </data>
   <data name="ServiceConnect_LblLoading" xml:space="preserve">
-    <value>Connecting satellite service, please wait..</value>
+    <value>正在连接卫星服务，请稍候..</value>
   </data>
   <data name="ServiceConnect_LblFetchConfig" xml:space="preserve">
-    <value>Fetch Configuration</value>
+    <value>获取配置</value>
   </data>
   <data name="ServiceGeneral_LblInfo1" xml:space="preserve">
-    <value>This page contains general configuration settings, for MQTT settings, commands, and sensors, browse the different tabs above.</value>
+    <value>此页面包含常规配置设置，如需 MQTT 设置、命令和传感器，请浏览上方不同的选项卡。</value>
   </data>
   <data name="ServiceGeneral_LblAuthId" xml:space="preserve">
-    <value>Auth &amp;ID</value>
+    <value>身份验证 ID(&I)</value>
   </data>
   <data name="ServiceGeneral_LblDeviceName" xml:space="preserve">
-    <value>Device &amp;Name</value>
+    <value>设备名称(&N)</value>
   </data>
   <data name="ServiceGeneral_LblTip1" xml:space="preserve">
-    <value>Tip: Double-click these fields to browse</value>
+    <value>提示：双击这些字段以浏览</value>
   </data>
   <data name="ServiceGeneral_LblCustomExecBinary" xml:space="preserve">
-    <value>Custom Executor &amp;Binary</value>
+    <value>自定义执行器可执行文件(&B)</value>
   </data>
   <data name="ServiceGeneral_LblCustomExecName" xml:space="preserve">
-    <value>Custom &amp;Executor Name</value>
+    <value>自定义执行器名称(&E)</value>
   </data>
   <data name="ServiceGeneral_LblSeconds" xml:space="preserve">
-    <value>seconds</value>
+    <value>秒</value>
   </data>
   <data name="ServiceGeneral_LblDisconGrace" xml:space="preserve">
-    <value>Disconnected Grace &amp;Period</value>
+    <value>断开连接宽限期(&P)</value>
   </data>
   <data name="ServiceGeneral_Apply" xml:space="preserve">
-    <value>Apply</value>
+    <value>应用</value>
   </data>
   <data name="ServiceGeneral_LblVersionInfo" xml:space="preserve">
-    <value>Version</value>
+    <value>版本</value>
   </data>
   <data name="ServiceGeneral_LblTip2" xml:space="preserve">
-    <value>Tip: Double-click to generate random</value>
+    <value>提示：双击以生成随机值</value>
   </data>
   <data name="ServiceGeneral_Stored" xml:space="preserve">
-    <value>Stored!</value>
+    <value>已存储！</value>
   </data>
   <data name="ServiceMqtt_LblTip2" xml:space="preserve">
-    <value>(leave empty to auto generate)</value>
+    <value>（留空以自动生成）</value>
   </data>
   <data name="ServiceMqtt_LblClientId" xml:space="preserve">
-    <value>Client ID</value>
+    <value>客户端 ID</value>
   </data>
   <data name="ServiceMqtt_LblTip3" xml:space="preserve">
-    <value>Tip: Double-click these fields to browse</value>
+    <value>提示：双击这些字段以浏览</value>
   </data>
   <data name="ServiceMqtt_LblClientCert" xml:space="preserve">
-    <value>Client Certificate</value>
+    <value>客户端证书</value>
   </data>
   <data name="ServiceMqtt_LblRootCert" xml:space="preserve">
-    <value>Root Certificate</value>
+    <value>根证书</value>
   </data>
   <data name="ServiceMqtt_CbUseRetainFlag" xml:space="preserve">
-    <value>Use &amp;Retain Flag</value>
+    <value>使用保留标志(&R)</value>
   </data>
   <data name="ServiceMqtt_CbAllowUntrustedCertificates" xml:space="preserve">
-    <value>&amp;Allow Untrusted Certificates</value>
+    <value>允许不受信任的证书(&A)</value>
   </data>
   <data name="ServiceMqtt_BtnMqttClearConfig" xml:space="preserve">
-    <value>&amp;Clear Configuration</value>
+    <value>清除配置(&C)</value>
   </data>
   <data name="ServiceMqtt_LblTip1" xml:space="preserve">
-    <value>(leave default if not sure)</value>
+    <value>（如果不确定，保持默认）</value>
   </data>
   <data name="ServiceMqtt_LblInfo1" xml:space="preserve">
-	  <value>Commands and sensors are sent through MQTT. Please provide credentials for your server. If you're using the HA addon,
-you can probably use the preset address.</value>
+    <value>命令和传感器通过 MQTT 发送。请为您的服务器提供凭据。如果您使用 HA 插件，
+您可能可以使用预设地址。</value>
   </data>
   <data name="ServiceMqtt_LblDiscoPrefix" xml:space="preserve">
-    <value>Discovery Prefix</value>
+    <value>发现前缀</value>
   </data>
   <data name="ServiceMqtt_LblBrokerPassword" xml:space="preserve">
-    <value>Password</value>
+    <value>密码</value>
   </data>
   <data name="ServiceMqtt_LblBrokerUsername" xml:space="preserve">
-    <value>Username</value>
+    <value>用户名</value>
   </data>
   <data name="ServiceMqtt_LblBrokerPort" xml:space="preserve">
-    <value>Port</value>
+    <value>端口</value>
   </data>
   <data name="ServiceMqtt_LblBrokerIp" xml:space="preserve">
-    <value>Broker IP Address or Hostname</value>
+    <value>代理 IP 地址或主机名</value>
   </data>
   <data name="ServiceMqtt_BtnStore" xml:space="preserve">
-    <value>&amp;Send &amp;&amp; Activate Configuration</value>
+    <value>发送并激活配置(&S)</value>
   </data>
   <data name="ServiceMqtt_BtnCopy" xml:space="preserve">
-    <value>Copy from &amp;HASS.Agent</value>
+    <value>从 HASS.Agent 复制(&H)</value>
   </data>
   <data name="ServiceMqtt_LblStored" xml:space="preserve">
-    <value>Configuration stored!</value>
+    <value>配置已存储！</value>
   </data>
   <data name="ServiceMqtt_LblStatusInfo" xml:space="preserve">
-    <value>Status</value>
+    <value>状态</value>
   </data>
   <data name="ServiceMqtt_LblStatus" xml:space="preserve">
-    <value>Querying..</value>
+    <value>正在查询..</value>
   </data>
   <data name="ServiceSensors_ClmName" xml:space="preserve">
-    <value>Name</value>
+    <value>名称</value>
   </data>
   <data name="ServiceSensors_ClmType" xml:space="preserve">
-    <value>Type</value>
+    <value>类型</value>
   </data>
   <data name="ServiceSensors_LblRefresh" xml:space="preserve">
-    <value>Refresh</value>
+    <value>刷新</value>
   </data>
   <data name="ServiceSensors_BtnRemove" xml:space="preserve">
-    <value>&amp;Remove</value>
+    <value>移除(&R)</value>
   </data>
   <data name="ServiceSensors_BtnAdd" xml:space="preserve">
-    <value>&amp;Add New</value>
+    <value>添加新项(&A)</value>
   </data>
   <data name="ServiceSensors_BtnModify" xml:space="preserve">
-    <value>&amp;Modify</value>
+    <value>修改(&M)</value>
   </data>
   <data name="ServiceSensors_BtnStore" xml:space="preserve">
-    <value>&amp;Send &amp;&amp; Activate Sensors</value>
+    <value>发送并激活传感器(&S)</value>
   </data>
   <data name="ServiceSensors_LblStored" xml:space="preserve">
-    <value>Sensors stored!</value>
+    <value>传感器已存储！</value>
   </data>
   <data name="PortReservation_LblInfo1" xml:space="preserve">
-    <value>Please wait a bit while the task is performed ..</value>
+    <value>请稍候，正在执行任务..</value>
   </data>
   <data name="PortReservation_LblTask1" xml:space="preserve">
-    <value>Create API Port Binding</value>
+    <value>创建 API 端口绑定</value>
   </data>
   <data name="PortReservation_LblTask2" xml:space="preserve">
-    <value>Set Firewall Rule</value>
+    <value>设置防火墙规则</value>
   </data>
   <data name="PortReservation_Title" xml:space="preserve">
-    <value>HASS.Agent Port Reservation</value>
+    <value>HASS.Agent 端口预留</value>
   </data>
   <data name="PostUpdate_LblInfo1" xml:space="preserve">
-    <value>Please wait a bit while some post-update tasks are performed ..</value>
+    <value>请稍候，正在执行一些更新后任务..</value>
   </data>
   <data name="PostUpdate_LblTask1" xml:space="preserve">
-    <value>Configuring Satellite Service</value>
+    <value>正在配置卫星服务</value>
   </data>
   <data name="PostUpdate_LblTask2" xml:space="preserve">
-    <value>Create API Port Binding</value>
+    <value>创建 API 端口绑定</value>
   </data>
   <data name="PostUpdate_Title" xml:space="preserve">
-    <value>HASS.Agent Post Update</value>
+    <value>HASS.Agent 更新后处理</value>
   </data>
   <data name="Restart_LblInfo1" xml:space="preserve">
-    <value>Please wait while HASS.Agent restarts..</value>
+    <value>请稍候，HASS.Agent 正在重启..</value>
   </data>
   <data name="Restart_LblTask1" xml:space="preserve">
-    <value>Waiting for previous instance to close..</value>
+    <value>正在等待上一个实例关闭..</value>
   </data>
   <data name="Restart_LblTask2" xml:space="preserve">
-    <value>Relaunch HASS.Agent</value>
+    <value>重新启动 HASS.Agent</value>
   </data>
   <data name="Restart_Title" xml:space="preserve">
-    <value>HASS.Agent Restarter</value>
+    <value>HASS.Agent 重启器</value>
   </data>
   <data name="ServiceReinstall_LblInfo1" xml:space="preserve">
-    <value>Please wait while the satellite service is re-installed..</value>
+    <value>请稍候，正在重新安装卫星服务..</value>
   </data>
   <data name="ServiceReinstall_LblTask1" xml:space="preserve">
-    <value>Remove Satellite Service</value>
+    <value>移除卫星服务</value>
   </data>
   <data name="ServiceReinstall_LblTask2" xml:space="preserve">
-    <value>Install Satellite Service</value>
+    <value>安装卫星服务</value>
   </data>
   <data name="ServiceReinstall_Title" xml:space="preserve">
-    <value>HASS.Agent Reinstall Satellite Service</value>
+    <value>HASS.Agent 重新安装卫星服务</value>
   </data>
   <data name="ServiceSetState_LblInfo1" xml:space="preserve">
-    <value>Please wait while the satellite service is configured..</value>
+    <value>请稍候，正在配置卫星服务..</value>
   </data>
   <data name="ServiceSetState_LblTask1" xml:space="preserve">
-    <value>Enable Satellite Service</value>
+    <value>启用卫星服务</value>
   </data>
   <data name="ServiceSetState_Title" xml:space="preserve">
-    <value>HASS.Agent Configure Satellite Service</value>
+    <value>HASS.Agent 配置卫星服务</value>
   </data>
   <data name="CommandMqttTopic_BtnClose" xml:space="preserve">
-    <value>&amp;Close</value>
+    <value>关闭(&C)</value>
   </data>
   <data name="CommandMqttTopic_LblInfo1" xml:space="preserve">
-    <value>This is the MQTT topic on which you can publish action commands:</value>
+    <value>这是您可以发布操作命令的 MQTT 主题：</value>
   </data>
   <data name="CommandMqttTopic_BtnCopyClipboard" xml:space="preserve">
-    <value>Copy &amp;to Clipboard</value>
+    <value>复制到剪贴板(&T)</value>
   </data>
   <data name="CommandMqttTopic_LblHelp" xml:space="preserve">
-    <value>help and examples</value>
+    <value>帮助和示例</value>
   </data>
   <data name="CommandMqttTopic_Title" xml:space="preserve">
-    <value>MQTT Action Topic</value>
+    <value>MQTT 操作主题</value>
   </data>
   <data name="CommandsConfig_BtnRemove" xml:space="preserve">
-    <value>&amp;Remove</value>
+    <value>移除(&R)</value>
   </data>
   <data name="CommandsConfig_BtnModify" xml:space="preserve">
-    <value>&amp;Modify</value>
+    <value>修改(&M)</value>
   </data>
   <data name="CommandsConfig_BtnAdd" xml:space="preserve">
-    <value>&amp;Add New</value>
+    <value>添加新项(&A)</value>
   </data>
   <data name="CommandsConfig_BtnStore" xml:space="preserve">
-    <value>&amp;Store and Activate Commands</value>
+    <value>存储并激活命令(&S)</value>
   </data>
   <data name="CommandsConfig_ClmName" xml:space="preserve">
-    <value>Name</value>
+    <value>名称</value>
   </data>
   <data name="CommandsConfig_ClmType" xml:space="preserve">
-    <value>Type</value>
+    <value>类型</value>
   </data>
   <data name="CommandsConfig_LblLowIntegrity" xml:space="preserve">
-    <value>Low Integrity</value>
+    <value>低完整性</value>
   </data>
   <data name="CommandsConfig_LblActionInfo" xml:space="preserve">
-    <value>Action</value>
+    <value>操作</value>
   </data>
   <data name="CommandsConfig_Title" xml:space="preserve">
-    <value>Commands Config</value>
+    <value>命令配置</value>
   </data>
   <data name="CommandsMod_BtnStore" xml:space="preserve">
-    <value>&amp;Store Command</value>
+    <value>存储命令(&S)</value>
   </data>
   <data name="CommandsMod_LblSetting" xml:space="preserve">
-    <value>&amp;Configuration</value>
+    <value>配置(&C)</value>
   </data>
   <data name="CommandsMod_LblName" xml:space="preserve">
-    <value>&amp;Name</value>
+    <value>名称(&N)</value>
   </data>
   <data name="CommandsMod_LblDescription" xml:space="preserve">
-    <value>Description</value>
+    <value>描述</value>
   </data>
   <data name="CommandsMod_CbRunAsLowIntegrity" xml:space="preserve">
-    <value>&amp;Run as 'Low Integrity'</value>
+    <value>以"低完整性"运行(&R)</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo" xml:space="preserve">
-    <value>What's this?</value>
+    <value>这是什么？</value>
   </data>
   <data name="CommandsMod_ClmSensorName" xml:space="preserve">
-    <value>  Type</value>
+    <value>  类型</value>
   </data>
   <data name="CommandsMod_LblSelectedType" xml:space="preserve">
-    <value>Selected Type</value>
+    <value>已选类型</value>
   </data>
   <data name="CommandsMod_LblService" xml:space="preserve">
-    <value>Service</value>
+    <value>服务</value>
   </data>
   <data name="CommandsMod_LblAgent" xml:space="preserve">
-    <value>agent</value>
+    <value>代理</value>
   </data>
   <data name="CommandsMod_LblSpecificClient" xml:space="preserve">
-    <value>HASS.Agent only!</value>
+    <value>仅 HASS.Agent！</value>
   </data>
   <data name="CommandsMod_LblEntityType" xml:space="preserve">
-    <value>&amp;Entity Type</value>
+    <value>实体类型(&E)</value>
   </data>
   <data name="CommandsMod_LblMqttTopic" xml:space="preserve">
-    <value>Show MQTT Action Topic</value>
+    <value>显示 MQTT 操作主题</value>
   </data>
   <data name="CommandsMod_LblActionInfo" xml:space="preserve">
-    <value>Action</value>
+    <value>操作</value>
   </data>
   <data name="CommandsMod_Title" xml:space="preserve">
-    <value>Command</value>
+    <value>命令</value>
   </data>
   <data name="QuickActions_LblLoading" xml:space="preserve">
-    <value>Retrieving entities, please wait..</value>
+    <value>正在检索实体，请稍候..</value>
   </data>
   <data name="QuickActions_Title" xml:space="preserve">
-    <value>Quick Actions</value>
+    <value>快捷操作</value>
   </data>
   <data name="QuickActionsConfig_BtnStore" xml:space="preserve">
-    <value>&amp;Store Quick Actions</value>
+    <value>存储快捷操作(&S)</value>
   </data>
   <data name="QuickActionsConfig_BtnAdd" xml:space="preserve">
-    <value>&amp;Add New</value>
+    <value>添加新项(&A)</value>
   </data>
   <data name="QuickActionsConfig_BtnModify" xml:space="preserve">
-    <value>&amp;Modify</value>
+    <value>修改(&M)</value>
   </data>
   <data name="QuickActionsConfig_BtnRemove" xml:space="preserve">
-    <value>&amp;Remove</value>
+    <value>移除(&R)</value>
   </data>
   <data name="QuickActionsConfig_BtnPreview" xml:space="preserve">
-    <value>&amp;Preview</value>
+    <value>预览(&P)</value>
   </data>
   <data name="QuickActionsConfig_ClmDomain" xml:space="preserve">
-    <value>Domain</value>
+    <value>域</value>
   </data>
   <data name="QuickActionsConfig_ClmEntity" xml:space="preserve">
-    <value>Entity</value>
+    <value>实体</value>
   </data>
   <data name="QuickActionsConfig_ClmAction" xml:space="preserve">
-    <value>Action</value>
+    <value>操作</value>
   </data>
   <data name="QuickActionsConfig_ClmHotKey" xml:space="preserve">
-    <value>Hotkey</value>
+    <value>热键</value>
   </data>
   <data name="QuickActionsConfig_ClmDescription" xml:space="preserve">
-    <value>Description</value>
+    <value>描述</value>
   </data>
   <data name="QuickActionsConfig_LblHotkey" xml:space="preserve">
-	  <value>Hotkey Enabled</value>
+    <value>热键已启用</value>
   </data>
   <data name="QuickActionsConfig_Title" xml:space="preserve">
-    <value>Quick Actions Configuration</value>
+    <value>快捷操作配置</value>
   </data>
   <data name="QuickActionsMod_BtnStore" xml:space="preserve">
-    <value>&amp;Store Quick Action</value>
+    <value>存储快捷操作(&amp;S)</value>
   </data>
   <data name="QuickActionsMod_LblDomain" xml:space="preserve">
-    <value>Domain</value>
+    <value>域</value>
   </data>
   <data name="QuickActionsMod_LblEntityInfo" xml:space="preserve">
-    <value>&amp;Entity</value>
+    <value>实体(&amp;E)</value>
   </data>
   <data name="QuickActionsMod_LblAction" xml:space="preserve">
-    <value>Desired &amp;Action</value>
+    <value>所需操作(&amp;A)</value>
   </data>
   <data name="QuickActionsMod_LblDescription" xml:space="preserve">
-    <value>&amp;Description</value>
+    <value>描述(&amp;D)</value>
   </data>
   <data name="QuickActionsMod_LblLoading" xml:space="preserve">
-    <value>Retrieving entities, please wait..</value>
+    <value>正在检索实体，请稍候..</value>
   </data>
   <data name="QuickActionsMod_CbEnableHotkey" xml:space="preserve">
-    <value>enable hotkey</value>
+    <value>启用热键</value>
   </data>
   <data name="QuickActionsMod_LblHotkey" xml:space="preserve">
-    <value>&amp;hotkey combination</value>
+    <value>热键组合(&amp;H)</value>
   </data>
   <data name="QuickActionsMod_LblTip1" xml:space="preserve">
-    <value>(optional, will be used instead of entity name)</value>
+    <value>（可选，将替代实体名称使用）</value>
   </data>
   <data name="QuickActionsMod_Title" xml:space="preserve">
-    <value>Quick Action</value>
+    <value>快捷操作</value>
   </data>
   <data name="SensorsConfig_BtnRemove" xml:space="preserve">
-    <value>&amp;Remove</value>
+    <value>移除(&amp;R)</value>
   </data>
   <data name="SensorsConfig_BtnModify" xml:space="preserve">
-    <value>&amp;Modify</value>
+    <value>修改(&amp;M)</value>
   </data>
   <data name="SensorsConfig_BtnAdd" xml:space="preserve">
-    <value>&amp;Add New</value>
+    <value>新增(&amp;A)</value>
   </data>
   <data name="SensorsConfig_BtnStore" xml:space="preserve">
-    <value>&amp;Store &amp;&amp; Activate Sensors</value>
+    <value>存储 &amp;&amp; 激活传感器(&amp;S)</value>
   </data>
   <data name="SensorsConfig_ClmName" xml:space="preserve">
-    <value>Name</value>
+    <value>名称</value>
   </data>
   <data name="SensorsConfig_ClmType" xml:space="preserve">
-    <value>Type</value>
+    <value>类型</value>
   </data>
   <data name="SensorsConfig_LblRefresh" xml:space="preserve">
-    <value>Refresh</value>
+    <value>刷新</value>
   </data>
   <data name="SensorsConfig_Title" xml:space="preserve">
-    <value>Sensors Configuration</value>
+    <value>传感器配置</value>
   </data>
   <data name="SensorsMod_BtnStore" xml:space="preserve">
-    <value>&amp;Store Sensor</value>
+    <value>存储传感器(&amp;S)</value>
   </data>
   <data name="SensorsMod_LblSetting1" xml:space="preserve">
-    <value>setting 1</value>
+    <value>设置 1</value>
   </data>
   <data name="SensorsMod_LblType" xml:space="preserve">
-    <value>Selected Type</value>
+    <value>所选类型</value>
   </data>
   <data name="SensorsMod_LblName" xml:space="preserve">
-    <value>&amp;Name</value>
+    <value>名称(&amp;N)</value>
   </data>
   <data name="SensorsMod_LblUpdate" xml:space="preserve">
-    <value>&amp;Update every</value>
+    <value>更新间隔(&amp;U)</value>
   </data>
   <data name="SensorsMod_LblSeconds" xml:space="preserve">
-    <value>seconds</value>
+    <value>秒</value>
   </data>
   <data name="SensorsMod_LblDescription" xml:space="preserve">
-    <value>Description</value>
+    <value>描述</value>
   </data>
   <data name="SensorsMod_LblSetting2" xml:space="preserve">
-    <value>Setting 2</value>
+    <value>设置 2</value>
   </data>
   <data name="SensorsMod_LblSetting3" xml:space="preserve">
-    <value>Setting 3</value>
+    <value>设置 3</value>
   </data>
   <data name="SensorsMod_ClmSensorName" xml:space="preserve">
-    <value>  Type</value>
+    <value>  类型</value>
   </data>
   <data name="SensorsMod_LblMultiValue" xml:space="preserve">
-	  <value>Multivalue</value>
+    <value>多值</value>
   </data>
   <data name="SensorsMod_LblAgent" xml:space="preserve">
-    <value>Agent</value>
+    <value>代理</value>
   </data>
   <data name="SensorsMod_LblService" xml:space="preserve">
-    <value>Service</value>
+    <value>服务</value>
   </data>
   <data name="SensorsMod_LblSpecificClient" xml:space="preserve">
-    <value>HASS.Agent only!</value>
+    <value>仅限 HASS.Agent！</value>
   </data>
   <data name="SensorsMod_Title" xml:space="preserve">
-    <value>Sensor</value>
+    <value>传感器</value>
   </data>
   <data name="ServiceConfig_TabGeneral" xml:space="preserve">
-    <value>     General     </value>
+    <value>     常规     </value>
   </data>
   <data name="ServiceConfig_TabMqtt" xml:space="preserve">
     <value>     MQTT     </value>
   </data>
   <data name="ServiceConfig_TabCommands" xml:space="preserve">
-    <value>     Commands     </value>
+    <value>     命令     </value>
   </data>
   <data name="ServiceConfig_TabSensors" xml:space="preserve">
-    <value>     Sensors     </value>
+    <value>     传感器     </value>
   </data>
   <data name="ServiceConfig_Title" xml:space="preserve">
-    <value>Satellite Service Configuration</value>
+    <value>卫星服务配置</value>
   </data>
   <data name="About_BtnClose" xml:space="preserve">
-    <value>&amp;Close</value>
+    <value>关闭(&amp;C)</value>
   </data>
   <data name="About_LblInfo1" xml:space="preserve">
-    <value>A Windows-based client for the Home Assistant platform.</value>
+    <value>Home Assistant 平台的 Windows 客户端。</value>
   </data>
   <data name="About_LblInfo3" xml:space="preserve">
-	  <value>This application is open source and completely free, please check the project pages of 
-the used components for their individual licenses:</value>
+    <value>本应用程序是开源且完全免费的，请查看
+所用组件的项目页面以了解其各自的许可证：</value>
   </data>
   <data name="About_LblInfo4" xml:space="preserve">
-	  <value>A big 'thank you' to the developers of these projects, who were kind enough to share
-their hard work with the rest of us mere mortals. </value>
+    <value>衷心感谢这些项目的开发者，他们慷慨地
+将其辛勤成果与我们这些普通凡人分享。</value>
   </data>
   <data name="About_LblInfo5" xml:space="preserve">
-	  <value>And of course; thanks to Paulus Shoutsen and the entire team of developers that 
-created and maintain Home Assistant :-)</value>
+    <value>当然，还要感谢 Paulus Shoutsen 以及
+创建和维护 Home Assistant 的整个开发团队 :-)</value>
   </data>
   <data name="About_LblInfo2" xml:space="preserve">
-    <value>Created with love by</value>
+    <value>由以下作者倾注心血创建：</value>
   </data>
   <data name="About_LblInfo6" xml:space="preserve">
-    <value>Like this tool? Support us (read: keep us awake) by buying a cup of coffee:</value>
+    <value>喜欢这个工具？请我们喝杯咖啡来支持我们（即：让我们保持清醒）：</value>
   </data>
   <data name="About_Title" xml:space="preserve">
-    <value>About</value>
+    <value>关于</value>
   </data>
   <data name="Configuration_TabGeneral" xml:space="preserve">
-    <value>General</value>
+    <value>常规</value>
   </data>
   <data name="Configuration_TabExternalTools" xml:space="preserve">
-    <value>External Tools</value>
+    <value>外部工具</value>
   </data>
   <data name="Configuration_TabHassApi" xml:space="preserve">
     <value>Home Assistant API</value>
   </data>
   <data name="Configuration_TabHotKey" xml:space="preserve">
-    <value>Hotkey</value>
+    <value>热键</value>
   </data>
   <data name="Configuration_TabLocalStorage" xml:space="preserve">
-    <value>Local Storage</value>
+    <value>本地存储</value>
   </data>
   <data name="Configuration_TabLogging" xml:space="preserve">
-    <value>Logging</value>
+    <value>日志</value>
   </data>
   <data name="Configuration_TabMQTT" xml:space="preserve">
     <value>MQTT</value>
   </data>
   <data name="Configuration_TabNotifications" xml:space="preserve">
-    <value>Notifications</value>
+    <value>通知</value>
   </data>
   <data name="Configuration_TabService" xml:space="preserve">
-    <value>Satellite Service</value>
+    <value>卫星服务</value>
   </data>
   <data name="Configuration_TabStartup" xml:space="preserve">
-    <value>Startup</value>
+    <value>启动</value>
   </data>
   <data name="Configuration_TabUpdates" xml:space="preserve">
-    <value>Updates</value>
+    <value>更新</value>
   </data>
   <data name="Configuration_BtnAbout" xml:space="preserve">
-    <value>&amp;About</value>
+    <value>关于(&amp;A)</value>
   </data>
   <data name="Configuration_BtnHelp" xml:space="preserve">
-    <value>&amp;Help &amp;&amp; Contact</value>
+    <value>帮助 &amp;&amp; 联系(&amp;H)</value>
   </data>
   <data name="Configuration_BtnStore" xml:space="preserve">
-    <value>&amp;Save Configuration</value>
+    <value>保存配置(&amp;S)</value>
   </data>
   <data name="Configuration_BtnClose" xml:space="preserve">
-    <value>Close &amp;Without Saving</value>
+    <value>不保存关闭(&amp;W)</value>
   </data>
   <data name="Configuration_Title" xml:space="preserve">
-    <value>Configuration</value>
+    <value>配置</value>
   </data>
   <data name="ExitDialog_LblInfo1" xml:space="preserve">
-    <value>What would you like to do?</value>
+    <value>您想做什么？</value>
   </data>
   <data name="ExitDialog_BtnRestart" xml:space="preserve">
-    <value>&amp;Restart</value>
+    <value>重启(&amp;R)</value>
   </data>
   <data name="ExitDialog_BtnHide" xml:space="preserve">
-    <value>&amp;Hide</value>
+    <value>隐藏(&amp;H)</value>
   </data>
   <data name="ExitDialog_BtnExit" xml:space="preserve">
-    <value>&amp;Exit</value>
+    <value>退出(&amp;E)</value>
   </data>
   <data name="ExitDialog_Title" xml:space="preserve">
-    <value>Exit Dialog</value>
+    <value>退出对话框</value>
   </data>
   <data name="Help_BtnClose" xml:space="preserve">
-    <value>&amp;Close</value>
+    <value>关闭(&amp;C)</value>
   </data>
   <data name="Help_LblInfo1" xml:space="preserve">
-	  <value>If you are having trouble with HASS.Agent and require support
-with any sensors, commands, or for general support and feedback,
-there are few ways you can reach us:</value>
+    <value>如果您在使用 HASS.Agent 时遇到问题并需要支持，
+无论是关于传感器、命令，还是一般性的支持和反馈，
+都可以通过以下方式联系我们：</value>
   </data>
   <data name="Help_LblAbout" xml:space="preserve">
-    <value>About</value>
+    <value>关于</value>
   </data>
   <data name="Help_LblHAForum" xml:space="preserve">
-    <value>Home Assistant Forum</value>
+    <value>Home Assistant 论坛</value>
   </data>
   <data name="Help_LblGitHub" xml:space="preserve">
     <value>GitHub Issues</value>
   </data>
   <data name="Help_LblHAInfo" xml:space="preserve">
-	  <value>Bit of everything, with the addition that other
-HA users can help you out too!</value>
+    <value>内容丰富，此外其他
+HA 用户也能帮助您！</value>
   </data>
   <data name="Help_LblGitHubInfo" xml:space="preserve">
-    <value>Report bugs, post feature requests, see latest changes, etc.</value>
+    <value>报告错误、提交功能请求、查看最新变更等。</value>
   </data>
   <data name="Help_LblDiscordInfo" xml:space="preserve">
-	  <value>Get help with setting up and using HASS.Agent, 
-report bugs or get involved in general chit-chat!</value>
+    <value>获取 HASS.Agent 设置和使用方面的帮助，
+报告错误或参与日常闲聊！</value>
   </data>
   <data name="Help_LblWikiInfo" xml:space="preserve">
-    <value>Browse HASS.Agent documentation and usage examples.</value>
+    <value>浏览 HASS.Agent 文档和使用示例。</value>
   </data>
   <data name="Help_Title" xml:space="preserve">
-    <value>Help</value>
+    <value>帮助</value>
   </data>
   <data name="Main_TsShow" xml:space="preserve">
-    <value>Show HASS.Agent</value>
+    <value>显示 HASS.Agent</value>
   </data>
   <data name="Main_TsShowQuickActions" xml:space="preserve">
-    <value>Show Quick Actions</value>
+    <value>显示快捷操作</value>
   </data>
   <data name="Main_TsConfig" xml:space="preserve">
-    <value>Configuration</value>
+    <value>配置</value>
   </data>
   <data name="Main_TsQuickItemsConfig" xml:space="preserve">
-    <value>Manage Quick Actions</value>
+    <value>管理快捷操作</value>
   </data>
   <data name="Main_TsLocalSensors" xml:space="preserve">
-    <value>Manage Local Sensors</value>
+    <value>管理本地传感器</value>
   </data>
   <data name="Main_TsCommands" xml:space="preserve">
-    <value>Manage Commands</value>
+    <value>管理命令</value>
   </data>
   <data name="Main_CheckForUpdates" xml:space="preserve">
-    <value>Check for Updates</value>
+    <value>检查更新</value>
   </data>
   <data name="Main_TsDonate" xml:space="preserve">
-    <value>Donate</value>
+    <value>捐赠</value>
   </data>
   <data name="Main_TsHelp" xml:space="preserve">
-    <value>Help &amp;&amp; Contact</value>
+    <value>帮助 &amp;&amp; 联系</value>
   </data>
   <data name="Main_TsAbout" xml:space="preserve">
-    <value>About</value>
+    <value>关于</value>
   </data>
   <data name="Main_TsExit" xml:space="preserve">
-    <value>Exit HASS.Agent</value>
+    <value>退出 HASS.Agent</value>
   </data>
   <data name="Main_BtnHide" xml:space="preserve">
-    <value>&amp;Hide</value>
+    <value>隐藏(&amp;H)</value>
   </data>
   <data name="Main_GpControls" xml:space="preserve">
-    <value>Controls</value>
+    <value>控制</value>
   </data>
   <data name="Main_BtnServiceManager" xml:space="preserve">
-    <value>S&amp;atellite Service</value>
+    <value>卫星服务(&amp;A)</value>
   </data>
   <data name="Main_BtnAppSettings" xml:space="preserve">
-    <value>C&amp;onfiguration</value>
+    <value>配置(&amp;O)</value>
   </data>
   <data name="Main_BtnActionsManager" xml:space="preserve">
-    <value>&amp;Quick Actions</value>
+    <value>快捷操作(&amp;Q)</value>
   </data>
   <data name="Main_BtnCommandsManager" xml:space="preserve">
-    <value>Loading..</value>
+    <value>加载中..</value>
   </data>
   <data name="Main_BtnSensorsManager" xml:space="preserve">
-    <value>Loading..</value>
+    <value>加载中..</value>
   </data>
   <data name="Main_GpStatus" xml:space="preserve">
-    <value>System Status</value>
+    <value>系统状态</value>
   </data>
   <data name="Main_LblService" xml:space="preserve">
-    <value>Satellite Service:</value>
+    <value>卫星服务：</value>
   </data>
   <data name="Main_LblCommands" xml:space="preserve">
-    <value>Commands:</value>
+    <value>命令：</value>
   </data>
   <data name="Main_LblSensors" xml:space="preserve">
-    <value>Sensors:</value>
+    <value>传感器：</value>
   </data>
   <data name="Main_LblQuickActions" xml:space="preserve">
-    <value>Quick Actions:</value>
+    <value>快捷操作：</value>
   </data>
   <data name="Main_LblHomeAssistantApi" xml:space="preserve">
-    <value>Home Assistant API:</value>
+    <value>Home Assistant API：</value>
   </data>
   <data name="Main_LblNotificationApi" xml:space="preserve">
-    <value>notification api:</value>
+    <value>通知 API：</value>
   </data>
   <data name="Onboarding_BtnNext" xml:space="preserve">
-    <value>&amp;Next</value>
+    <value>下一步(&amp;N)</value>
   </data>
   <data name="Onboarding_BtnClose" xml:space="preserve">
-    <value>&amp;Close</value>
+    <value>关闭(&amp;C)</value>
   </data>
   <data name="Onboarding_BtnPrevious" xml:space="preserve">
-    <value>&amp;Previous</value>
+    <value>上一步(&amp;P)</value>
   </data>
   <data name="Onboarding_Onboarding" xml:space="preserve">
-    <value>HASS.Agent Onboarding</value>
+    <value>HASS.Agent 引导</value>
   </data>
   <data name="UpdatePending_BtnDownload" xml:space="preserve">
-    <value>Fetching info, please wait..</value>
+    <value>正在获取信息，请稍候..</value>
   </data>
   <data name="UpdatePending_LblNewReleaseInfo" xml:space="preserve">
-    <value>There's a new release available:</value>
+    <value>有新版本可用：</value>
   </data>
   <data name="UpdatePending_LblInfo1" xml:space="preserve">
-    <value>Release notes</value>
+    <value>发行说明</value>
   </data>
   <data name="UpdatePending_BtnIgnore" xml:space="preserve">
-    <value>&amp;Ignore Update</value>
+    <value>忽略更新(&amp;I)</value>
   </data>
   <data name="UpdatePending_LblRelease" xml:space="preserve">
-    <value>Release Page</value>
+    <value>发布页面</value>
   </data>
   <data name="UpdatePending_Title" xml:space="preserve">
-    <value>HASS.Agent Update</value>
+    <value>HASS.Agent 更新</value>
   </data>
   <data name="CommandsManager_CustomCommandDescription" xml:space="preserve">
-	  <value>Execute a custom command.
+    <value>执行自定义命令。
 
-These commands run without special elevation. To run elevated, create a Scheduled Task, and use 'schtasks /Run /TN "TaskName"' as the command to execute your task.
+这些命令运行时没有特殊提权。如需以提权方式运行，请创建计划任务，并使用 'schtasks /Run /TN "TaskName"' 作为执行任务的命令。
 
-Or enable 'run as low integrity' for even stricter execution.</value>
+或者启用"以低完整性级别运行"以获得更严格的执行环境。</value>
   </data>
   <data name="CommandsManager_CustomExecutorCommandDescription" xml:space="preserve">
-	  <value>Executes the command through the configured custom executor (in Configuration -&gt; External Tools).
+    <value>通过配置的自定义执行器（在 配置 -&gt; 外部工具 中）执行命令。
 
-Your command is provided as an argument 'as is', so you have to supply your own quotes etc. if necessary.</value>
+您的命令将"按原样"作为参数提供，因此如有必要，您需要自行添加引号等。</value>
   </data>
   <data name="CommandsManager_HibernateCommandDescription" xml:space="preserve">
-    <value>Sets the machine in hibernation.</value>
+    <value>使机器进入休眠状态。</value>
   </data>
   <data name="CommandsManager_KeyCommandDescription" xml:space="preserve">
-	  <value>Simulates a single keypress.
+    <value>模拟单次按键。
 
-Click on the 'keycode' textbox and press the key you want simulated. The corresponding keycode will be entered for you.
+点击"键码"文本框，然后按下您想要模拟的键，系统将自动填入对应的键码。
+TAB 键请使用 LCTRL+TAB。
 
-If you need more keys and/or modifiers like CTRL, use the MultipleKeys command.</value>
+如果您需要更多按键和/或 CTRL 等修饰键，请使用 MultipleKeys 命令。</value>
   </data>
   <data name="CommandsManager_LaunchUrlCommandDescription" xml:space="preserve">
-	  <value>Launches the provided URL, by default in your default browser.
+    <value>启动提供的 URL，默认在您的默认浏览器中打开。
 
-To use 'incognito', provide a specific browser in Configuration -&gt; External Tools.
+要使用"无痕模式"，请在 配置 -&gt; 外部工具 中指定特定浏览器。
 
-If you just want a window with a specific URL (not an entire browser), use a 'WebView' command.</value>
+如果您只需要一个显示特定 URL 的窗口（而非整个浏览器），请使用 'WebView' 命令。</value>
   </data>
   <data name="CommandsManager_LockCommandDescription" xml:space="preserve">
-    <value>Locks the current session.</value>
+    <value>锁定当前会话。</value>
   </data>
   <data name="CommandsManager_LogOffCommandDescription" xml:space="preserve">
-    <value>Logs off the current session.</value>
+    <value>注销当前会话。</value>
   </data>
   <data name="CommandsManager_MediaMuteCommandDescription" xml:space="preserve">
-    <value>Simulates 'Mute' key.</value>
+    <value>模拟"静音"键。</value>
   </data>
   <data name="CommandsManager_MediaNextCommandDescription" xml:space="preserve">
-    <value>Simulates 'Media Next' key.</value>
+    <value>模拟"媒体下一首"键。</value>
   </data>
   <data name="CommandsManager_MediaPlayPauseCommandDescription" xml:space="preserve">
-    <value>Simulates 'Media Pause/Play' key.</value>
+    <value>模拟"媒体暂停/播放"键。</value>
   </data>
   <data name="CommandsManager_MediaPreviousCommandDescription" xml:space="preserve">
-    <value>Simulates 'Media Previous' key.</value>
+    <value>模拟"媒体上一首"键。</value>
   </data>
   <data name="CommandsManager_MediaVolumeDownCommandDescription" xml:space="preserve">
-    <value>Simulates 'Volume Down' key.</value>
+    <value>模拟"音量减小"键。</value>
   </data>
   <data name="CommandsManager_MediaVolumeUpCommandDescription" xml:space="preserve">
-    <value>Simulates 'Volume Up' key.</value>
+    <value>模拟"音量增大"键。</value>
   </data>
   <data name="CommandsManager_MultipleKeysCommandDescription" xml:space="preserve">
-	  <value>Simulates pressing mulitple keys.
+    <value>模拟按下多个按键。
 
-You need to put [ ] between every key, otherwise HASS.Agent can't tell them apart. So say you want to press X TAB Y SHIFT-Z, it'd be [X] [{TAB}] [Y] [+Z].
+您需要在每个按键之间用 [ ] 分隔，否则 HASS.Agent 无法区分它们。例如，您想按下 X TAB Y SHIFT-Z，则应写为 [X] [{TAB}] [Y] [+Z]。
 
-There are a few tricks you can use:
+您可以使用以下技巧：
 
-- If you want a bracket pressed, escape it, so [ is [\[] and ] is [\]] 
+- 如需按下括号键，请对其进行转义，即 [ 写为 [\[]，] 写为 [\]]
 
-- Special keys go between { }, like {TAB} or {UP}
+- 特殊键放在 { } 中，例如 {TAB} 或 {UP}
 
-- Put a + in front of a key to add SHIFT, ^ for CTRL and % for ALT. So, +C is SHIFT-C. Or, +(CD) is SHIFT-C and SHIFT-D, while +CD is SHIFT-C and D
+- 在按键前加 + 表示 SHIFT，加 ^ 表示 CTRL，加 % 表示 ALT。因此，+C 表示 SHIFT-C。而 +(CD) 表示 SHIFT-C 和 SHIFT-D，+CD 则表示 SHIFT-C 和 D
 
-- For multiple presses, use {z 15}, which means Z will get pressed 15 times.
+- 如需多次按键，使用 {z 15}，表示 Z 将被按下 15 次。
 
-More info: https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.sendkeys</value>
+更多信息：https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.sendkeys</value>
   </data>
   <data name="CommandsManager_PowershellCommandDescription" xml:space="preserve">
-	  <value>Execute a Powershell command or script.
+    <value>执行 PowerShell 命令或脚本。
 
-You can either provide the location of a script (*.ps1), or a single-line command.
+您可以提供脚本（*.ps1）的位置，或单行命令。
 
-This will run without special elevation.</value>
+此命令运行时没有特殊提权。</value>
   </data>
   <data name="CommandsManager_PublishAllSensorsCommandDescription" xml:space="preserve">
-	  <value>Resets all sensor checks, forcing all sensors to process and send their value.
+    <value>重置所有传感器检查，强制所有传感器处理并发送其值。
 
-Useful for example if you want to force HASS.Agent to update all your sensors after a HA reboot.</value>
+例如，当您想在 HA 重启后强制 HASS.Agent 更新所有传感器时非常有用。</value>
   </data>
   <data name="CommandsManager_RestartCommandDescription" xml:space="preserve">
-	  <value>Restarts the machine after one minute.
+    <value>一分钟后重启机器。
 
-Tip: Accidentally triggered? Run 'shutdown /a' to abort shutdown.</value>
+提示：误触发了？运行 'shutdown /a' 中止关机。</value>
   </data>
   <data name="CommandsManager_ShutdownCommandDescription" xml:space="preserve">
-	  <value>Shuts down the machine after one minute.
+    <value>一分钟后关闭机器。
 
-Tip: Accidentally triggered? Run 'shutdown /a' to abort shutdown.</value>
+提示：误触发了？运行 'shutdown /a' 中止关机。</value>
   </data>
   <data name="CommandsManager_SleepCommandDescription" xml:space="preserve">
-	  <value>Puts the machine to sleep.
+    <value>使机器进入睡眠状态。
 
-Note: due to a limitation in Windows, this only works if hibernation is disabled, otherwise it will just hibernate.
+注意：由于 Windows 的限制，此功能仅在禁用休眠时有效，否则机器将进入休眠。
 
-You can use something like NirCmd (http://www.nirsoft.net/utils/nircmd.html) to circumvent this.</value>
+您可以使用 NirCmd（http://www.nirsoft.net/utils/nircmd.html）等工具绕过此限制。</value>
   </data>
   <data name="ConfigExternalTools_BtnExternalBrowserIncognitoTest_MessageBox1" xml:space="preserve">
-    <value>Please enter the location of your browser's binary! (.exe file)</value>
+    <value>请输入浏览器可执行文件的位置！（.exe 文件）</value>
   </data>
   <data name="ConfigExternalTools_ConfigExternalTools_BtnExternalBrowserIncognitoTest_MessageBox2" xml:space="preserve">
-    <value>The browser binary provided could not be found, please ensure the path is correct and try again.</value>
+    <value>找不到提供的浏览器可执行文件，请确保路径正确后重试。</value>
   </data>
   <data name="ConfigExternalTools_BtnExternalBrowserIncognitoTest_MessageBox3" xml:space="preserve">
-	  <value>No incognito arguments were provided so the browser will likely launch normally.
+    <value>未提供无痕模式参数，浏览器可能会正常启动。
 
-Do you want to continue?</value>
+您要继续吗？</value>
   </data>
   <data name="ConfigExternalTools_BtnExternalBrowserIncognitoTest_MessageBox4" xml:space="preserve">
-	  <value>Something went wrong while launching your browser in incognito mode!
+    <value>以无痕模式启动浏览器时出错！
 
-Please check the logs for more information.</value>
+请查看日志以获取更多信息。</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox1" xml:space="preserve">
-    <value>Please enter a valid API key!</value>
+    <value>请输入有效的 API 密钥！</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox2" xml:space="preserve">
-    <value>Please enter a value for your Home Assistant's URI.</value>
+    <value>请输入您的 Home Assistant URI 值。</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox3" xml:space="preserve">
-	  <value>Unable to connect, the following error was returned:
+    <value>无法连接，返回以下错误：
 
 {0}</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox4" xml:space="preserve">
-	  <value>Connection OK!
+    <value>连接成功！
 
-Home Assistant version: {0}</value>
+Home Assistant 版本：{0}</value>
   </data>
   <data name="ConfigLocalStorage_BtnClearImageCache_MessageBox1" xml:space="preserve">
-    <value>Image cache has been cleared!</value>
+    <value>图片缓存已清除！</value>
   </data>
   <data name="ConfigLocalStorage_BtnClearImageCache_InfoText1" xml:space="preserve">
-    <value>Cleaning..</value>
+    <value>清理中..</value>
   </data>
   <data name="ConfigNotifications_BtnSendTestNotification_MessageBox1" xml:space="preserve">
-    <value>Notifications are currently disabled, please enable them and restart the HASS.Agent, then try again.</value>
+    <value>通知当前已禁用，请启用通知并重启 HASS.Agent 后重试。</value>
   </data>
   <data name="ConfigNotifications_BtnSendTestNotification_MessageBox2" xml:space="preserve">
-	  <value>The test notification should have appeared, if you did not receive it please check the logs or consult the documentation for troubleshooting tips.
+    <value>测试通知应该已经显示，如果您没有收到，请查看日志或查阅文档以获取故障排查提示。
 
-Note: This only tests locally whether notifications can be shown!</value>
+注意：这仅在本地测试通知是否能显示！</value>
   </data>
   <data name="ConfigNotifications_TestNotification" xml:space="preserve">
-    <value>This is a test notification!</value>
+    <value>这是一条测试通知！</value>
   </data>
   <data name="ConfigNotifications_BtnExecutePortReservation_Busy" xml:space="preserve">
-    <value>Executing, please wait..</value>
+    <value>执行中，请稍候..</value>
   </data>
   <data name="ConfigNotifications_BtnExecutePortReservation_MessageBox1" xml:space="preserve">
-	  <value>Something went wrong whilst reserving the port!
+    <value>预留端口时出错！
 
-Manual execution is required and a command has been copied to your clipboard, please open an elevated terminal and paste the command.
+需要手动执行，命令已复制到剪贴板，请打开提权终端并粘贴命令。
 
-Additionally, remember to change your Firewall Rules port!</value>
+此外，请记得更改防火墙规则的端口！</value>
   </data>
   <data name="ConfigService_NotInstalled" xml:space="preserve">
-    <value>Not Installed</value>
+    <value>未安装</value>
   </data>
   <data name="ConfigService_Disabled" xml:space="preserve">
-    <value>Disabled</value>
+    <value>已禁用</value>
   </data>
   <data name="ConfigService_Running" xml:space="preserve">
-    <value>Running</value>
+    <value>运行中</value>
   </data>
   <data name="ConfigService_Stopped" xml:space="preserve">
-    <value>Stopped</value>
+    <value>已停止</value>
   </data>
   <data name="ConfigService_Failed" xml:space="preserve">
-    <value>Failed</value>
+    <value>失败</value>
   </data>
   <data name="ConfigService_BtnStopService_MessageBox1" xml:space="preserve">
-	  <value>Something went wrong whilst stopping the service, did you allow the UAC prompt?
+    <value>停止服务时出错，您是否允许了 UAC 提示？
 
-Check the HASS.Agent (not the service) logs for more information.</value>
+请查看 HASS.Agent（非服务）的日志以获取更多信息。</value>
   </data>
   <data name="ConfigService_BtnStartService_MessageBox1" xml:space="preserve">
-	  <value>The service is set to 'disabled', so it cannot be started.
+    <value>服务已设为"禁用"，无法启动。
 
-Please enable the service first and try again.</value>
+请先启用服务后再重试。</value>
   </data>
   <data name="ConfigService_BtnStartService_MessageBox2" xml:space="preserve">
-	  <value>Something went wrong whilst starting the service, did you allow the UAC prompt?
+    <value>启动服务时出错，您是否允许了 UAC 提示？
 
-Check the HASS.Agent (not the service) logs for more information.</value>
+请查看 HASS.Agent（非服务）的日志以获取更多信息。</value>
   </data>
   <data name="ConfigService_BtnDisableService_MessageBox1" xml:space="preserve">
-	  <value>Something went wrong whilst disabling the service, did you allow the UAC prompt?
+    <value>禁用服务时出错，您是否允许了 UAC 提示？
 
-Check the HASS.Agent (not the service) logs for more information.</value>
+请查看 HASS.Agent（非服务）的日志以获取更多信息。</value>
   </data>
   <data name="ConfigService_BtnEnableService_MessageBox1" xml:space="preserve">
-	  <value>Something went wrong whilst enabling the service, did you allow the UAC prompt?
+    <value>启用服务时出错，您是否允许了 UAC 提示？
 
-Check the HASS.Agent (not the service) logs for more information.</value>
+请查看 HASS.Agent（非服务）的日志以获取更多信息。</value>
   </data>
   <data name="ConfigService_BtnShowLogs_MessageBox1" xml:space="preserve">
-	  <value>Something went wrong whilst reinstalling the service, did you allow the UAC prompt?
+    <value>重新安装服务时出错，您是否允许了 UAC 提示？
 
-Check the HASS.Agent (not the service) logs for more information.</value>
+请查看 HASS.Agent（非服务）的日志以获取更多信息。</value>
   </data>
   <data name="ConfigStartup_BtnSetStartOnLogin_MessageBox1" xml:space="preserve">
-    <value>Something went wrong whilst disabling Start-on-Login, please check the logs for more information.</value>
+    <value>禁用开机启动时出错，请查看日志以获取更多信息。</value>
   </data>
   <data name="ConfigStartup_BtnSetStartOnLogin_MessageBox2" xml:space="preserve">
-    <value>Something went wrong whilst disabling Start-on-Login, please check the logs for more information.</value>
+    <value>禁用开机启动时出错，请查看日志以获取更多信息。</value>
   </data>
   <data name="ConfigStartup_Enabled" xml:space="preserve">
-    <value>Enabled</value>
+    <value>已启用</value>
   </data>
   <data name="ConfigStartup_Disable" xml:space="preserve">
-    <value>Disable Start-on-Login</value>
+    <value>禁用开机启动</value>
   </data>
   <data name="ConfigStartup_Disabled" xml:space="preserve">
-    <value>Disabled</value>
+    <value>已禁用</value>
   </data>
   <data name="ConfigStartup_Enable" xml:space="preserve">
-    <value>Enable Start-on-Login</value>
+    <value>启用开机启动</value>
   </data>
   <data name="OnboardingStartup_Activated" xml:space="preserve">
-    <value>Start-on-Login has been activated!</value>
+    <value>开机启动已激活！</value>
   </data>
   <data name="OnboardingStartup_EnableNow" xml:space="preserve">
-    <value>Do you want to enable Start-on-Login now?</value>
+    <value>您想现在启用开机启动吗？</value>
   </data>
   <data name="OnboardingStartup_AlreadyActivated" xml:space="preserve">
-    <value>Start-on-Login is already activated, all set!</value>
+    <value>开机启动已激活，一切就绪！</value>
   </data>
   <data name="OnboardingStartup_Activating" xml:space="preserve">
-    <value>Activating Start-on-Login..</value>
+    <value>正在激活开机启动..</value>
   </data>
   <data name="OnboardingStartup_Failed" xml:space="preserve">
-    <value>Something went wrong. You can try again, or skip to the next page and retry after HASS.Agent's restart.</value>
+    <value>出错了。您可以重试，或跳到下一页并在 HASS.Agent 重启后重试。</value>
   </data>
   <data name="OnboardingStartup_BtnSetLaunchOnLogin_2" xml:space="preserve">
-    <value>Enable Start-on-Login</value>
+    <value>启用开机启动</value>
   </data>
   <data name="OnboardingApi_BtnTest_MessageBox1" xml:space="preserve">
-    <value>Please provide a valid API key.</value>
+    <value>请提供有效的 API 密钥。</value>
   </data>
   <data name="OnboardingApi_BtnTest_MessageBox2" xml:space="preserve">
-    <value>Please enter your Home Assistant's URI.</value>
+    <value>请输入您的 Home Assistant URI。</value>
   </data>
   <data name="OnboardingApi_BtnTest_MessageBox3" xml:space="preserve">
-	  <value>Unable to connect, the following error was returned:
+    <value>无法连接，返回以下错误：
 
 {0}</value>
   </data>
   <data name="OnboardingApi_BtnTest_MessageBox4" xml:space="preserve">
-	  <value>Connection OK!
+    <value>连接成功！
 
-Home Assistant version: {0}</value>
+Home Assistant 版本：{0}</value>
   </data>
   <data name="OnboardingApi_BtnTest_Testing" xml:space="preserve">
-    <value>Testing..</value>
+    <value>测试中..</value>
   </data>
   <data name="ServiceCommands_BtnStore_MessageBox1" xml:space="preserve">
-    <value>An error occurred whilst saving your commands, please check the logs for more information.</value>
+    <value>保存命令时出错，请查看日志以获取更多信息。</value>
   </data>
   <data name="ServiceCommands_BtnStore_Storing" xml:space="preserve">
-    <value>Storing and registering, please wait..</value>
+    <value>存储并注册中，请稍候..</value>
   </data>
   <data name="ServiceConnect_Connecting" xml:space="preserve">
-    <value>Connecting with satellite service, please wait..</value>
+    <value>正在连接卫星服务，请稍候..</value>
   </data>
   <data name="ServiceConnect_Failed" xml:space="preserve">
-    <value>Connecting to the service has failed!</value>
+    <value>连接服务失败！</value>
   </data>
   <data name="ServiceConnect_FailedMessage" xml:space="preserve">
-	  <value>The service hasn't been found! You can install and manage it from the configuration panel.
+    <value>未找到服务！您可以在配置面板中安装和管理它。
 
-When it's up and running, come back here to configure the commands and sensors.</value>
+当服务启动并运行后，请返回此处配置命令和传感器。</value>
   </data>
   <data name="ServiceConnect_CommunicationFailed" xml:space="preserve">
-    <value>Communicating with the service has failed!</value>
+    <value>与服务通信失败！</value>
   </data>
   <data name="ServiceConnect_CommunicationFailedMessage" xml:space="preserve">
-	  <value>Unable to communicate with the service. Check the logs for more info.
+    <value>无法与服务通信。请查看日志以获取更多信息。
 
-You can open the logs and manage the service from the configuration panel.</value>
+您可以在配置面板中打开日志并管理服务。</value>
   </data>
   <data name="ServiceConnect_Unauthorized" xml:space="preserve">
-    <value>Unauthorized</value>
+    <value>未授权</value>
   </data>
   <data name="ServiceConnect_UnauthorizedMessage" xml:space="preserve">
-	  <value>You are not authorized to contact the service.
+    <value>您无权访问该服务。
 
-If you have the correct auth ID, you can set it now and try again.</value>
+如果您有正确的身份验证 ID，可以现在设置并重试。</value>
   </data>
   <data name="ServiceConnect_SettingsFailed" xml:space="preserve">
-    <value>Fetching settings failed!</value>
+    <value>获取设置失败！</value>
   </data>
   <data name="ServiceConnect_SettingsFailedMessage" xml:space="preserve">
-	  <value>The service returned an error while requesting its settings. Check the logs for more info.
+    <value>请求设置时服务返回了错误。请查看日志以获取更多信息。
 
-You can open the logs and manage the service from the configuration panel.</value>
+您可以在配置面板中打开日志并管理服务。</value>
   </data>
   <data name="ServiceConnect_MqttFailed" xml:space="preserve">
-    <value>Fetching MQTT settings failed!</value>
+    <value>获取 MQTT 设置失败！</value>
   </data>
   <data name="ServiceConnect_MqttFailedMessage" xml:space="preserve">
-	  <value>The service returned an error while requesting its MQTT settings. Check the logs for more info.
+    <value>请求 MQTT 设置时服务返回了错误。请查看日志以获取更多信息。
 
-You can open the logs and manage the service from the configuration panel.</value>
+您可以在配置面板中打开日志并管理服务。</value>
   </data>
   <data name="ServiceConnect_CommandsFailed" xml:space="preserve">
-    <value>Fetching configured commands failed!</value>
+    <value>获取已配置的命令失败！</value>
   </data>
   <data name="ServiceConnect_CommandsFailedMessage" xml:space="preserve">
-	  <value>The service returned an error while requesting its configured commands. Check the logs for more info.
+    <value>请求已配置的命令时服务返回了错误。请查看日志以获取更多信息。
 
-You can open the logs and manage the service from the configuration panel.</value>
+您可以在配置面板中打开日志并管理服务。</value>
   </data>
   <data name="ServiceConnect_SensorsFailed" xml:space="preserve">
-    <value>Fetching configured sensors failed!</value>
+    <value>获取已配置的传感器失败！</value>
   </data>
   <data name="ServiceConnect_SensorsFailedMessage" xml:space="preserve">
-	  <value>The service returned an error while requesting its configured sensors. Check the logs for more info.
+    <value>请求已配置的传感器时服务返回了错误。请查看日志以获取更多信息。
 
-You can open the logs and manage the service from the configuration panel.</value>
+您可以在配置面板中打开日志并管理服务。</value>
   </data>
   <data name="ServiceGeneral_TbAuthId_MessageBox1" xml:space="preserve">
-	  <value>Storing an empty auth ID will allow all HASS.Agent to access the service.
+    <value>存储空的身份验证 ID 将允许所有 HASS.Agent 访问该服务。
 
-Are you sure you want this?</value>
+您确定要这样做吗？</value>
   </data>
   <data name="ServiceGeneral_SavingFailedMessageBox" xml:space="preserve">
-    <value>An error occurred whilst saving, check the logs for more information.</value>
+    <value>保存时出错，请查看日志以获取更多信息。</value>
   </data>
   <data name="ServiceGeneral_BtnStoreDeviceName_MessageBox1" xml:space="preserve">
-    <value>Please provide a device name!</value>
+    <value>请提供设备名称！</value>
   </data>
   <data name="ServiceGeneral_BtnStoreCustomExecutor_MessageBox1" xml:space="preserve">
-    <value>Please select an executor first. (Tip: Double click to Browse)</value>
+    <value>请先选择一个执行器。（提示：双击进行浏览）</value>
   </data>
   <data name="ServiceGeneral_BtnStoreCustomExecutor_MessageBox2" xml:space="preserve">
-    <value>The selected executor could not be found, please ensure the path provided is correct and try again.</value>
+    <value>找不到所选的执行器，请确保提供的路径正确后重试。</value>
   </data>
   <data name="ServiceGeneral_LblAuthIdInfo_MessageBox1" xml:space="preserve">
-	  <value>Set an auth ID if you don't want every instance of HASS.Agent on this PC to connect with the satellite service.
+    <value>如果您不希望此 PC 上的每个 HASS.Agent 实例都连接到卫星服务，请设置身份验证 ID。
 
-Only the instances that have the correct ID, can connect.
+只有拥有正确 ID 的实例才能连接。
 
-Leave empty to allow all to connect.</value>
+留空则允许所有实例连接。</value>
   </data>
   <data name="ServiceGeneral_LblDeviceNameInfo_MessageBox1" xml:space="preserve">
-	  <value>This is the name with which the satellite service registers itself on Home Assistant.
+    <value>这是卫星服务在 Home Assistant 上注册时使用的名称。
 
-By default, it's your PC's name plus '-satellite'.</value>
+默认情况下，它是您的 PC 名称加上 '-satellite'。</value>
   </data>
   <data name="ServiceGeneral_LblDisconGraceInfo_MessageBox1" xml:space="preserve">
-    <value>The amount of time the satellite service will wait before reporting a lost connection to the MQTT broker.</value>
+    <value>卫星服务在报告与 MQTT 代理失去连接前等待的时间。</value>
   </data>
   <data name="ServiceMqtt_StatusError" xml:space="preserve">
-    <value>Error fetching status, please check logs for information.</value>
+    <value>获取状态时出错，请查看日志以获取信息</value>
   </data>
   <data name="ServiceMqtt_BtnStore_MessageBox1" xml:space="preserve">
-    <value>An error occurred whilst saving the configuration, please check the logs for more information.</value>
+    <value>保存配置时出错，请查看日志以获取更多信息。</value>
   </data>
   <data name="ServiceMqtt_BtnStore_Storing" xml:space="preserve">
-    <value>Storing and registering, please wait..</value>
+    <value>存储并注册中，请稍候..</value>
   </data>
   <data name="ServiceSensors_BtnStore_MessageBox1" xml:space="preserve">
-    <value>An error occurred whilst saving the sensors, please check the logs for more information.</value>
+    <value>保存传感器时出错，请查看日志以获取更多信息。</value>
   </data>
   <data name="ServiceSensors_BtnStore_Storing" xml:space="preserve">
-    <value>Storing and registering, please wait..</value>
+    <value>存储并注册中，请稍候..</value>
   </data>
   <data name="PortReservation_ProcessPostUpdate_MessageBox1" xml:space="preserve">
-    <value>Not all steps completed succesfully. Please consult the logs for more information.</value>
+    <value>并非所有步骤都成功完成。请查看日志以获取更多信息。</value>
   </data>
   <data name="PostUpdate_ProcessPostUpdate_MessageBox1" xml:space="preserve">
-    <value>Not all steps completed succesfully. Please consult the logs for more information.</value>
+    <value>并非所有步骤都成功完成。请查看日志以获取更多信息。</value>
   </data>
   <data name="Restart_ProcessRestart_MessageBox1" xml:space="preserve">
-	  <value>HASS.Agent is still active after {0} seconds. Please close all instances and restart manually.
+    <value>{0} 秒后 HASS.Agent 仍然处于活动状态。请关闭所有实例并手动重启。
 
-Check the logs for more info, and optionally inform the developers.</value>
+请查看日志以获取更多信息，并可选择通知开发者。</value>
   </data>
   <data name="ServiceReinstall_ProcessReinstall_MessageBox1" xml:space="preserve">
-    <value>Not all steps completed successfully, please check the logs for more information.</value>
+    <value>并非所有步骤都成功完成，请查看日志以获取更多信息。</value>
   </data>
   <data name="ServiceSetState_Enabled" xml:space="preserve">
-    <value>Enable Satellite Service</value>
+    <value>启用卫星服务</value>
   </data>
   <data name="ServiceSetState_Disabled" xml:space="preserve">
-    <value>Disable Satellite Service</value>
+    <value>禁用卫星服务</value>
   </data>
   <data name="ServiceSetState_Started" xml:space="preserve">
-    <value>Start Satellite Service</value>
+    <value>启动卫星服务</value>
   </data>
   <data name="ServiceSetState_Stopped" xml:space="preserve">
-    <value>Stop Satellite Service</value>
+    <value>停止卫星服务</value>
   </data>
   <data name="ServiceSetState_ProcessState_MessageBox1" xml:space="preserve">
-	  <value>Something went wrong while processing the desired service state.
+    <value>处理所需的服务状态时出错。
 
-Please consult the logs for more information.</value>
+请查看日志以获取更多信息。</value>
   </data>
   <data name="CommandMqttTopic_BtnCopyClipboard_Copied" xml:space="preserve">
-    <value>Topic copied to clipboard!</value>
+    <value>主题已复制到剪贴板！</value>
   </data>
   <data name="CommandsConfig_BtnStore_Storing" xml:space="preserve">
-    <value>Storing and registering, please wait..</value>
+    <value>存储并注册中，请稍候..</value>
   </data>
   <data name="CommandsConfig_BtnStore_MessageBox1" xml:space="preserve">
-    <value>An error occurred whilst saving commands, please check the logs for more information.</value>
+    <value>保存命令时出错，请查看日志以获取更多信息。</value>
   </data>
   <data name="CommandsMod_Title_NewCommand" xml:space="preserve">
-    <value>New Command</value>
+    <value>新建命令</value>
   </data>
   <data name="CommandsMod_Title_ModCommand" xml:space="preserve">
-    <value>Mod Command</value>
+    <value>修改命令</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox1" xml:space="preserve">
-    <value>Please select a command type!</value>
+    <value>请选择命令类型！</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox2" xml:space="preserve">
-    <value>Please select a valid command type!</value>
+    <value>请选择有效的命令类型！</value>
   </data>
   <data name="CommandsMod_MessageBox_EntityType" xml:space="preserve">
-    <value>Select a valid entity type first.</value>
+    <value>请先选择有效的实体类型。</value>
   </data>
   <data name="CommandsMod_MessageBox_Name" xml:space="preserve">
-    <value>Please provide a name!</value>
+    <value>请提供名称！</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox3" xml:space="preserve">
-    <value>A command with that name already exists, are you sure you want to continue?</value>
+    <value>同名命令已存在，您确定要继续吗？</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox4" xml:space="preserve">
-	  <value>If a command is not provided, you may only use this entity with an 'action' value via Home Assistant, running it as-is will have no action.
+    <value>如果未提供命令，则只能通过 Home Assistant 使用 'action' 值来使用此实体，直接运行不会产生任何动作。
 
-Are you sure you want to proceed?</value>
+您确定要继续吗？</value>
   </data>
   <data name="CommandsMod_MessageBox_Action" xml:space="preserve">
-	  <value>If you don't enter a command or script, you can only use this entity with an 'action' value through Home Assistant. Running it as-is won't do anything.
+    <value>如果您不输入命令或脚本，则只能通过 Home Assistant 使用 'action' 值来使用此实体。直接运行不会产生任何效果。
 
-Are you sure you want this?</value>
+您确定要这样吗？</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox5" xml:space="preserve">
-    <value>Please enter a key code!</value>
+    <value>请输入键码！</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox6" xml:space="preserve">
-    <value>Checking keys failed: {0}</value>
+    <value>检查按键失败：{0}</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox7" xml:space="preserve">
-	  <value>If a URL is not provided, you may only use this entity with an 'action' value via Home Assistant, running it as-is will have no action.
+    <value>如果未提供 URL，则只能通过 Home Assistant 使用 'action' 值来使用此实体，直接运行不会产生任何动作。
 
-Are you sure you want to proceed?</value>
+您确定要继续吗？</value>
   </data>
   <data name="CommandsMod_LblSetting_Command" xml:space="preserve">
-    <value>Command</value>
+    <value>命令</value>
   </data>
   <data name="CommandsMod_LblSetting_CommandScript" xml:space="preserve">
-    <value>Command or Script</value>
+    <value>命令或脚本</value>
   </data>
   <data name="CommandsMod_LblSetting_KeyCode" xml:space="preserve">
-    <value>Keycode</value>
+    <value>键码</value>
   </data>
   <data name="CommandsMod_LblSetting_KeyCodes" xml:space="preserve">
-    <value>Keycodes</value>
+    <value>键码</value>
   </data>
   <data name="CommandsMod_CbCommandSpecific_Incognito" xml:space="preserve">
-    <value>Launch in Incognito Mode</value>
+    <value>以无痕模式启动</value>
   </data>
   <data name="CommandsMod_LblInfo_Browser" xml:space="preserve">
-	  <value>Browser: Default
+    <value>浏览器：默认
 
-Please configure a custom browser to enable incognito mode.</value>
+请配置自定义浏览器以启用无痕模式。</value>
   </data>
   <data name="CommandsMod_LblSetting_Url" xml:space="preserve">
     <value>URL</value>
   </data>
   <data name="CommandsMod_LblInfo_BrowserSpecific" xml:space="preserve">
-    <value>Browser: {0}</value>
+    <value>浏览器：{0}</value>
   </data>
   <data name="CommandsMod_LblInfo_Executor" xml:space="preserve">
-	  <value>Executor: None
+    <value>执行器：无
 
-Please configure an executor or your command will not run.</value>
+请配置一个执行器，否则您的命令将不会运行。</value>
   </data>
   <data name="CommandsMod_LblInfo_ExecutorSpecific" xml:space="preserve">
-    <value>Executor: {0}</value>
+    <value>执行器：{0}</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo_InfoMsg1" xml:space="preserve">
-    <value>Low integrity means your command will be executed with restricted privileges.</value>
+    <value>低完整性意味着您的命令将以受限权限执行。</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo_InfoMsg2" xml:space="preserve">
-    <value>This means it will only be able to save and modify files in certain locations,</value>
+    <value>这意味着它只能在特定位置保存和修改文件，</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo_InfoMsg3" xml:space="preserve">
-    <value>such as the '%USERPROFILE%\AppData\LocalLow' folder or</value>
+    <value>例如 '%USERPROFILE%\AppData\LocalLow' 文件夹或</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo_InfoMsg4" xml:space="preserve">
-    <value>the 'HKEY_CURRENT_USER\Software\AppDataLow' registry key.</value>
+    <value>'HKEY_CURRENT_USER\Software\AppDataLow' 注册表项。</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo_InfoMsg5" xml:space="preserve">
-    <value>You should test your command to make sure it's not influenced by this!</value>
+    <value>您应该测试您的命令以确保其不受此影响！</value>
   </data>
   <data name="CommandsMod_SpecificClient" xml:space="preserve">
-    <value>{0} only!</value>
+    <value>仅 {0}！</value>
   </data>
   <data name="CommandsMod_LblMqttTopic_MessageBox1" xml:space="preserve">
-    <value>The MQTT manager hasn't been configured properly, or hasn't yet completed its startup.</value>
+    <value>MQTT 管理器尚未正确配置，或尚未完成启动。</value>
   </data>
   <data name="QuickActions_CheckHassManager_MessageBox1" xml:space="preserve">
-    <value>Unable to fetch your entities because of missing config, please enter the required values in the config screen.</value>
+    <value>由于缺少配置，无法获取您的实体，请在配置界面中输入所需的值。</value>
   </data>
   <data name="QuickActions_MessageBox_EntityFailed" xml:space="preserve">
-    <value>There was an error trying to fetch your entities!</value>
+    <value>获取实体时出现错误！</value>
   </data>
   <data name="QuickActionsMod_Title_New" xml:space="preserve">
-    <value>New Quick Action</value>
+    <value>新建快捷操作</value>
   </data>
   <data name="QuickActionsMod_Title_Mod" xml:space="preserve">
-    <value>Mod Quick Action</value>
+    <value>修改快捷操作</value>
   </data>
   <data name="QuickActionsMod_CheckHassManager_MessageBox1" xml:space="preserve">
-    <value>Unable to fetch your entities because of missing config, please enter the required values in the config screen.</value>
+    <value>由于缺少配置，无法获取您的实体，请在配置界面中输入所需的值。</value>
   </data>
   <data name="QuickActionsMod_MessageBox_Entities" xml:space="preserve">
-    <value>There was an error trying to fetch your entities.</value>
+    <value>获取实体时出现错误。</value>
   </data>
   <data name="QuickActionsMod_BtnStore_MessageBox1" xml:space="preserve">
-    <value>Please select an entity!</value>
+    <value>请选择一个实体！</value>
   </data>
   <data name="QuickActionsMod_BtnStore_MessageBox2" xml:space="preserve">
-    <value>Please select an domain!</value>
+    <value>请选择一个域！</value>
   </data>
   <data name="QuickActionsMod_BtnStore_MessageBox3" xml:space="preserve">
-    <value>Unknown action, please select a valid one.</value>
+    <value>未知操作，请选择一个有效的操作。</value>
   </data>
   <data name="SensorsConfig_BtnStore_Storing" xml:space="preserve">
-    <value>Storing and registering, please wait..</value>
+    <value>正在保存和注册，请稍候..</value>
   </data>
   <data name="SensorsConfig_BtnStore_MessageBox1" xml:space="preserve">
-    <value>An error occurred whilst saving the sensors, please check the logs for more information.</value>
+    <value>保存传感器时发生错误，请查看日志以获取更多信息。</value>
   </data>
   <data name="SensorsMod_Title_New" xml:space="preserve">
-    <value>New Sensor</value>
+    <value>新建传感器</value>
   </data>
   <data name="SensorsMod_Title_Mod" xml:space="preserve">
-    <value>Mod Sensor</value>
+    <value>修改传感器</value>
   </data>
   <data name="SensorsMod_LblSetting1_WindowName" xml:space="preserve">
-    <value>Window Name</value>
+    <value>窗口名称</value>
   </data>
   <data name="SensorsMod_LblSetting1_Wmi" xml:space="preserve">
-    <value>WMI Query</value>
+    <value>WMI 查询</value>
   </data>
   <data name="SensorsMod_LblSetting2_Wmi" xml:space="preserve">
-    <value>WMI Scope (optional)</value>
+    <value>WMI 范围（可选）</value>
   </data>
   <data name="SensorsMod_LblSetting1_Category" xml:space="preserve">
-    <value>Category</value>
+    <value>类别</value>
   </data>
   <data name="SensorsMod_LblSetting2_Counter" xml:space="preserve">
-    <value>Counter</value>
+    <value>计数器</value>
   </data>
   <data name="SensorsMod_LblSetting3_Instance" xml:space="preserve">
-    <value>Instance (optional)</value>
+    <value>实例（可选）</value>
   </data>
   <data name="SensorsMod_LblSetting1_Process" xml:space="preserve">
-    <value>Process</value>
+    <value>进程</value>
   </data>
   <data name="SensorsMod_LblSetting1_Service" xml:space="preserve">
-    <value>Service</value>
+    <value>服务</value>
   </data>
   <data name="SensorsMod_BtnStore_MessageBox1" xml:space="preserve">
-    <value>Please select a sensor type!</value>
+    <value>请选择一个传感器类型！</value>
   </data>
   <data name="SensorsMod_BtnStore_MessageBox2" xml:space="preserve">
-    <value>Please select a valid sensor type!</value>
+    <value>请选择一个有效的传感器类型！</value>
   </data>
   <data name="SensorsMod_BtnStore_MessageBox3" xml:space="preserve">
-    <value>Please provide a name!</value>
+    <value>请提供一个名称！</value>
   </data>
   <data name="SensorsMod_BtnStore_MessageBox4" xml:space="preserve">
-    <value>A single-value sensor already exists with that name, are you sure you want to proceed?</value>
+    <value>已存在使用该名称的单值传感器，您确定要继续吗？</value>
   </data>
   <data name="SensorsMod_BtnStore_MessageBox5" xml:space="preserve">
-    <value>A multi-value sensor already exists with that name, are you sure you want to proceed?</value>
+    <value>已存在使用该名称的多值传感器，您确定要继续吗？</value>
   </data>
   <data name="SensorsMod_BtnStore_MessageBox6" xml:space="preserve">
-    <value>Please provide an interval between 1 and 43200 (12 hours)!</value>
+    <value>请提供一个介于 1 和 43200（12 小时）之间的间隔！</value>
   </data>
   <data name="SensorsMod_BtnStore_MessageBox7" xml:space="preserve">
-    <value>Please enter a window name!</value>
+    <value>请输入窗口名称！</value>
   </data>
   <data name="SensorsMod_BtnStore_MessageBox8" xml:space="preserve">
-    <value>Please enter a query!</value>
+    <value>请输入查询！</value>
   </data>
   <data name="SensorsMod_BtnStore_MessageBox9" xml:space="preserve">
-    <value>Please enter a category and instance!</value>
+    <value>请输入类别和实例！</value>
   </data>
   <data name="SensorsMod_BtnStore_MessageBox10" xml:space="preserve">
-    <value>Please enter the name of a process!</value>
+    <value>请输入进程名称！</value>
   </data>
   <data name="SensorsMod_BtnStore_MessageBox11" xml:space="preserve">
-    <value>Please enter the name of a service!</value>
+    <value>请输入服务名称！</value>
   </data>
   <data name="SensorsMod_SpecificClient" xml:space="preserve">
-    <value>{0} only!</value>
+    <value>仅 {0}！</value>
   </data>
   <data name="Configuration_ProcessChanges_MessageBox1" xml:space="preserve">
-	  <value>You've changed your device's name.
+    <value>您已更改了设备的名称。
 
-All your sensors and commands will now be unpublished, and HASS.Agent will restart afterwards to republish them.
+您的所有传感器和命令将被取消发布，HASS.Agent 将在之后重启以重新发布它们。
 
-Don't worry, they'll keep their current names, so your automations or scripts will keep working.
+别担心，它们会保留当前的名称，因此您的自动化或脚本将继续正常工作。
 
-Note: the name will get 'sanitized', which means everything except letters, digits and whitespace get replaced by an underscore. This is required by HA.</value>
+注意：名称将被"清理"，即除字母、数字和空格外的所有字符都将被替换为下划线。这是 Home Assistant 的要求。</value>
   </data>
   <data name="Configuration_ProcessChanges_MessageBox2" xml:space="preserve">
-	  <value>You've changed the local API's port. This new port needs to be reserved.
+    <value>您已更改了本地 API 的端口。此新端口需要被保留。
 
-You'll get an UAC request to do so, please approve.</value>
+您将收到一个 UAC 请求来执行此操作，请批准。</value>
   </data>
   <data name="Configuration_ProcessChanges_MessageBox3" xml:space="preserve">
-	  <value>Something went wrong!
+    <value>出现错误！
 
-Please manually execute the required command. It has been copied onto your clipboard, you just need to paste it into an elevated command prompt.
+请手动执行所需的命令。该命令已复制到您的剪贴板，您只需将其粘贴到提升的命令提示符中即可。
 
-Remember to change your firewall rule's port as well.</value>
+请记住同时更改防火墙规则的端口。</value>
   </data>
   <data name="Configuration_ProcessChanges_MessageBox4" xml:space="preserve">
-	  <value>The port has succesfully been reserved!
+    <value>端口已成功保留！
 
-HASS.Agent will now restart to activate the new configuration.</value>
+HASS.Agent 现在将重启以激活新配置。</value>
   </data>
   <data name="Configuration_MessageBox_RestartManually" xml:space="preserve">
-	  <value>Something went wrong while preparing to restart.
-Please restart manually.</value>
+    <value>准备重启时出现错误。
+请手动重启。</value>
   </data>
   <data name="Configuration_ProcessChanges_MessageBox5" xml:space="preserve">
-	  <value>Your configuration has been saved. Most changes require HASS.Agent to restart before they take effect.
+    <value>您的配置已保存。大部分更改需要 HASS.Agent 重启后才能生效。
 
-Do you want to restart now?</value>
+您想现在重启吗？</value>
   </data>
   <data name="Main_Load_MessageBox1" xml:space="preserve">
-	  <value>Something went wrong while loading your settings.
+    <value>加载设置时出现错误。
 
-Check appsettings.json in the 'config' subfolder, or just delete it to start fresh.</value>
+请检查 'config' 子文件夹中的 appsettings.json，或者直接删除它以重新开始。</value>
   </data>
   <data name="Main_Load_MessageBox2" xml:space="preserve">
-	  <value>There was an error launching HASS.Agent.
-Please check the logs and make a bug report on GitHub.</value>
+    <value>启动 HASS.Agent 时出现错误。
+请检查日志并在 GitHub 上提交错误报告。</value>
   </data>
   <data name="Main_BtnSensorsManage_Ready" xml:space="preserve">
-	  <value>&amp;Sensors</value>
+    <value>传感器(&amp;S)</value>
   </data>
   <data name="Main_BtnCommandsManager_Ready" xml:space="preserve">
-    <value>&amp;Commands</value>
+    <value>命令(&amp;C)</value>
   </data>
   <data name="Main_Checking" xml:space="preserve">
-    <value>Checking..</value>
+    <value>检查中..</value>
   </data>
   <data name="Main_CheckForUpdate_MessageBox1" xml:space="preserve">
-    <value>You're running the latest version: {0}{1}</value>
+    <value>您正在运行最新版本：{0}{1}</value>
   </data>
   <data name="UpdatePending_NewBetaRelease" xml:space="preserve">
-    <value>There's a new BETA release available:</value>
+    <value>有新的 BETA 版本可用：</value>
   </data>
   <data name="UpdatePending_Title_Beta" xml:space="preserve">
-    <value>HASS.Agent BETA Update</value>
+    <value>HASS.Agent BETA 更新</value>
   </data>
   <data name="UpdatePending_LblUpdateQuestion_Download" xml:space="preserve">
-    <value>Do you want to &amp;download and launch the installer?</value>
+    <value>您想下载并启动安装程序吗(&amp;D)？</value>
   </data>
   <data name="UpdatePending_LblUpdateQuestion_Navigate" xml:space="preserve">
-    <value>Do you want to &amp;navigate to the release page?</value>
+    <value>您想导航到发布页面吗(&amp;N)？</value>
   </data>
   <data name="UpdatePending_InstallUpdate" xml:space="preserve">
-    <value>Install Update</value>
+    <value>安装更新</value>
   </data>
   <data name="UpdatePending_InstallBetaRelease" xml:space="preserve">
-    <value>Install Beta Release</value>
+    <value>安装 Beta 版本</value>
   </data>
   <data name="UpdatePending_OpenReleasePage" xml:space="preserve">
-    <value>Open Release Page</value>
+    <value>打开发布页面</value>
   </data>
   <data name="UpdatePending_OpenBetaReleasePage" xml:space="preserve">
-    <value>Open Beta Release Page</value>
+    <value>打开 Beta 发布页面</value>
   </data>
   <data name="UpdatePending_LblUpdateQuestion_Processing" xml:space="preserve">
-    <value>Processing request, please wait..</value>
+    <value>正在处理请求，请稍候..</value>
   </data>
   <data name="UpdatePending_BtnDownload_Processing" xml:space="preserve">
-    <value>Processing..</value>
+    <value>处理中..</value>
   </data>
   <data name="OnboardingManager_OnboardingTitle_Start" xml:space="preserve">
-    <value>HASS.Agent Onboarding: Start [{0}/{1}]</value>
+    <value>HASS.Agent 引导：开始 [{0}/{1}]</value>
   </data>
   <data name="OnboardingManager_OnboardingTitle_Startup" xml:space="preserve">
-    <value>HASS.Agent Onboarding: Startup [{0}/{1}]</value>
+    <value>HASS.Agent 引导：启动 [{0}/{1}]</value>
   </data>
   <data name="OnboardingManager_OnboardingTitle_Notifications" xml:space="preserve">
-    <value>HASS.Agent Onboarding: Notifications [{0}/{1}]</value>
+    <value>HASS.Agent 引导：通知 [{0}/{1}]</value>
   </data>
   <data name="OnboardingManager_OnboardingTitle_Integration" xml:space="preserve">
-    <value>HASS.Agent Onboarding: Integration [{0}/{1}]</value>
+    <value>HASS.Agent 引导：集成 [{0}/{1}]</value>
   </data>
   <data name="OnboardingManager_OnboardingTitle_Api" xml:space="preserve">
-    <value>HASS.Agent Onboarding: API [{0}/{1}]</value>
+    <value>HASS.Agent 引导：API [{0}/{1}]</value>
   </data>
   <data name="OnboardingManager_OnboardingTitle_Mqtt" xml:space="preserve">
-    <value>HASS.Agent Onboarding: MQTT [{0}/{1}]</value>
+    <value>HASS.Agent 引导：MQTT [{0}/{1}]</value>
   </data>
   <data name="OnboardingManager_OnboardingTitle_HotKey" xml:space="preserve">
-    <value>HASS.Agent Onboarding: HotKey [{0}/{1}]</value>
+    <value>HASS.Agent 引导：热键 [{0}/{1}]</value>
   </data>
   <data name="OnboardingManager_OnboardingTitle_Updates" xml:space="preserve">
-    <value>HASS.Agent Onboarding: Updates [{0}/{1}]</value>
+    <value>HASS.Agent 引导：更新 [{0}/{1}]</value>
   </data>
   <data name="OnboardingManager_OnboardingTitle_Completed" xml:space="preserve">
-    <value>HASS.Agent Onboarding: Completed [{0}/{1}]</value>
+    <value>HASS.Agent 引导：已完成 [{0}/{1}]</value>
   </data>
   <data name="OnboardingManager_ConfirmBeforeClose_MessageBox1" xml:space="preserve">
-	  <value>Are you sure you want to abort the onboarding process?
+    <value>您确定要中止引导过程吗？
 
-Your progress will not be saved, and it will not be shown again on next launch.</value>
+您的进度将不会被保存，并且在下次启动时不会再显示。</value>
   </data>
   <data name="UpdateManager_GetLatestVersionInfo_Error" xml:space="preserve">
-    <value>Error fetching info, please check logs for more information.</value>
+    <value>获取信息时出错，请查看日志以获取更多信息。</value>
   </data>
   <data name="UpdateManager_DownloadAndExecuteUpdate_MessageBox1" xml:space="preserve">
-	  <value>Unable to prepare downloading the update, check the logs for more info.
+    <value>无法准备下载更新，请查看日志以获取更多信息。
 
-The release page will now open instead.</value>
+将改为打开发布页面。</value>
   </data>
   <data name="UpdateManager_DownloadAndExecuteUpdate_MessageBox2" xml:space="preserve">
-	  <value>Unable to download the update, check the logs for more info.
+    <value>无法下载更新，请查看日志以获取更多信息。
 
-The release page will now open instead.</value>
+将改为打开发布页面。</value>
   </data>
   <data name="UpdateManager_DownloadAndExecuteUpdate_MessageBox3" xml:space="preserve">
-	  <value>The downloaded file FAILED the certificate check.
+    <value>下载的文件未通过证书检查。
 
-This could be a technical error, but also a tampered file!
+这可能是技术错误，但也可能是文件被篡改！
 
-Please check the logs, and post a ticket with the findings.</value>
+请检查日志，并提交一个包含发现结果的工单。</value>
   </data>
   <data name="UpdateManager_DownloadAndExecuteUpdate_MessageBox4" xml:space="preserve">
-	  <value>Unable to launch the installer (did you approve the UAC prompt?), check the logs for more info.
+    <value>无法启动安装程序（您是否批准了 UAC 提示？），请查看日志以获取更多信息。
 
-The release page will now open instead.</value>
+将改为打开发布页面。</value>
   </data>
   <data name="HassApiManager_ToolTip_ConnectionSetupFailed" xml:space="preserve">
-    <value>HASS API: Connection setup failed.</value>
+    <value>HASS API：连接设置失败。</value>
   </data>
   <data name="HassApiManager_ToolTip_InitialConnectionFailed" xml:space="preserve">
-    <value>HASS API: Initial connection failed.</value>
+    <value>HASS API：初始连接失败。</value>
   </data>
   <data name="HassApiManager_ToolTip_ConnectionFailed" xml:space="preserve">
-    <value>HASS API: Connection failed.</value>
+    <value>HASS API：连接失败。</value>
   </data>
   <data name="HassApiManager_CheckHassConfig_CertNotFound" xml:space="preserve">
-    <value>Client certificate file not found.</value>
+    <value>未找到客户端证书文件。</value>
   </data>
   <data name="HassApiManager_CheckHassConfig_UnableToConnect" xml:space="preserve">
-    <value>Unable to connect, check URI.</value>
+    <value>无法连接，请检查 URI。</value>
   </data>
   <data name="HassApiManager_CheckHassConfig_ConfigFailed" xml:space="preserve">
-    <value>Unable to fetch configuration, please check API key.</value>
+    <value>无法获取配置，请检查 API 密钥。</value>
   </data>
   <data name="HassApiManager_ConnectionFailed" xml:space="preserve">
-    <value>Unable to connect, please check URI and configuration.</value>
+    <value>无法连接，请检查 URI 和配置。</value>
   </data>
   <data name="HassApiManager_ToolTip_QuickActionFailed" xml:space="preserve">
-    <value>quick action: action failed, check the logs for info</value>
+    <value>快捷操作：操作失败，请查看日志以获取信息</value>
   </data>
   <data name="HassApiManager_ToolTip_QuickActionFailedOnEntity" xml:space="preserve">
-    <value>quick action: action failed, entity not found</value>
+    <value>快捷操作：操作失败，未找到实体</value>
   </data>
   <data name="MqttManager_ToolTip_ConnectionError" xml:space="preserve">
-    <value>MQTT: Error while connecting</value>
+    <value>MQTT：连接时出错</value>
   </data>
   <data name="MqttManager_ToolTip_ConnectionFailed" xml:space="preserve">
-    <value>MQTT: Failed to connect</value>
+    <value>MQTT：连接失败</value>
   </data>
   <data name="MqttManager_ToolTip_Disconnected" xml:space="preserve">
-    <value>MQTT: Disconnected</value>
+    <value>MQTT：已断开</value>
   </data>
   <data name="NotifierManager_Initialize_MessageBox1" xml:space="preserve">
-	  <value>Error trying to bind the API to port {0}.
+    <value>尝试将 API 绑定到端口 {0} 时出错。
 
-Make sure no other instance of HASS.Agent is running and the port is available and registered.</value>
+请确保没有其他 HASS.Agent 实例正在运行，且该端口可用并已注册。</value>
   </data>
   <data name="SensorsManager_ActiveWindowSensorDescription" xml:space="preserve">
-    <value>Provides the title of the current active window.</value>
+    <value>提供当前活动窗口的标题。</value>
   </data>
   <data name="SensorsManager_AudioSensorsDescription" xml:space="preserve">
-	  <value>Provides information various aspects of your device's audio:
+    <value>提供有关设备音频各个方面的信息：
 
-Current peak volume level (can be used as a simple 'is something playing' value).
+当前峰值音量级别（可用作简单的"是否有内容正在播放"的值）。
 
-Default audio device: name, state and volume.
+默认音频设备：名称、状态和音量。
 
-Summary of your audio sessions: application name, muted state, volume and current peak volume.</value>
+音频会话摘要：应用程序名称、静音状态、音量和当前峰值音量。</value>
   </data>
   <data name="SensorsManager_BatterySensorsDescription" xml:space="preserve">
-    <value>Provides a sensor with the current charging status, estimated amount of minutes on a full charge, remaining charge as a percentage, remaining charge in minutes and the powerline status.</value>
+    <value>提供一个包含当前充电状态、充满电预计分钟数、剩余电量百分比、剩余电量分钟数和电源线状态的传感器。</value>
   </data>
   <data name="SensorsManager_CpuLoadSensorDescription" xml:space="preserve">
-    <value>Provides the current load of the first CPU as a percentage.</value>
+    <value>以百分比形式提供第一个 CPU 的当前负载。</value>
   </data>
   <data name="SensorsManager_CurrentClockSpeedSensorDescription" xml:space="preserve">
-    <value>Provides the current clockspeed of the first CPU.</value>
+    <value>提供第一个 CPU 的当前时钟频率。</value>
   </data>
   <data name="SensorsManager_CurrentVolumeSensorDescription" xml:space="preserve">
-	  <value>Provides the current volume level as a percentage.
+    <value>以百分比形式提供当前音量级别。
 
-Currently takes the volume of your default device.</value>
+目前取您默认设备的音量。</value>
   </data>
   <data name="SensorsManager_DisplaySensorsDescription" xml:space="preserve">
-    <value>Provides a sensor with the amount of displays, name of the primary display, and per display its name, resolution and bits per pixel.</value>
+    <value>提供一个包含显示器数量、主显示器名称，以及每个显示器的名称、分辨率和每像素位数的传感器。</value>
   </data>
   <data name="SensorsManager_DummySensorDescription" xml:space="preserve">
-    <value>Dummy sensor for testing purposes, sends a random integer value between 0 and 100.</value>
+    <value>用于测试的虚拟传感器，发送一个 0 到 100 之间的随机整数值。</value>
   </data>
   <data name="SensorsManager_GpuLoadSensorDescription" xml:space="preserve">
-    <value>Provides the current load of the first GPU as a percentage.</value>
+    <value>以百分比形式提供第一个 GPU 的当前负载。</value>
   </data>
   <data name="SensorsManager_GpuTemperatureSensorDescription" xml:space="preserve">
-    <value>NOTE: This is a non-functioning sensor.
+    <value>注意：这是一个不工作的传感器。
 
-Due to the security concerns regarding Libre Hardware Monitor (library allowing HASS.Agent to access GPU temperature data) this sensor is left for backward compatibility reasons and will always return 0.
-Please see documentation for alternative options.</value>
+由于关于 Libre Hardware Monitor（允许 HASS.Agent 访问 GPU 温度数据的库）的安全顾虑，此传感器保留用于向后兼容，将始终返回 0。
+请查看文档以获取替代方案。</value>
   </data>
   <data name="SensorsManager_LastActiveSensorDescription" xml:space="preserve">
-    <value>Provides a datetime value containing the last moment the user provided any input.</value>
+    <value>提供一个包含用户最后提供任何输入时间的日期时间值。</value>
   </data>
   <data name="SensorsManager_LastBootSensorDescription" xml:space="preserve">
-	  <value>Provides a datetime value containing the last moment the system (re)booted.
+    <value>提供一个包含系统上次（重）启动时间的日期时间值。
 
-Important: Windows' FastBoot option can throw this value off, because that's a form of hibernation. You can disable it through Power Options -&gt; 'Choose what the power buttons do' -&gt; uncheck 'Turn on fast start-up'. It doesn't make much difference for modern machines with SSDs, but disabling makes sure you get a clean state after rebooting.</value>
+重要提示：Windows 的 FastBoot 选项可能会影响此值，因为这实际上是一种休眠形式。您可以通过以下路径禁用它：电源选项 -&gt; '选择电源按钮的功能' -&gt; 取消勾选'启用快速启动'。对于使用 SSD 的现代计算机影响不大，但禁用后可以确保重启后获得干净的状态。</value>
   </data>
   <data name="SensorsManager_LastSystemStateChangeSensorDescription" xml:space="preserve">
-	  <value>Provides the last system state change:
+    <value>提供上次系统状态变更：
 
-ApplicationStarted, Logoff, SystemShutdown, Resume, Suspend, ConsoleConnect, ConsoleDisconnect, RemoteConnect, RemoteDisconnect, SessionLock, SessionLogoff, SessionLogon, SessionRemoteControl and SessionUnlock.</value>
+ApplicationStarted、Logoff、SystemShutdown、Resume、Suspend、ConsoleConnect、ConsoleDisconnect、RemoteConnect、RemoteDisconnect、SessionLock、SessionLogoff、SessionLogon、SessionRemoteControl 和 SessionUnlock。</value>
   </data>
   <data name="SensorsManager_LoggedUserSensorDescription" xml:space="preserve">
-	  <value>Returns the name of the currently logged user.
+    <value>返回当前登录用户的名称。
 
-This will only show active users, and falls back to 'Empty' if there are none. If there are multiple, the first will be used.</value>
+这只会显示活跃用户，如果没有则返回 'Empty'。如果有多个，将使用第一个。</value>
   </data>
   <data name="SensorsManager_LoggedUsersSensorDescription" xml:space="preserve">
-	  <value>Returns a json-formatted list of currently logged users.
+    <value>返回当前登录用户的 JSON 格式列表。
 
-This will also contain users that aren't active. If you only want the current active user, use the LoggedUser sensor instead.</value>
+这也会包含不活跃的用户。如果您只想获取当前活跃用户，请改用 LoggedUser 传感器。</value>
   </data>
   <data name="SensorsManager_MemoryUsageSensorDescription" xml:space="preserve">
-    <value>Provides the amount of used memory as a percentage.</value>
+    <value>以百分比形式提供已用内存量。</value>
   </data>
   <data name="SensorsManager_MicrophoneActiveSensorDescription" xml:space="preserve">
-	  <value>Provides a bool value based on whether the microphone is currently being used.
+    <value>提供一个基于麦克风当前是否正在使用的布尔值。
 
-Note: if used in the satellite service, it won't detect userspace applications.</value>
+注意：如果在卫星服务中使用，将无法检测用户空间应用程序。</value>
   </data>
   <data name="SensorsManager_NamedWindowSensorDescription" xml:space="preserve">
-    <value>Provides an ON/OFF value based on whether the window is currently open (doesn't have to be active).</value>
+    <value>基于窗口当前是否打开（不一定是活动的）提供一个 ON/OFF 值。</value>
   </data>
   <data name="SensorsManager_NetworkSensorsDescription" xml:space="preserve">
-	  <value>Provides card info, configuration, transfer- &amp; package statistics and addresses (ip, mac, dhcp, dns) of the selected network card(s).
+    <value>提供所选网卡的卡信息、配置、传输 &amp; 包统计信息以及地址（ip、mac、dhcp、dns）。
 
-This is a multi-value sensor.</value>
+这是一个多值传感器。</value>
   </data>
   <data name="SensorsManager_PerformanceCounterSensorDescription" xml:space="preserve">
-	  <value>Provides the values of a performance counter.
+    <value>提供性能计数器的值。
 
-For example, the built-in CPU load sensor uses these values:
+例如，内置的 CPU 负载传感器使用以下值：
 
-Category: Processor
-Counter: % Processor Time
-Instance: _Total
+类别：Processor
+计数器：% Processor Time
+实例：_Total
 
-You can explore the counters through Windows' 'perfmon.exe' tool.</value>
+您可以通过 Windows 的 'perfmon.exe' 工具来浏览计数器。</value>
   </data>
   <data name="SensorsManager_ProcessActiveSensorDescription" xml:space="preserve">
-	  <value>Provides the number of active instances of the process.
+    <value>提供该进程的活动实例数量。
 
-Note: don't add the extension (eg. notepad.exe becomes notepad).</value>
+注意：不要添加扩展名（例如 notepad.exe 变成 notepad）。</value>
   </data>
   <data name="SensorsManager_ServiceStateSensorDescription" xml:space="preserve">
-	  <value>Returns the state of the provided service: NotFound, Stopped, StartPending, StopPending, Running, ContinuePending, PausePending or Paused.
+    <value>返回所提供服务的状态：NotFound、Stopped、StartPending、StopPending、Running、ContinuePending、PausePending 或 Paused。
 
-Make sure to provide the 'Service name', not the 'Display name'.</value>
+请确保提供"服务名称"，而不是"显示名称"。</value>
   </data>
   <data name="SensorsManager_SessionStateSensorDescription" xml:space="preserve">
-	  <value>Provides the current session state:
+    <value>提供当前会话状态：
 
-Locked, Unlocked or Unknown.
+Locked、Unlocked 或 Unknown。
 
-Use a LastSystemStateChangeSensor to monitor session state changes.</value>
+使用 LastSystemStateChangeSensor 来监控会话状态变更。</value>
   </data>
   <data name="SensorsManager_StorageSensorsDescription" xml:space="preserve">
-    <value>Provides the labels, total size (MB), available space (MB), used space (MB) and file system of all present non-removable disks.</value>
+    <value>提供所有存在的非可移动磁盘的标签、总大小（MB）、可用空间（MB）、已用空间（MB）和文件系统。</value>
   </data>
   <data name="SensorsManager_UserNotificationStateSensorDescription" xml:space="preserve">
-	  <value>Provides the current user state:
+    <value>提供当前用户状态：
 
-NotPresent, Busy, RunningDirect3dFullScreen, PresentationMode, AcceptsNotifications, QuietTime or RunningWindowsStoreApp.
+NotPresent、Busy、RunningDirect3dFullScreen、PresentationMode、AcceptsNotifications、QuietTime 或 RunningWindowsStoreApp。
 
-Can for instance be used to determine whether to send notifications or TTS messages.</value>
+例如，可用于确定是否发送通知或 TTS 消息。</value>
   </data>
   <data name="SensorsManager_WebcamActiveSensorDescription" xml:space="preserve">
-	  <value>Provides a bool value based on whether the webcam is currently being used.
+    <value>提供一个基于摄像头当前是否正在使用的布尔值。
 
-Note: if used in the satellite service, it won't detect userspace applications.</value>
+注意：如果在卫星服务中使用，将无法检测用户空间应用程序。</value>
   </data>
   <data name="SensorsManager_WindowsUpdatesSensorsDescription" xml:space="preserve">
-	  <value>Provides a sensor with the amount of pending driver updates, a sensor with the amount of pending software updates, a sensor containing all pending driver updates information (title, kb article id's, hidden, type and categories) and a sensor containing the same for pending software updates.
+    <value>提供一个包含待处理驱动程序更新数量的传感器、一个包含待处理软件更新数量的传感器、一个包含所有待处理驱动程序更新信息（标题、kb 文章 ID、是否隐藏、类型和类别）的传感器，以及一个包含待处理软件更新相同信息的传感器。
 
-This is a costly request, so the recommended interval is 15 minutes (900 seconds). But it's capped at 10 minutes, if you provide a lower value, you'll get the last known list.</value>
+这是一个开销较大的请求，因此建议间隔为 15 分钟（900 秒）。但最低限制为 10 分钟，如果您提供更低的值，将获取上次已知的列表。</value>
   </data>
   <data name="SensorsManager_WmiQuerySensorDescription" xml:space="preserve">
-    <value>Provides the result of the WMI query.</value>
+    <value>提供 WMI 查询的结果。</value>
   </data>
   <data name="SettingsManager_LoadAppSettings_MessageBox1" xml:space="preserve">
-	  <value>Error loading settings:
+    <value>加载设置时出错：
 
 {0}</value>
   </data>
   <data name="SettingsManager_StoreInitialSettings_MessageBox1" xml:space="preserve">
-	  <value>Error storing initial settings:
+    <value>存储初始设置时出错：
 
 {0}</value>
   </data>
   <data name="SettingsManager_StoreAppSettings_MessageBox1" xml:space="preserve">
-	  <value>Error storing settings:
+    <value>存储设置时出错：
 
 {0}</value>
   </data>
   <data name="StoredCommands_Load_MessageBox1" xml:space="preserve">
-	  <value>Error loading commands:
+    <value>加载命令时出错：
 
 {0}</value>
   </data>
   <data name="StoredCommands_Store_MessageBox1" xml:space="preserve">
-	  <value>Error storing commands:
+    <value>存储命令时出错：
 
 {0}</value>
   </data>
   <data name="StoredQuickActions_Load_MessageBox1" xml:space="preserve">
-	  <value>Error loading quick actions:
+    <value>加载快捷操作时出错：
 
 {0}</value>
   </data>
   <data name="StoredQuickActions_Store_MessageBox1" xml:space="preserve">
-	  <value>Error storing quick actions:
+    <value>存储快捷操作时出错：
 
 {0}</value>
   </data>
   <data name="StoredSensors_Load_MessageBox1" xml:space="preserve">
-	  <value>Error loading sensors:
+    <value>加载传感器时出错：
 
 {0}</value>
   </data>
   <data name="StoredSensors_Store_MessageBox1" xml:space="preserve">
-	  <value>Error storing sensors:
+    <value>存储传感器时出错：
 
 {0}</value>
   </data>
@@ -2201,1089 +2200,1087 @@ This is a costly request, so the recommended interval is 15 minutes (900 seconds
     <value>Wiki</value>
   </data>
   <data name="Configuration_BtnStore_Busy" xml:space="preserve">
-    <value>Busy, please wait..</value>
+    <value>正忙，请稍候..</value>
   </data>
   <data name="ConfigGeneral_LblInterfaceLangauge" xml:space="preserve">
-    <value>Interface &amp;Language</value>
+    <value>界面语言(&amp;L)</value>
   </data>
   <data name="About_LblOr" xml:space="preserve">
-    <value>or</value>
+    <value>或</value>
   </data>
   <data name="OnboardingManager_BtnNext_Finish" xml:space="preserve">
-    <value>Finish</value>
+    <value>完成</value>
   </data>
   <data name="OnboardingWelcome_LblInterfaceLangauge" xml:space="preserve">
-    <value>Interface &amp;Language</value>
+    <value>界面语言(&amp;L)</value>
   </data>
   <data name="ServiceMqtt_SetMqttStatus_ConfigError" xml:space="preserve">
-    <value>Configuration missing</value>
+    <value>配置缺失</value>
   </data>
   <data name="ServiceMqtt_SetMqttStatus_Connected" xml:space="preserve">
-    <value>Connected</value>
+    <value>已连接</value>
   </data>
   <data name="ServiceMqtt_SetMqttStatus_Connecting" xml:space="preserve">
-    <value>Connecting..</value>
+    <value>连接中..</value>
   </data>
   <data name="ServiceMqtt_SetMqttStatus_Disconnected" xml:space="preserve">
-    <value>Disconnected</value>
+    <value>已断开</value>
   </data>
   <data name="ServiceMqtt_SetMqttStatus_Error" xml:space="preserve">
-    <value>Error</value>
+    <value>错误</value>
   </data>
   <data name="CommandType_CustomCommand" xml:space="preserve">
-    <value>Custom</value>
+    <value>自定义</value>
   </data>
   <data name="CommandType_CustomExecutorCommand" xml:space="preserve">
-    <value>CustomExecutor</value>
+    <value>自定义执行器</value>
   </data>
   <data name="CommandType_HibernateCommand" xml:space="preserve">
-    <value>Hibernate</value>
+    <value>休眠</value>
   </data>
   <data name="CommandType_KeyCommand" xml:space="preserve">
-    <value>Key</value>
+    <value>按键</value>
   </data>
   <data name="CommandType_LaunchUrlCommand" xml:space="preserve">
-    <value>LaunchUrl</value>
+    <value>启动 URL</value>
   </data>
   <data name="CommandType_LockCommand" xml:space="preserve">
-    <value>Lock</value>
+    <value>锁定</value>
   </data>
   <data name="CommandType_LogOffCommand" xml:space="preserve">
-    <value>LogOff</value>
+    <value>注销</value>
   </data>
   <data name="CommandType_MediaMuteCommand" xml:space="preserve">
-    <value>MediaMute</value>
+    <value>静音</value>
   </data>
   <data name="CommandType_MediaNextCommand" xml:space="preserve">
-    <value>MediaNext</value>
+    <value>下一曲</value>
   </data>
   <data name="CommandType_MediaPlayPauseCommand" xml:space="preserve">
-    <value>MediaPlayPause</value>
+    <value>播放/暂停</value>
   </data>
   <data name="CommandType_MediaPreviousCommand" xml:space="preserve">
-    <value>MediaPrevious</value>
+    <value>上一曲</value>
   </data>
   <data name="CommandType_MediaVolumeDownCommand" xml:space="preserve">
-    <value>MediaVolumeDown</value>
+    <value>音量减</value>
   </data>
   <data name="CommandType_MediaVolumeUpCommand" xml:space="preserve">
-    <value>MediaVolumeUp</value>
+    <value>音量加</value>
   </data>
   <data name="CommandType_MultipleKeysCommand" xml:space="preserve">
-    <value>MultipleKeys</value>
+    <value>多按键</value>
   </data>
   <data name="CommandType_PowershellCommand" xml:space="preserve">
-    <value>Powershell</value>
+    <value>PowerShell</value>
   </data>
   <data name="CommandType_PublishAllSensorsCommand" xml:space="preserve">
-    <value>PublishAllSensors</value>
+    <value>发布所有传感器</value>
   </data>
   <data name="CommandType_RestartCommand" xml:space="preserve">
-    <value>Restart</value>
+    <value>重启</value>
   </data>
   <data name="CommandType_ShutdownCommand" xml:space="preserve">
-    <value>Shutdown</value>
+    <value>关机</value>
   </data>
   <data name="CommandType_SleepCommand" xml:space="preserve">
-    <value>Sleep</value>
+    <value>睡眠</value>
   </data>
   <data name="UserNotificationState_AcceptsNotifications" xml:space="preserve">
-    <value>AcceptsNotifications</value>
+    <value>接受通知</value>
   </data>
   <data name="UserNotificationState_Busy" xml:space="preserve">
-    <value>Busy</value>
+    <value>忙碌</value>
   </data>
   <data name="UserNotificationState_NotPresent" xml:space="preserve">
-    <value>NotPresent</value>
+    <value>不在场</value>
   </data>
   <data name="UserNotificationState_PresentationMode" xml:space="preserve">
-    <value>PresentationMode</value>
+    <value>演示模式</value>
   </data>
   <data name="UserNotificationState_QuietTime" xml:space="preserve">
-    <value>QuietTime</value>
+    <value>安静时间</value>
   </data>
   <data name="UserNotificationState_RunningDirect3dFullScreen" xml:space="preserve">
-    <value>RunningDirect3dFullScreen</value>
+    <value>正在运行 Direct3D 全屏</value>
   </data>
   <data name="UserNotificationState_RunningWindowsStoreApp" xml:space="preserve">
-    <value>RunningWindowsStoreApp</value>
+    <value>正在运行 Windows 应用商店应用</value>
   </data>
   <data name="SystemStateEvent_ConsoleConnect" xml:space="preserve">
-    <value>ConsoleConnect</value>
+    <value>控制台连接</value>
   </data>
   <data name="SystemStateEvent_ConsoleDisconnect" xml:space="preserve">
-    <value>ConsoleDisconnect</value>
+    <value>控制台断开</value>
   </data>
   <data name="SystemStateEvent_HassAgentSatelliteServiceStarted" xml:space="preserve">
-    <value>HassAgentSatelliteServiceStarted</value>
+    <value>HASS.Agent 卫星服务已启动</value>
   </data>
   <data name="SystemStateEvent_HassAgentStarted" xml:space="preserve">
-    <value>HassAgentStarted</value>
+    <value>HASS.Agent 已启动</value>
   </data>
   <data name="SystemStateEvent_Logoff" xml:space="preserve">
-    <value>Logoff</value>
+    <value>注销</value>
   </data>
   <data name="SystemStateEvent_RemoteConnect" xml:space="preserve">
-    <value>RemoteConnect</value>
+    <value>远程连接</value>
   </data>
   <data name="SystemStateEvent_RemoteDisconnect" xml:space="preserve">
-    <value>RemoteDisconnect</value>
+    <value>远程断开</value>
   </data>
   <data name="SystemStateEvent_Resume" xml:space="preserve">
-    <value>Resume</value>
+    <value>恢复</value>
   </data>
   <data name="SystemStateEvent_SessionLock" xml:space="preserve">
-    <value>SessionLock</value>
+    <value>会话锁定</value>
   </data>
   <data name="SystemStateEvent_SessionLogoff" xml:space="preserve">
-    <value>SessionLogoff</value>
+    <value>会话注销</value>
   </data>
   <data name="SystemStateEvent_SessionLogon" xml:space="preserve">
-    <value>SessionLogon</value>
+    <value>会话登录</value>
   </data>
   <data name="SystemStateEvent_SessionRemoteControl" xml:space="preserve">
-    <value>SessionRemoteControl</value>
+    <value>会话远程控制</value>
   </data>
   <data name="SystemStateEvent_SessionUnlock" xml:space="preserve">
-    <value>SessionUnlock</value>
+    <value>会话解锁</value>
   </data>
   <data name="SystemStateEvent_Suspend" xml:space="preserve">
-    <value>Suspend</value>
+    <value>挂起</value>
   </data>
   <data name="SystemStateEvent_SystemShutdown" xml:space="preserve">
-    <value>SystemShutdown</value>
+    <value>系统关机</value>
   </data>
   <data name="SensorType_ActiveWindowSensor" xml:space="preserve">
-    <value>ActiveWindow</value>
+    <value>活动窗口</value>
   </data>
   <data name="SensorType_AudioSensors" xml:space="preserve">
-    <value>Audio</value>
+    <value>音频</value>
   </data>
   <data name="SensorType_BatterySensors" xml:space="preserve">
-    <value>Battery</value>
+    <value>电池</value>
   </data>
   <data name="SensorType_CpuLoadSensor" xml:space="preserve">
-    <value>CpuLoad</value>
+    <value>CPU 负载</value>
   </data>
   <data name="SensorType_CurrentClockSpeedSensor" xml:space="preserve">
-    <value>CurrentClockSpeed</value>
+    <value>当前时钟频率</value>
   </data>
   <data name="SensorType_CurrentVolumeSensor" xml:space="preserve">
-    <value>CurrentVolume</value>
+    <value>当前音量</value>
   </data>
   <data name="SensorType_DisplaySensors" xml:space="preserve">
-    <value>Display</value>
+    <value>显示器</value>
   </data>
   <data name="SensorType_DummySensor" xml:space="preserve">
-    <value>Dummy</value>
+    <value>虚拟</value>
   </data>
   <data name="SensorType_GpuLoadSensor" xml:space="preserve">
-    <value>GpuLoad</value>
+    <value>GPU 负载</value>
   </data>
   <data name="SensorType_GpuTemperatureSensor" xml:space="preserve">
-    <value>GpuTemperature</value>
+    <value>GPU 温度</value>
   </data>
   <data name="SensorType_LastActiveSensor" xml:space="preserve">
-    <value>LastActive</value>
+    <value>最后活动</value>
   </data>
   <data name="SensorType_LastBootSensor" xml:space="preserve">
-    <value>LastBoot</value>
+    <value>最后启动</value>
   </data>
   <data name="SensorType_LastSystemStateChangeSensor" xml:space="preserve">
-    <value>LastSystemStateChange</value>
+    <value>最后系统状态变更</value>
   </data>
   <data name="SensorType_LoggedUserSensor" xml:space="preserve">
-    <value>LoggedUser</value>
+    <value>已登录用户</value>
   </data>
   <data name="SensorType_LoggedUsersSensor" xml:space="preserve">
-    <value>LoggedUsers</value>
+    <value>已登录用户列表</value>
   </data>
   <data name="SensorType_MemoryUsageSensor" xml:space="preserve">
-    <value>MemoryUsage</value>
+    <value>内存使用</value>
   </data>
   <data name="SensorType_MicrophoneActiveSensor" xml:space="preserve">
-    <value>MicrophoneActive</value>
+    <value>麦克风活动</value>
   </data>
   <data name="SensorType_NamedWindowSensor" xml:space="preserve">
-    <value>NamedWindow</value>
+    <value>命名窗口</value>
   </data>
   <data name="SensorType_NetworkSensors" xml:space="preserve">
-    <value>Network</value>
+    <value>网络</value>
   </data>
   <data name="SensorType_PerformanceCounterSensor" xml:space="preserve">
-    <value>PerformanceCounter</value>
+    <value>性能计数器</value>
   </data>
   <data name="SensorType_ProcessActiveSensor" xml:space="preserve">
-    <value>ProcessActive</value>
+    <value>进程活动</value>
   </data>
   <data name="SensorType_ServiceStateSensor" xml:space="preserve">
-    <value>ServiceState</value>
+    <value>服务状态</value>
   </data>
   <data name="SensorType_SessionStateSensor" xml:space="preserve">
-    <value>SessionState</value>
+    <value>会话状态</value>
   </data>
   <data name="SensorType_StorageSensors" xml:space="preserve">
-    <value>Storage</value>
+    <value>存储</value>
   </data>
   <data name="SensorType_UserNotificationStateSensor" xml:space="preserve">
-    <value>UserNotification</value>
+    <value>用户通知</value>
   </data>
   <data name="SensorType_WebcamActiveSensor" xml:space="preserve">
-    <value>WebcamActive</value>
+    <value>摄像头活动</value>
   </data>
   <data name="SensorType_WindowsUpdatesSensors" xml:space="preserve">
-    <value>WindowsUpdates</value>
+    <value>Windows 更新</value>
   </data>
   <data name="SensorType_WmiQuerySensor" xml:space="preserve">
-    <value>WmiQuery</value>
+    <value>WMI 查询</value>
   </data>
   <data name="HassDomain_Automation" xml:space="preserve">
-    <value>Automation</value>
+    <value>自动化</value>
   </data>
   <data name="HassDomain_Climate" xml:space="preserve">
-    <value>Climate</value>
+    <value>气候</value>
   </data>
   <data name="HassDomain_Cover" xml:space="preserve">
-    <value>Cover</value>
+    <value>窗帘</value>
   </data>
   <data name="HassDomain_InputBoolean" xml:space="preserve">
-    <value>InputBoolean</value>
+    <value>输入布尔</value>
   </data>
   <data name="HassDomain_Light" xml:space="preserve">
-    <value>Light</value>
+    <value>灯</value>
   </data>
   <data name="HassDomain_MediaPlayer" xml:space="preserve">
-    <value>MediaPlayer</value>
+    <value>媒体播放器</value>
   </data>
   <data name="HassDomain_Scene" xml:space="preserve">
-    <value>Scene</value>
+    <value>场景</value>
   </data>
   <data name="HassDomain_Script" xml:space="preserve">
-    <value>Script</value>
+    <value>脚本</value>
   </data>
   <data name="HassDomain_Switch" xml:space="preserve">
-    <value>Switch</value>
+    <value>开关</value>
   </data>
   <data name="HassAction_Close" xml:space="preserve">
-    <value>Close</value>
+    <value>关闭</value>
   </data>
   <data name="HassAction_Off" xml:space="preserve">
-    <value>Off</value>
+    <value>关</value>
   </data>
   <data name="HassAction_On" xml:space="preserve">
-    <value>On</value>
+    <value>开启</value>
   </data>
   <data name="HassAction_Open" xml:space="preserve">
-    <value>Open</value>
+    <value>打开</value>
   </data>
   <data name="HassAction_Pause" xml:space="preserve">
-    <value>Pause</value>
+    <value>暂停</value>
   </data>
   <data name="HassAction_Play" xml:space="preserve">
-    <value>Play</value>
+    <value>播放</value>
   </data>
   <data name="HassAction_Stop" xml:space="preserve">
-    <value>Stop</value>
+    <value>停止</value>
   </data>
   <data name="HassAction_Toggle" xml:space="preserve">
-    <value>Toggle</value>
+    <value>切换</value>
   </data>
   <data name="CommandEntityType_Button" xml:space="preserve">
-    <value>Button</value>
+    <value>按钮</value>
   </data>
   <data name="CommandEntityType_Light" xml:space="preserve">
-    <value>Light</value>
+    <value>灯</value>
   </data>
   <data name="CommandEntityType_Lock" xml:space="preserve">
-    <value>Lock</value>
+    <value>锁</value>
   </data>
   <data name="CommandEntityType_Siren" xml:space="preserve">
-    <value>Siren</value>
+    <value>警报器</value>
   </data>
   <data name="CommandEntityType_Switch" xml:space="preserve">
-    <value>Switch</value>
+    <value>开关</value>
   </data>
   <data name="ComponentStatus_Connecting" xml:space="preserve">
-    <value>Connecting..</value>
+    <value>连接中..</value>
   </data>
   <data name="ComponentStatus_Disabled" xml:space="preserve">
-    <value>Disabled</value>
+    <value>已禁用</value>
   </data>
   <data name="ComponentStatus_Failed" xml:space="preserve">
-    <value>Failed</value>
+    <value>失败</value>
   </data>
   <data name="ComponentStatus_Loading" xml:space="preserve">
-    <value>Loading..</value>
+    <value>加载中..</value>
   </data>
   <data name="ComponentStatus_Ok" xml:space="preserve">
-	  <value>Running</value>
+    <value>运行中</value>
   </data>
   <data name="ComponentStatus_Stopped" xml:space="preserve">
-    <value>Stopped</value>
+    <value>已停止</value>
   </data>
   <data name="LockState_Locked" xml:space="preserve">
-    <value>Locked</value>
+    <value>已锁定</value>
   </data>
   <data name="LockState_Unknown" xml:space="preserve">
-    <value>Unknown</value>
+    <value>未知</value>
   </data>
   <data name="LockState_Unlocked" xml:space="preserve">
-    <value>Unlocked</value>
+    <value>已解锁</value>
   </data>
   <data name="SensorType_GeoLocationSensor" xml:space="preserve">
-    <value>GeoLocation</value>
+    <value>地理位置</value>
   </data>
   <data name="SensorsMod_All" xml:space="preserve">
-    <value>All</value>
+    <value>全部</value>
   </data>
   <data name="SensorsMod_BtnTest" xml:space="preserve">
-    <value>&amp;Test</value>
+    <value>测试(&T)</value>
   </data>
   <data name="SensorsMod_BtnTest_PerformanceCounter" xml:space="preserve">
-    <value>Test Performance Counter</value>
+    <value>测试性能计数器</value>
   </data>
   <data name="SensorsMod_BtnTest_Wmi" xml:space="preserve">
-    <value>Test WMI Query</value>
+    <value>测试 WMI 查询</value>
   </data>
   <data name="SensorsMod_LblSetting1_Network" xml:space="preserve">
-    <value>Network Card</value>
+    <value>网卡</value>
   </data>
   <data name="SensorsMod_TestPerformanceCounter_MessageBox1" xml:space="preserve">
-    <value>Enter a category and counter first.</value>
+    <value>请先输入类别和计数器。</value>
   </data>
   <data name="SensorsMod_TestPerformanceCounter_MessageBox2" xml:space="preserve">
-	  <value>Test succesfully executed, result value:
+    <value>测试成功执行，结果值为：
 
 {0}</value>
   </data>
   <data name="SensorsMod_TestPerformanceCounter_MessageBox3" xml:space="preserve">
-	  <value>The test failed to execute:
+    <value>测试执行失败：
 
 {0}
 
-Do you want to open the logs folder?</value>
+你想打开日志文件夹吗？</value>
   </data>
   <data name="SensorsMod_TestWmi_MessageBox1" xml:space="preserve">
-    <value>Enter a WMI query first.</value>
+    <value>请先输入 WMI 查询。</value>
   </data>
   <data name="SensorsMod_TestWmi_MessageBox2" xml:space="preserve">
-	  <value>Query succesfully executed, result value:
+    <value>查询成功执行，结果值为：
 
 {0}</value>
   </data>
   <data name="SensorsMod_TestWmi_MessageBox3" xml:space="preserve">
-	  <value>The query failed to execute:
+    <value>查询执行失败：
 
 {0}
 
-Do you want to open the logs folder?</value>
+你想打开日志文件夹吗？</value>
   </data>
   <data name="SensorsMod_WmiTestFailed" xml:space="preserve">
-	  <value>It looks like your scope is malformed, it should probably start like this:
+    <value>你的作用域格式似乎不正确，它可能应该以如下形式开头：
 
 \\.\ROOT\
 
-The scope you entered:
+你输入的作用域：
 
 {0}
 
-Tip: make sure you haven't switched the scope and query fields around.
+提示：请确保你没有调换作用域和查询字段的位置。
 
-Do you still want to use the current values?</value>
+你仍然想使用当前值吗？</value>
   </data>
   <data name="SystemStateEvent_ApplicationStarted" xml:space="preserve">
-    <value>ApplicationStarted</value>
+    <value>应用程序已启动</value>
   </data>
   <data name="ServiceGeneral_LblInfo2" xml:space="preserve">
-    <value>You can use the satellite service to run sensors and commands without having to be logged in. Not all types are available, for instance the 'LaunchUrl' command can only be added as a regular command.</value>
+    <value>你可以使用卫星服务在不登录的情况下运行传感器和命令。并非所有类型都可用，例如 'LaunchUrl' 命令只能作为常规命令添加。</value>
   </data>
   <data name="SensorsConfig_ClmValue" xml:space="preserve">
-    <value>Last Known Value</value>
+    <value>最后已知值</value>
   </data>
   <data name="LocalApiManager_Initialize_MessageBox1" xml:space="preserve">
-	  <value>Error trying to bind the API to port {0}.
+    <value>尝试将 API 绑定到端口 {0} 时出错。
 
-Make sure no other instance of HASS.Agent is running and the port is available and registered.</value>
+请确保没有其他 HASS.Agent 实例正在运行，并且该端口可用且已注册。</value>
   </data>
   <data name="CommandType_SendWindowToFrontCommand" xml:space="preserve">
-    <value>SendWindowToFront</value>
+    <value>发送窗口到前台</value>
   </data>
   <data name="CommandType_WebViewCommand" xml:space="preserve">
     <value>WebView</value>
   </data>
   <data name="CommandsManager_WebViewCommandDescription" xml:space="preserve">
-	  <value>Shows a window with the provided URL.
+    <value>显示一个包含指定 URL 的窗口。
 
-This differs from the 'LaunchUrl' command in that it doesn't load a full-fledged browser, just the provided URL in its own window.
+这与 'LaunchUrl' 命令的不同之处在于，它不会加载完整的浏览器，只是在独立窗口中显示提供的 URL。
 
-You can use this to for instance quickly show Home Assistant's dashboard.
+例如，你可以使用它来快速显示 Home Assistant 的仪表板。
 
-By default, it stores cookies indefinitely so you only have to log in once.</value>
+默认情况下，它会永久存储 cookies，因此你只需登录一次。</value>
   </data>
   <data name="HassDomain_HASSAgentCommands" xml:space="preserve">
-    <value>HASS.Agent Commands</value>
+    <value>HASS.Agent 命令</value>
   </data>
   <data name="CommandsManager_CommandsManager_SendWindowToFrontCommandDescription" xml:space="preserve">
-	  <value>Looks for the specified process, and tries to send its main window to the front.
+    <value>查找指定的进程，并尝试将其主窗口发送到前台。
 
-If the application is minimized, it'll get restored.
+如果应用程序已最小化，它将被还原。
 
-Example: if you want to send VLC to the foreground, use 'vlc'.</value>
+例如：如果要将 VLC 发送到前台，请使用 'vlc'。</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox8" xml:space="preserve">
-	  <value>If you do not configure the command, you may only use this entity with an 'action' value via Home Assistant and it will appear using the default settings, running it as-is will have no action.
+    <value>如果不配置命令，你可能只能通过 Home Assistant 使用 'action' 值来操作此实体，它将以默认设置显示，按原样运行将不会有任何操作。
 
-Are you sure you want to do this?</value>
+你确定要这样做吗？</value>
   </data>
   <data name="ConfigLocalStorage_BtnClearAudioCache" xml:space="preserve">
-    <value>Clear Audio Cache</value>
+    <value>清除音频缓存</value>
   </data>
   <data name="ConfigLocalStorage_BtnClearAudioCache_InfoText1" xml:space="preserve">
-    <value>Cleaning..</value>
+    <value>清理中..</value>
   </data>
   <data name="ConfigLocalStorage_BtnClearAudioCache_MessageBox1" xml:space="preserve">
-    <value>The audio cache has been cleared!</value>
+    <value>音频缓存已清除！</value>
   </data>
   <data name="ConfigLocalStorage_BtnClearWebViewCache" xml:space="preserve">
-    <value>Clear WebView Cache</value>
+    <value>清除 WebView 缓存</value>
   </data>
   <data name="ConfigLocalStorage_BtnClearWebViewCache_InfoText1" xml:space="preserve">
-    <value>Cleaning..</value>
+    <value>清理中..</value>
   </data>
   <data name="ConfigLocalStorage_BtnClearWebViewCache_MessageBox1" xml:space="preserve">
-    <value>The WebView cache has been cleared!</value>
+    <value>WebView 缓存已清除！</value>
   </data>
   <data name="Main_CheckDpiScalingFactor_MessageBox1" xml:space="preserve">
-	  <value>It looks like you're using an alternative scaling. This may result in some parts of HASS.Agent not looking as intended.
+    <value>看起来你正在使用替代缩放比例。这可能导致 HASS.Agent 的某些部分显示不正常。
 
-Please report any unusable aspects on GitHub. Thanks!
+请在 GitHub 上报告任何无法使用的部分。谢谢！
 
-Note: this message only shows once.</value>
+注意：此消息只会显示一次。</value>
   </data>
   <data name="WebViewCommandConfig_SetStoredVariables_MessageBox1" xml:space="preserve">
-    <value>Unable to load the stored command settings, resetting to default.</value>
+    <value>无法加载存储的命令设置，将重置为默认值。</value>
   </data>
   <data name="CommandsMod_BtnConfigureCommand" xml:space="preserve">
-    <value>Configure Command &amp;Parameters</value>
+    <value>配置命令参数(&P)</value>
   </data>
   <data name="ConfigLocalApi_BtnExecutePortReservation" xml:space="preserve">
-    <value>Execute Port &amp;Reservation</value>
+    <value>执行端口保留(&R)</value>
   </data>
   <data name="ConfigLocalApi_CbLocalApiActive" xml:space="preserve">
-    <value>&amp;Enable Local API</value>
+    <value>启用本地 API(&E)</value>
   </data>
   <data name="ConfigLocalApi_LblInfo1" xml:space="preserve">
-	  <value>HASS.Agent has its own local API, so Home Assistant can send requests (for instance to send a notification). You can configure it globally here, and afterwards you can configure the dependent sections (currently notifications and mediaplayer).
+    <value>HASS.Agent 有自己的本地 API，因此 Home Assistant 可以发送请求（例如发送通知）。你可以在此处全局配置它，然后配置相关部分（目前是通知和媒体播放器）。
 
-Note: this is not required for the new integration to function. Only enable and use it if you don't use MQTT.</value>
+注意：新集成无需此功能即可运行。仅在不使用 MQTT 时才启用并使用它。</value>
   </data>
   <data name="ConfigLocalApi_LblInfo2" xml:space="preserve">
-    <value>To be able to listen to the requests, HASS.Agent needs to have its port reserved and opened in your firewall. You can use this button to have it done for you.</value>
+    <value>为了能够监听请求，HASS.Agent 需要在你的防火墙中保留并打开其端口。你可以使用此按钮自动完成此操作。</value>
   </data>
   <data name="ConfigLocalApi_LblPort" xml:space="preserve">
-    <value>&amp;Port</value>
+    <value>端口(&P)</value>
   </data>
   <data name="ConfigLocalStorage_LblAudioCacheLocation" xml:space="preserve">
-    <value>Audio Cache Location</value>
+    <value>音频缓存位置</value>
   </data>
   <data name="ConfigLocalStorage_LblImageCacheDays" xml:space="preserve">
-    <value>days</value>
+    <value>天</value>
   </data>
   <data name="ConfigLocalStorage_LblImageCacheLocation" xml:space="preserve">
-    <value>Image Cache Location</value>
+    <value>图片缓存位置</value>
   </data>
   <data name="ConfigLocalStorage_LblKeepAudio" xml:space="preserve">
-    <value>Keep audio for</value>
+    <value>保留音频</value>
   </data>
   <data name="ConfigLocalStorage_LblKeepImages" xml:space="preserve">
-    <value>Keep images for</value>
+    <value>保留图片</value>
   </data>
   <data name="ConfigLocalStorage_LblKeepWebView" xml:space="preserve">
-    <value>Clear cache every</value>
+    <value>清除缓存频率</value>
   </data>
   <data name="ConfigLocalStorage_LblWebViewCacheLocation" xml:space="preserve">
-    <value>WebView Cache Location</value>
+    <value>WebView 缓存位置</value>
   </data>
   <data name="ConfigMediaPlayer_BtnMediaPlayerReadme" xml:space="preserve">
-    <value>Media Player &amp;Documentation</value>
+    <value>媒体播放器文档(&D)</value>
   </data>
   <data name="ConfigMediaPlayer_CbEnableMediaPlayer" xml:space="preserve">
-    <value>&amp;Enable Media Player Functionality</value>
+    <value>启用媒体播放器功能(&E)</value>
   </data>
   <data name="ConfigMediaPlayer_LblInfo1" xml:space="preserve">
-    <value>HASS.Agent can act as a media player for Home Assistant, so you'll be able to see and control any media that's playing, and send text-to-speech. If you have MQTT enabled, your device will automatically get added. Otherwise, manually configure the integration to use the local API.</value>
+    <value>HASS.Agent 可以作为 Home Assistant 的媒体播放器，因此你将能够查看和控制任何正在播放的媒体，并发送文本转语音。如果你启用了 MQTT，你的设备将被自动添加。否则，请手动配置集成以使用本地 API。</value>
   </data>
   <data name="ConfigMediaPlayer_LblInfo2" xml:space="preserve">
-	  <value>If something is not working, make sure you try the following steps:
+    <value>如果某些功能无法正常工作，请尝试以下步骤：
 
-- Install the HASS.Agent integration
-- Restart Home Assistant
-- Make sure HASS.Agent is active with MQTT enabled!
-- Your device should get detected and added as an entity automatically
-- Optionally: manually add it using the local API</value>
+- 安装 HASS.Agent 集成
+- 重启 Home Assistant
+- 确保 HASS.Agent 处于活动状态并启用了 MQTT！
+- 你的设备应该会被自动检测并添加为实体
+- 可选：使用本地 API 手动添加</value>
   </data>
   <data name="ConfigMediaPlayer_LblLocalApiDisabled" xml:space="preserve">
-    <value>The local API is disabled however the media player requires it in order to function.</value>
+    <value>本地 API 已禁用，但媒体播放器需要它才能运行。</value>
   </data>
   <data name="ConfigMqtt_CbMqttTls" xml:space="preserve">
-    <value>&amp;TLS</value>
+    <value>TLS(&T)</value>
   </data>
   <data name="ConfigNotifications_LblLocalApiDisabled" xml:space="preserve">
-    <value>The local API is disabled however the media player requires it in order to function.</value>
+    <value>本地 API 已禁用，但媒体播放器需要它才能运行。</value>
   </data>
   <data name="ConfigTrayIcon_BtnShowWebViewPreview" xml:space="preserve">
-    <value>Show &amp;Preview</value>
+    <value>显示预览(&P)</value>
   </data>
   <data name="ConfigTrayIcon_CbDefaultMenu" xml:space="preserve">
-    <value>Show &amp;Default Menu</value>
+    <value>显示默认菜单(&D)</value>
   </data>
   <data name="ConfigTrayIcon_CbShowWebView" xml:space="preserve">
-    <value>Show &amp;WebView</value>
+    <value>显示 WebView(&W)</value>
   </data>
   <data name="ConfigTrayIcon_CbWebViewKeepLoaded" xml:space="preserve">
-    <value>&amp;Keep page loaded in the background</value>
+    <value>在后台保持页面加载(&K)</value>
   </data>
   <data name="ConfigTrayIcon_LblInfo1" xml:space="preserve">
-    <value>Control the behaviour of the tray icon when it is right-clicked.</value>
+    <value>控制右键单击托盘图标时的行为。</value>
   </data>
   <data name="ConfigTrayIcon_LblInfo2" xml:space="preserve">
-    <value>(This uses extra resources, but reduces loading time.)</value>
+    <value>（这会使用额外资源，但会减少加载时间。）</value>
   </data>
   <data name="ConfigTrayIcon_LblWebViewSize" xml:space="preserve">
-    <value>Size (px)</value>
+    <value>大小 (px)</value>
   </data>
   <data name="ConfigTrayIcon_LblWebViewUrl" xml:space="preserve">
-    <value>&amp;WebView URL (For instance, your Home Assistant Dashboard URL)</value>
+    <value>WebView URL(&W)（例如，你的 Home Assistant 仪表板 URL）</value>
   </data>
   <data name="Configuration_TablLocalApi" xml:space="preserve">
-    <value>Local API</value>
+    <value>本地 API</value>
   </data>
   <data name="Configuration_TabMediaPlayer" xml:space="preserve">
-    <value>Media Player</value>
+    <value>媒体播放器</value>
   </data>
   <data name="Configuration_TabTrayIcon" xml:space="preserve">
-    <value>Tray Icon</value>
+    <value>托盘图标</value>
   </data>
   <data name="HelperFunctions_InputLanguageCheckDiffers_ErrorMsg1" xml:space="preserve">
-    <value>Your input language '{0}' is known to collide with the default CTRL-ALT-Q hotkey. Please set your own.</value>
+    <value>你的输入语言 '{0}' 已知会与默认的 CTRL-ALT-Q 热键冲突。请设置你自己的热键。</value>
   </data>
   <data name="HelperFunctions_InputLanguageCheckDiffers_ErrorMsg2" xml:space="preserve">
-    <value>Your input language '{0}' is unknown, and might collide with the default CTRL-ALT-Q hotkey. Please check to be sure. If it does, consider opening a ticket on GitHub so it can be added to the list.</value>
+    <value>你的输入语言 '{0}' 未知，可能与默认的 CTRL-ALT-Q 热键冲突。请检查确认。如果确实冲突，请考虑在 GitHub 上提交工单，以便将其添加到列表中。</value>
   </data>
   <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg1" xml:space="preserve">
-    <value>No keys found</value>
+    <value>未找到键</value>
   </data>
   <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg2" xml:space="preserve">
-    <value>brackets missing, start and close all keys with [ ]</value>
+    <value>缺少括号，请用 [ ] 开始和结束所有键</value>
   </data>
   <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg3" xml:space="preserve">
-    <value>Error while parsing keys, please check the logs for more information.</value>
+    <value>解析键时出错，请查看日志以获取更多信息。</value>
   </data>
   <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg4" xml:space="preserve">
-    <value>The number of open brackets ('[') does not correspond to the number of closed brackets. (']')! ({0} to {1})</value>
+    <value>左括号 ('[') 的数量与右括号 (']') 的数量不匹配！({0} 对 {1})</value>
   </data>
   <data name="Help_LblDocumentation" xml:space="preserve">
-    <value>Documentation</value>
+    <value>文档</value>
   </data>
   <data name="Help_LblDocumentationInfo" xml:space="preserve">
-    <value>Documentation and Usage Examples</value>
+    <value>文档和使用示例</value>
   </data>
   <data name="Main_BtnCheckForUpdate" xml:space="preserve">
-    <value>Check for &amp;Updates</value>
+    <value>检查更新(&U)</value>
   </data>
   <data name="Main_LblLocalApi" xml:space="preserve">
-    <value>Local API:</value>
+    <value>本地 API：</value>
   </data>
   <data name="Main_TsSatelliteService" xml:space="preserve">
-    <value>Manage Satellite Service</value>
+    <value>管理卫星服务</value>
   </data>
   <data name="OnboardingIntegrations_LblInfo1" xml:space="preserve">
-	  <value>To use notifications, you need to install and configure the HASS.Agent-notifier integration in
-Home Assistant.
+    <value>要使用通知，你需要在 Home Assistant 中安装并配置 HASS.Agent-notifier 集成。
 
-This is very easy using HACS, but you can also install manually. Visit the link below for more
-information.</value>
+使用 HACS 安装非常简单，你也可以手动安装。请访问下方链接获取更多信息。</value>
   </data>
   <data name="OnboardingIntegrations_LblInfo2" xml:space="preserve">
-	  <value>Make sure you follow these steps:
+    <value>请确保按照以下步骤操作：
 
-- Install the HASS.Agent-Notifier and / or HASS.Agent-MediaPlayer integration
-- Restart Home Assistant
--Configure a notifier and / or media_player entity
--Restart Home Assistant</value>
+- 安装 HASS.Agent-Notifier 和/或 HASS.Agent-MediaPlayer 集成
+- 重启 Home Assistant
+- 配置 notifier 和/或 media_player 实体
+- 重启 Home Assistant</value>
   </data>
   <data name="OnboardingIntegrations_LblInfo3" xml:space="preserve">
-    <value>The same goes for the media player, this integration allows you to control your device as a media_player entity, see what's playing and send text-to-speech.</value>
+    <value>媒体播放器也是如此，此集成允许你将设备作为 media_player 实体进行控制，查看正在播放的内容并发送文本转语音。</value>
   </data>
   <data name="OnboardingIntegrations_LblMediaPlayerIntegration" xml:space="preserve">
-    <value>HASS.Agent-MediaPlayer GitHub Page</value>
+    <value>HASS.Agent-MediaPlayer GitHub 页面</value>
   </data>
   <data name="OnboardingIntegrations_LblNotifierIntegration" xml:space="preserve">
-    <value>HASS.Agent-Integration GitHub Page</value>
+    <value>HASS.Agent-Integration GitHub 页面</value>
   </data>
   <data name="OnboardingLocalApi_CbEnableLocalApi" xml:space="preserve">
-    <value>Yes, &amp;enable the local API on port</value>
+    <value>是，启用本地 API 端口(&E)</value>
   </data>
   <data name="OnboardingLocalApi_CbEnableMediaPlayer" xml:space="preserve">
-    <value>Enable &amp;Media Player and text-to-speech (TTS)</value>
+    <value>启用媒体播放器和文本转语音(TTS)(&M)</value>
   </data>
   <data name="OnboardingLocalApi_CbEnableNotifications" xml:space="preserve">
-    <value>Enable &amp;Notifications</value>
+    <value>启用通知(&N)</value>
   </data>
   <data name="OnboardingLocalApi_LblInfo1" xml:space="preserve">
-	  <value>HASS.Agent has its own internal API, so Home Assistant can send requests (like notifications or text-to-speech).
+    <value>HASS.Agent 有自己的内部 API，因此 Home Assistant 可以发送请求（如通知或文本转语音）。
 
-Do you want to enable it?</value>
+你想要启用它吗？</value>
   </data>
   <data name="OnboardingLocalApi_LblInfo2" xml:space="preserve">
-    <value>You can choose what modules you want to enable. They require HA integrations, but don't worry, the next page will give you more info on how to set them up.</value>
+    <value>你可以选择要启用的模块。它们需要 HA 集成，但别担心，下一页将为你提供更多关于如何设置它们的信息。</value>
   </data>
   <data name="OnboardingLocalApi_LblTip1" xml:space="preserve">
-    <value>Note: 5115 is the default port, only change it if you changed it in Home Assistant.</value>
+    <value>注意：5115 是默认端口，只有在 Home Assistant 中更改过才需要修改。</value>
   </data>
   <data name="OnboardingMqtt_CbMqttTls" xml:space="preserve">
-    <value>&amp;TLS</value>
+    <value>TLS(&T)</value>
   </data>
   <data name="OnboardingWelcome_Store_MessageBox1" xml:space="preserve">
-	  <value>Your device name contained some characters that are not allowed by HA (only letters, digits and whitespace).
+    <value>你的设备名称包含一些 HA 不允许的字符（只允许字母、数字和空格）。
 
-The final name is: {0}
+最终名称为：{0}
 
-Do you want to use that version?</value>
+你想使用该版本吗？</value>
   </data>
   <data name="Onboarding_Title" xml:space="preserve">
-    <value>HASS.Agent Onboarding</value>
+    <value>HASS.Agent 引导</value>
   </data>
   <data name="ServiceGeneral_LblAuthStored" xml:space="preserve">
-    <value>stored!</value>
+    <value>已存储！</value>
   </data>
   <data name="ServiceMqtt_CbMqttTls" xml:space="preserve">
-    <value>&amp;TLS</value>
+    <value>TLS(&T)</value>
   </data>
   <data name="WebViewCommandConfig_BtnSave" xml:space="preserve">
-    <value>&amp;Save</value>
+    <value>保存(&S)</value>
   </data>
   <data name="WebViewCommandConfig_CbCenterScreen" xml:space="preserve">
-    <value>&amp;Always show centered in screen</value>
+    <value>始终在屏幕居中显示(&A)</value>
   </data>
   <data name="WebViewCommandConfig_CbShowTitleBar" xml:space="preserve">
-    <value>Show the window's &amp;title bar</value>
+    <value>显示窗口标题栏(&T)</value>
   </data>
   <data name="WebViewCommandConfig_CbTopMost" xml:space="preserve">
-    <value>Set window as 'Always on &amp;Top'</value>
+    <value>将窗口设置为'始终置顶'(&T)</value>
   </data>
   <data name="WebViewCommandConfig_LblInfo1" xml:space="preserve">
-    <value>Drag and resize this window to set the size and location of your webview command.</value>
+    <value>拖动并调整此窗口的大小，以设置你的 WebView 命令的大小和位置。</value>
   </data>
   <data name="WebViewCommandConfig_LblLocation" xml:space="preserve">
-    <value>Location</value>
+    <value>位置</value>
   </data>
   <data name="WebViewCommandConfig_LblSize" xml:space="preserve">
-    <value>Size</value>
+    <value>大小</value>
   </data>
   <data name="WebViewCommandConfig_LblTip1" xml:space="preserve">
-    <value>Tip: Press ESCAPE to close a WebView.</value>
+    <value>提示：按 ESCAPE 键关闭 WebView。</value>
   </data>
   <data name="WebViewCommandConfig_LblUrl" xml:space="preserve">
-    <value>&amp;URL</value>
+    <value>URL(&U)</value>
   </data>
   <data name="WebViewCommandConfig_Title" xml:space="preserve">
-    <value>WebView Configuration</value>
+    <value>WebView 配置</value>
   </data>
   <data name="WebView_Title" xml:space="preserve">
     <value>WebView</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox9" xml:space="preserve">
-	  <value>The keycode you have provided is not a valid number!
+    <value>你提供的键码不是有效的数字！
 
-Please ensure the keycode field is in focus and press the key you want simulated, the keycode should then be generated for you.</value>
+请确保键码字段处于焦点状态，然后按下你想要模拟的键，系统将为你生成键码。</value>
   </data>
   <data name="ConfigGeneral_CbEnableDeviceNameSanitation" xml:space="preserve">
-    <value>Enable Device Name &amp;Sanitation</value>
+    <value>启用设备名称清理(&S)</value>
   </data>
   <data name="ConfigGeneral_CbEnableStateNotifications" xml:space="preserve">
-    <value>Enable State Notifications</value>
+    <value>启用状态通知</value>
   </data>
   <data name="ConfigGeneral_LblInfo5" xml:space="preserve">
-    <value>HASS.Agent will sanitize your device name to make sure HA will accept it, you can overrule this rule below if you're sure that your name will be accepted as-is.</value>
+    <value>HASS.Agent 将清理你的设备名称以确保 HA 接受它，如果你确定你的名称原样会被接受，可以在下方覆盖此规则。</value>
   </data>
   <data name="ConfigGeneral_LblInfo6" xml:space="preserve">
-    <value>HASS.Agent sends notifications when the state of a module changes, you can adjust whether or not you want to receive these notifications below.</value>
+    <value>当模块状态发生变化时，HASS.Agent 会发送通知，你可以在下方调整是否要接收这些通知。</value>
   </data>
   <data name="Configuration_ProcessChanges_MessageBox6" xml:space="preserve">
-	  <value>You've changed your device's name.
+    <value>你已更改了设备名称。
 
-All your sensors and commands will now be unpublished and published again after the HASS.Agent restarts.
+所有传感器和命令将被取消发布，并在 HASS.Agent 重启后重新发布。
 
-Don't worry! they'll keep their current names so your automations and scripts will continue to work.
+别担心！它们将保留当前名称，因此你的自动化和脚本将继续工作。
 
-Note: You disabled sanitation, so make sure your device name is accepted by Home Assistant.</value>
+注意：你已禁用名称清理，请确保你的设备名称被 Home Assistant 接受。</value>
   </data>
   <data name="SensorType_PrintersSensors" xml:space="preserve">
-    <value>Printers</value>
+    <value>打印机</value>
   </data>
   <data name="CommandType_MonitorSleepCommand" xml:space="preserve">
-    <value>MonitorSleep</value>
+    <value>显示器休眠</value>
   </data>
   <data name="CommandType_MonitorWakeCommand" xml:space="preserve">
-    <value>MonitorWake</value>
+    <value>显示器唤醒</value>
   </data>
   <data name="MonitorPowerEvent_PowerOn" xml:space="preserve">
-    <value>PowerOn</value>
+    <value>开启</value>
   </data>
   <data name="MonitorPowerEvent_PowerOff" xml:space="preserve">
-    <value>PowerOff</value>
+    <value>关闭</value>
   </data>
   <data name="MonitorPowerEvent_Dimmed" xml:space="preserve">
-    <value>Dimmed</value>
+    <value>变暗</value>
   </data>
   <data name="MonitorPowerEvent_Unknown" xml:space="preserve">
-    <value>Unknown</value>
+    <value>未知</value>
   </data>
   <data name="SensorType_MonitorPowerStateSensor" xml:space="preserve">
-    <value>MonitorPowerState</value>
+    <value>显示器电源状态</value>
   </data>
   <data name="SensorType_PowershellSensor" xml:space="preserve">
-    <value>PowershellSensor</value>
+    <value>PowerShell 传感器</value>
   </data>
   <data name="CommandType_SetVolumeCommand" xml:space="preserve">
-    <value>SetVolume</value>
+    <value>设置音量</value>
   </data>
   <data name="WindowState_Maximized" xml:space="preserve">
-    <value>Maximized</value>
+    <value>最大化</value>
   </data>
   <data name="WindowState_Minimized" xml:space="preserve">
-    <value>Minimized</value>
+    <value>最小化</value>
   </data>
   <data name="WindowState_Normal" xml:space="preserve">
-    <value>Normal</value>
+    <value>正常</value>
   </data>
   <data name="WindowState_Unknown" xml:space="preserve">
-    <value>Unknown</value>
+    <value>未知</value>
   </data>
   <data name="WindowState_Hidden" xml:space="preserve">
-    <value>Hidden</value>
+    <value>隐藏</value>
   </data>
   <data name="SensorType_WindowStateSensor" xml:space="preserve">
-    <value>WindowState</value>
+    <value>窗口状态</value>
   </data>
   <data name="SensorType_WebcamProcessSensor" xml:space="preserve">
-    <value>WebcamProcess</value>
+    <value>摄像头进程</value>
   </data>
   <data name="SensorType_MicrophoneProcessSensor" xml:space="preserve">
-    <value>MicrophoneProcess</value>
+    <value>麦克风进程</value>
   </data>
   <data name="CommandsManager_MonitorSleepCommandDescription" xml:space="preserve">
-    <value>Puts all monitors in sleep (low power) mode.</value>
+    <value>将所有显示器置于休眠（低功耗）模式。</value>
   </data>
   <data name="CommandsManager_MonitorWakeCommandDescription" xml:space="preserve">
-    <value>Tries to wake up all monitors by simulating a 'arrow up' keypress.</value>
+    <value>尝试通过模拟'向上箭头'按键来唤醒所有显示器。</value>
   </data>
   <data name="CommandsManager_SetVolumeCommandDescription" xml:space="preserve">
-    <value>Sets the volume of the current default audiodevice to the specified level.</value>
+    <value>将当前默认音频设备的音量设置为指定级别。</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox10" xml:space="preserve">
-    <value>Please enter a value between 0-100 as the desired volume level!</value>
+    <value>请输入一个 0-100 之间的值作为所需的音量级别！</value>
   </data>
   <data name="CommandsMod_CommandsMod" xml:space="preserve">
-    <value>Command</value>
+    <value>命令</value>
   </data>
   <data name="CommandsMod_MessageBox_Action2" xml:space="preserve">
-	  <value>If you don't enter a volume value, you can only use this entity with an 'action' value through Home Assistant. Running it as-is won't do anything.
+    <value>如果不输入音量值，你只能通过 Home Assistant 使用 'action' 值来操作此实体。按原样运行不会有任何效果。
 
-Are you sure you want this?</value>
+你确定要这样做吗？</value>
   </data>
   <data name="CommandsMod_MessageBox_Sanitize" xml:space="preserve">
-	  <value>The name you provided contains unsupported characters and won't work. The suggested version is:
+    <value>你提供的名称包含不支持的字符，无法使用。建议的版本为：
 
 {0}
 
-Do you want to use this version?</value>
+你想使用此版本吗？</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox5" xml:space="preserve">
-	  <value>The API token you have provided doesn't appear to be valid, please ensure you selected the entire token (Don't use CTRL + A or double-click). A valid API key contains three sections, separated by two dots.
+    <value>你提供的 API 令牌似乎无效，请确保你选择了整个令牌（不要使用 CTRL + A 或双击）。有效的 API 密钥包含三部分，由两个点分隔。
 
-Are you sure you want to use this key anyway?</value>
+你确定仍要使用此密钥吗？</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox6" xml:space="preserve">
-	  <value>The URI you have provided does not appear to be valid, a valid URI may look like either of the following:
+    <value>你提供的 URI 似乎无效，有效的 URI 可能类似于以下格式：
 - http://homeassistant.local:8123
 - http://192.168.0.1:8123
 
-Are you sure you want to use this URI anyway?</value>
+你确定仍要使用此 URI 吗？</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi_Testing" xml:space="preserve">
-    <value>Testing..</value>
+    <value>测试中..</value>
   </data>
   <data name="ConfigMediaPlayer_LblConnectivityDisabled" xml:space="preserve">
-    <value>both the local API and MQTT are disabled, but the integration needs at least one for it to work</value>
+    <value>本地 API 和 MQTT 均已禁用，但集成需要至少启用一个才能工作</value>
   </data>
   <data name="ConfigMqtt_CbEnableMqtt" xml:space="preserve">
-    <value>Enable MQTT</value>
+    <value>启用 MQTT</value>
   </data>
   <data name="ConfigMqtt_LblMqttDisabledWarning" xml:space="preserve">
-    <value>If MQTT is not enabled, commands and sensors will not work!</value>
+    <value>如果未启用 MQTT，命令和传感器将无法工作！</value>
   </data>
   <data name="ConfigNotifications_LblConnectivityDisabled" xml:space="preserve">
-    <value>both the local API and MQTT are disabled, but the integration needs at least one for it to work</value>
+    <value>本地 API 和 MQTT 均已禁用，但集成需要至少启用一个才能工作</value>
   </data>
   <data name="ConfigService_BtnManageService" xml:space="preserve">
-    <value>&amp;Manage Service</value>
+    <value>管理服务(&M)</value>
   </data>
   <data name="ConfigService_BtnManageService_MessageBox1" xml:space="preserve">
-	  <value>The service is currently stopped and cannot be configured.
+    <value>服务当前已停止，无法配置。
 
-Please start the service first in order to configure it.</value>
+请先启动服务才能进行配置。</value>
   </data>
   <data name="ConfigService_LblInfo5" xml:space="preserve">
-    <value>If you want to manage the service (add commands and sensor, change settings) you can do so here, or by using the 'satellite service' button on the main window.</value>
+    <value>如果你想管理服务（添加命令和传感器、更改设置），可以在此处进行，或使用主窗口上的'卫星服务'按钮。</value>
   </data>
   <data name="ConfigTrayIcon_CbWebViewShowMenuOnLeftClick" xml:space="preserve">
-    <value>Show default menu on mouse left-click</value>
+    <value>鼠标左键单击时显示默认菜单</value>
   </data>
   <data name="Configuration_CheckValues_MessageBox1" xml:space="preserve">
-	  <value>Your Home Assistant API token doesn't look right. Make sure you selected the entire token (don't use CTRL+A or doubleclick).
-It should contain three sections (seperated by two dots).
+    <value>你的 Home Assistant API 令牌看起来不正确。请确保你选择了整个令牌（不要使用 CTRL+A 或双击）。
+它应该包含三部分（由两个点分隔）。
 
-Are you sure you want to use it like this?</value>
+你确定要这样使用它吗？</value>
   </data>
   <data name="Configuration_CheckValues_MessageBox2" xml:space="preserve">
-	  <value>Your Home Assistant URI doesn't look right. It should look something like 'http://homeassistant.local:8123' or 'https://192.168.0.1:8123'.
+    <value>你的 Home Assistant URI 看起来不正确。它应该类似于 'http://homeassistant.local:8123' 或 'https://192.168.0.1:8123'。
 
-Are you sure you want to use it like this?</value>
+你确定要这样使用它吗？</value>
   </data>
   <data name="Configuration_CheckValues_MessageBox3" xml:space="preserve">
-	  <value>Your MQTT broker URI doesn't look right. It should look something like 'homeassistant.local' or '192.168.0.1'.
+    <value>你的 MQTT 代理 URI 看起来不正确。它应该类似于 'homeassistant.local' 或 '192.168.0.1'。
 
-Are you sure you want to use it like this?</value>
+你确定要这样使用它吗？</value>
   </data>
   <data name="Donate_BtnClose" xml:space="preserve">
-    <value>&amp;Close</value>
+    <value>关闭(&C)</value>
   </data>
   <data name="Donate_CbHideDonateButton" xml:space="preserve">
-    <value>I already donated, hide the button on the main window.</value>
+    <value>我已经捐赠，在主窗口上隐藏按钮。</value>
   </data>
   <data name="Donate_LblInfo" xml:space="preserve">
-	  <value>HASS.Agent is completely free, and will always stay that way without restrictions!
+    <value>HASS.Agent 完全免费，并将始终保持免费，没有任何限制！
 
-However, developing and maintaining this tool (and everything that surrounds it, like support and the docs) takes up a lot of time. 
+然而，开发和维护此工具（以及围绕它的所有工作，如支持和文档）需要花费大量时间。
 
-Like most developers, I run on caffeïne - so if you can spare it, a cup of coffee is always very much appreciated!</value>
+像大多数开发者一样，我靠咖啡因维持——因此，如果你有余力，一杯咖啡将非常感谢！</value>
   </data>
   <data name="Donate_Title" xml:space="preserve">
-    <value>Donate</value>
+    <value>捐赠</value>
   </data>
   <data name="Main_NotifyIcon_MouseClick_MessageBox1" xml:space="preserve">
-    <value>No URL has been set! Please configure the webview through Configuration -&gt; Tray Icon.</value>
+    <value>未设置 URL！请通过 配置 -&gt; 托盘图标 配置 WebView。</value>
   </data>
   <data name="Main_TsCheckForUpdates" xml:space="preserve">
-    <value>Check for Updates</value>
+    <value>检查更新</value>
   </data>
   <data name="OnboardingApi_BtnTest_MessageBox5" xml:space="preserve">
-	  <value>The API token you have provided doesn't appear to be valid, please ensure you selected the entire token (Don't use CTRL + A or double-click). A valid API key contains three sections, separated by two dots.
+    <value>你提供的 API 令牌似乎无效，请确保你选择了整个令牌（不要使用 CTRL + A 或双击）。有效的 API 密钥包含三部分，由两个点分隔。
 
-Are you sure you want to use this key anyway?</value>
+你确定仍要使用此密钥吗？</value>
   </data>
   <data name="OnboardingApi_BtnTest_MessageBox6" xml:space="preserve">
-	  <value>The URI you have provided does not appear to be valid, a valid URI may look like either of the following:
+    <value>你提供的 URI 似乎无效，有效的 URI 可能类似于以下格式：
 - http://homeassistant.local:8123
 - http://192.168.0.1:8123
 
-Are you sure you want to use this URI anyway?</value>
+你确定仍要使用此 URI 吗？</value>
   </data>
   <data name="OnboardingDone_LblInfo6" xml:space="preserve">
-    <value>Currently, we (HASS.Agent Team maintaining the fork) do not accept donations in any form :)
-Please however feel free to donate to the original author of HASS.Agent - Sam! Wherever they currently are, cup of coffee might brighten their day.</value>
+    <value>目前，我们（维护此分支的 HASS.Agent 团队）不接受任何形式的捐赠 :)
+但请随意向 HASS.Agent 的原作者 - Sam 捐赠！无论他们现在在哪里，一杯咖啡可能会让他们开心一天。</value>
   </data>
   <data name="OnboardingDone_LblTip2" xml:space="preserve">
-    <value>Tip: Other donation methods are available on the About Window.</value>
+    <value>提示：其他捐赠方式可在"关于"窗口中找到。</value>
   </data>
   <data name="OnboardingIntegrations_CbEnableMediaPlayer" xml:space="preserve">
-    <value>Enable &amp;Media Player (including text-to-speech)</value>
+    <value>启用媒体播放器(&M)（包括文本转语音）</value>
   </data>
   <data name="OnboardingIntegrations_CbEnableNotifications" xml:space="preserve">
-    <value>Enable &amp;Notifications</value>
+    <value>启用通知(&N)</value>
   </data>
   <data name="OnboardingMqtt_CbEnableMqtt" xml:space="preserve">
-    <value>Enable MQTT</value>
+    <value>启用 MQTT</value>
   </data>
   <data name="PostUpdate_PostUpdate" xml:space="preserve">
-    <value>HASS.Agent Post Update</value>
+    <value>HASS.Agent 更新后处理</value>
   </data>
   <data name="SensorsManager_BluetoothDevicesSensorDescription" xml:space="preserve">
-	  <value>Provides a sensor with the amount of bluetooth devices found.
+    <value>提供一个传感器，显示找到的蓝牙设备数量。
 
-The devices and their connected state are added as attributes.</value>
+设备和它们的连接状态将作为属性添加。</value>
   </data>
   <data name="SensorsManager_BluetoothLeDevicesSensorDescription" xml:space="preserve">
-	  <value>Provides a sensors with the amount of bluetooth LE devices found.
+    <value>提供一个传感器，显示找到的蓝牙 LE 设备数量。
 
-The devices and their connected state are added as attributes.
+设备和它们的连接状态将作为属性添加。
 
-Only shows devices that were seen since the last report, ie. when the sensor publishes, the list clears.</value>
+仅显示自上次报告以来出现的设备，即当传感器发布时，列表会清空。</value>
   </data>
   <data name="SensorsManager_GeoLocationSensorDescription" xml:space="preserve">
-	  <value>Returns your current latitude, longitude and altitude as a comma-seperated value.
+    <value>返回你当前的纬度、经度和海拔，以逗号分隔的值形式。
 
-Make sure Windows' location services are enabled!
+请确保 Windows 的定位服务已启用！
 
-Depending on your Windows version, this can be found in the new control panel -&gt; 'privacy and security' -&gt; 'location'.</value>
+根据你的 Windows 版本，这可以在新的控制面板 -&gt; '隐私和安全' -&gt; '位置' 中找到。</value>
   </data>
   <data name="SensorsManager_MicrophoneProcessSensorDescription" xml:space="preserve">
-	  <value>Provides the name of the process that's currently using the microphone.
+    <value>提供当前正在使用麦克风的进程名称。
 
-Note: if used in the satellite service, it won't detect userspace applications.</value>
+注意：如果在卫星服务中使用，将无法检测用户空间应用程序。</value>
   </data>
   <data name="SensorsManager_MonitorPowerStateSensorDescription" xml:space="preserve">
-	  <value>Provides the last monitor power state change:
+    <value>提供上次显示器电源状态变化：
 
-Dimmed, PowerOff, PowerOn and Unkown.</value>
+变暗、关闭、开启和未知。</value>
   </data>
   <data name="SensorsManager_PowershellSensorDescription" xml:space="preserve">
-	  <value>Returns the result of the provided Powershell command or script.
+    <value>返回提供的 PowerShell 命令或脚本的结果。
 
-Converts the outcome to text.</value>
+将结果转换为文本。</value>
   </data>
   <data name="SensorsManager_PrintersSensorsDescription" xml:space="preserve">
-    <value>Provides information about all installed printers and their queues.</value>
+    <value>提供所有已安装打印机及其队列的信息。</value>
   </data>
   <data name="SensorsManager_WebcamProcessSensorDescription" xml:space="preserve">
-	  <value>Provides the name of the process that's currently using the webcam.
+    <value>提供当前正在使用摄像头的进程名称。
 
-Note: if used in the satellite service, it won't detect userspace applications.</value>
+注意：如果在卫星服务中使用，将无法检测用户空间应用程序。</value>
   </data>
   <data name="SensorsManager_WindowStateSensorDescription" xml:space="preserve">
-	  <value>Provides the current state of the process' window:
+    <value>提供进程窗口的当前状态：
 
-Hidden, Maximized, Minimized, Normal and Unknown.</value>
+隐藏、最大化、最小化、正常和未知。</value>
   </data>
   <data name="SensorsMod_LblSetting1_Powershell" xml:space="preserve">
-    <value>powershell command or script</value>
+    <value>powershell 命令或脚本</value>
   </data>
   <data name="SensorsMod_MessageBox_Sanitize" xml:space="preserve">
-	  <value>The name you provided contains unsupported characters and won't work. The suggested version is:
+    <value>你提供的名称包含不支持的字符，无法使用。建议的版本为：
 
 {0}
 
-Do you want to use this version?</value>
+你想使用此版本吗？</value>
   </data>
   <data name="SensorsMod_SensorsMod_BtnTest_Powershell" xml:space="preserve">
-    <value>Test Command/Script</value>
+    <value>测试命令/脚本</value>
   </data>
   <data name="SensorsMod_TestPowershell_MessageBox1" xml:space="preserve">
-    <value>Please enter a command or script!</value>
+    <value>请输入命令或脚本！</value>
   </data>
   <data name="SensorsMod_TestPowershell_MessageBox2" xml:space="preserve">
-	  <value>Test succesfully executed, result value:
+    <value>测试成功执行，结果值为：
 
 {0}</value>
   </data>
   <data name="SensorsMod_TestPowershell_MessageBox3" xml:space="preserve">
-	  <value>The test failed to execute:
+    <value>测试执行失败：
 
 {0}
 
-Do you want to open the logs folder?</value>
+你想打开日志文件夹吗？</value>
   </data>
   <data name="SensorType_BluetoothDevicesSensor" xml:space="preserve">
-    <value>BluetoothDevices</value>
+    <value>蓝牙设备</value>
   </data>
   <data name="SensorType_BluetoothLeDevicesSensor" xml:space="preserve">
-    <value>BluetoothLeDevices</value>
+    <value>蓝牙LE设备</value>
   </data>
   <data name="ServiceControllerManager_Error_Fatal" xml:space="preserve">
-    <value>Fatal error, please check logs for information!</value>
+    <value>致命错误，请查看日志获取信息！</value>
   </data>
   <data name="ServiceControllerManager_Error_Timeout" xml:space="preserve">
-    <value>Timeout expired</value>
+    <value>超时已过期</value>
   </data>
   <data name="ServiceControllerManager_Error_Unknown" xml:space="preserve">
-    <value>unknown reason</value>
+    <value>未知原因</value>
   </data>
   <data name="ServiceHelper_ChangeStartMode_Error1" xml:space="preserve">
-    <value>unable to open Service Manager</value>
+    <value>无法打开服务管理器</value>
   </data>
   <data name="ServiceHelper_ChangeStartMode_Error2" xml:space="preserve">
-    <value>unable to open service</value>
+    <value>无法打开服务</value>
   </data>
   <data name="ServiceHelper_ChangeStartMode_Error3" xml:space="preserve">
-    <value>Error configuring startup mode, please check the logs for more information.</value>
+    <value>配置启动模式时出错，请查看日志获取更多信息。</value>
   </data>
   <data name="ServiceHelper_ChangeStartMode_Error4" xml:space="preserve">
-    <value>Error setting startup mode, please check the logs for more information.</value>
+    <value>设置启动模式时出错，请查看日志获取更多信息。</value>
   </data>
   <data name="WebView_InitializeAsync_MessageBox1" xml:space="preserve">
-	  <value>Microsoft's WebView2 runtime isn't found on your machine. Usually this is handled by the installer, but you can install it manually.
+    <value>未在你的计算机上找到 Microsoft 的 WebView2 运行时。通常这由安装程序处理，但你也可以手动安装。
 
-Do you want to download the runtime installer?</value>
+你想下载运行时安装程序吗？</value>
   </data>
   <data name="WebView_InitializeAsync_MessageBox2" xml:space="preserve">
-    <value>Something went wrong while initializing the WebView! Please check your logs and open a GitHub issue for further assistance.</value>
+    <value>初始化 WebView 时出现问题！请检查你的日志并在 GitHub 上提交 issue 以获取进一步帮助。</value>
   </data>
   <data name="QuickActionsMod_ClmDomain" xml:space="preserve">
-	  <value>domain</value>
+    <value>域</value>
   </data>
   <data name="CommandType_RadioCommand" xml:space="preserve">
-    <value>RadioCommand</value>
+    <value>无线电命令</value>
   </data>
   <data name="SensorType_InternalDeviceSensor" xml:space="preserve">
-    <value>InternalDeviceSensor</value>
+    <value>内部设备传感器</value>
   </data>
   <data name="SensorType_ActiveDesktopSensor" xml:space="preserve">
-    <value>ActiveDesktop</value>
+    <value>活动桌面</value>
   </data>
   <data name="CommandType_SetApplicationVolumeCommand" xml:space="preserve">
-    <value>SetApplicationVolume</value>
+    <value>设置应用音量</value>
   </data>
   <data name="CommandType_SetAudioOutputCommand" xml:space="preserve">
-    <value>SetAudioOutputCommand</value>
+    <value>设置音频输出命令</value>
   </data>
   <data name="SensorType_ScreenshotSensor" xml:space="preserve">
-    <value>Screenshot</value>
+    <value>截图</value>
   </data>
   <data name="CommandType_SetAudioInputCommand" xml:space="preserve">
-    <value>SetAudioInputCommand</value>
+    <value>设置音频输入命令</value>
   </data>
   <data name="CommandType_TrayWebViewCommand" xml:space="preserve">
-    <value>TrayWebView</value>
+    <value>托盘WebView</value>
   </data>
   <data name="HassAction_Trigger" xml:space="preserve">
-    <value>Trigger</value>
+    <value>触发</value>
   </data>
   <data name="HassAction_Press" xml:space="preserve">
-    <value>Press</value>
+    <value>按下</value>
   </data>
   <data name="HassDomain_Button" xml:space="preserve">
-    <value>Button</value>
+    <value>按钮</value>
   </data>
   <data name="SensorType_NamedActiveWindowSensor" xml:space="preserve">
-    <value>NamedActiveWindow</value>
+    <value>命名活动窗口</value>
   </data>
   <data name="SensorsManager_NamedActiveWindowSensorDescription" xml:space="preserve">
-    <value>Provides an ON/OFF value based on whether the focused window name contains configured string.</value>
+    <value>根据焦点窗口名称是否包含配置的字符串，提供一个 ON/OFF 值。</value>
   </data>
   <data name="SensorType_AccentColorSensor" xml:space="preserve">
-    <value>AccentColor</value>
+    <value>强调色</value>
   </data>
   <data name="HassDomain_InputButton" xml:space="preserve">
-    <value>InputButton</value>
+    <value>输入按钮</value>
   </data>
   <data name="HassDomain_Fan" xml:space="preserve">
-    <value>Fan</value>
+    <value>风扇</value>
   </data>
   <data name="CommandsManager_WinformsSleepCommandDescription" xml:space="preserve">
-    <value>Puts the machine to sleep using WinForms API.
+    <value>使用 WinForms API 使机器进入休眠。
 
-Note: due to "Modern Sleep" the sleep commands might behave differently depending on the device OEM and OS configuration.</value>
+注意：由于"现代休眠"，休眠命令可能会根据设备 OEM 和操作系统配置的不同而表现不同。</value>
   </data>
   <data name="CommandType_WinformsSleepCommand" xml:space="preserve">
-    <value>WinformsSleep</value>
+    <value>Winforms休眠</value>
   </data>
   <data name="CommandType_MonitorSleepPowerPlanCommand" xml:space="preserve">
-    <value>MonitorSleepPowerPlan</value>
+    <value>显示器休眠电源计划</value>
   </data>
   <data name="CommandsManager_MonitorSleepPowerPlanCommandDescription" xml:space="preserve">
-    <value>Puts all monitors in sleep (low power) mode using alternative approach of power plan modification.
-Should provide better experience with new systems with "modern S0ix sleep" and not put the system to sleep.</value>
+    <value>使用修改电源计划的替代方法将所有显示器置于休眠（低功耗）模式。
+对于具有"现代 S0ix 休眠"的新系统，应提供更好的体验，并且不会使系统进入休眠。</value>
   </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigExternalTools.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigExternalTools.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigGeneral.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigGeneral.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigHomeAssistantApi.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigHomeAssistantApi.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigHotKey.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigHotKey.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigLocalStorage.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigLocalStorage.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigLogging.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigLogging.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigMqtt.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigMqtt.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigNotifications.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigNotifications.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigService.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigService.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigStartup.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigStartup.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigUpdates.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Configuration/ConfigUpdates.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-1-Welcome.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-1-Welcome.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-2-Startup.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-2-Startup.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-3-API.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-3-API.zh-CN.resx
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="LblInfo1.Text" xml:space="preserve">
+    <value>为了解您配置了哪些实体并发送快捷操作，HASS.Agent 需要使用
+Home Assistant 的 API。
+
+请提供长期访问令牌和您的 Home Assistant 实例地址。
+您可以在 Home Assistant 中点击左下角的个人资料头像，
+切换到顶部的安全选项卡，然后导航到页面底部，
+直到看到"创建令牌"按钮。
+
+请注意，要使用可操作通知功能，您需要提供管理员账户的令牌。</value>
+  </data>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-4-MQTT.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-4-MQTT.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-5-Integrations.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-5-Integrations.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-6-HotKey.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-6-HotKey.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-7-Updates.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-7-Updates.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-8-Done.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Onboarding/Onboarding-8-Done.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/QuickActionControl.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/QuickActionControl.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Service/ServiceCommands.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Service/ServiceCommands.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Service/ServiceConnect.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Service/ServiceConnect.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Service/ServiceGeneral.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Service/ServiceGeneral.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Service/ServiceMQTT.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Service/ServiceMQTT.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Controls/Service/ServiceSensors.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Controls/Service/ServiceSensors.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/About.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/About.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/ChildApplications/CompatibilityTask.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/ChildApplications/CompatibilityTask.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/ChildApplications/PortReservation.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/ChildApplications/PortReservation.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/ChildApplications/PostUpdate.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/ChildApplications/PostUpdate.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/ChildApplications/Restart.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/ChildApplications/Restart.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/ChildApplications/ServiceReinstall.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/ChildApplications/ServiceReinstall.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/ChildApplications/ServiceSetState.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/ChildApplications/ServiceSetState.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/Commands/CommandsConfig.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/Commands/CommandsConfig.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/Commands/CommandsMod.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/Commands/CommandsMod.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/Configuration.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/Configuration.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/ExitDialog.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/ExitDialog.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/Help.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/Help.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/Main.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/Main.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/Onboarding.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/Onboarding.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/QuickActions/QuickActions.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/QuickActions/QuickActions.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/QuickActions/QuickActionsConfig.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/QuickActions/QuickActionsConfig.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/QuickActions/QuickActionsMod.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/QuickActions/QuickActionsMod.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/Sensors/SensorsConfig.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/Sensors/SensorsConfig.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/Sensors/SensorsMod.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/Sensors/SensorsMod.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/Service/ServiceConfig.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/Service/ServiceConfig.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Forms/UpdatePending.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Forms/UpdatePending.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Managers/LocalizationManager.cs
+++ b/src/HASS.Agent/HASS.Agent/Managers/LocalizationManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using HASS.Agent.Models.Internal;
 using HASS.Agent.Shared;
@@ -145,7 +145,7 @@ namespace HASS.Agent.Managers
         /// </summary>
         private static void LoadSupportedUILanguages()
         {
-            var supportedCultureList = new List<string> { "en", "pt-BR", "sl", "es", "nl", "de", "ru", "fr", "pl", "tr" };
+            var supportedCultureList = new List<string> { "en", "pt-BR", "sl", "es", "nl", "de", "ru", "fr", "pl", "tr", "zh-CN" };
 
             foreach (var supportedUILanguage in supportedCultureList.Select(supportedCulture => new CultureInfo(supportedCulture)).Select(culture => new SupportedUILanguage(culture)))
             {

--- a/src/HASS.Agent/HASS.Agent/Properties/Resources.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Properties/Resources.zh-CN.resx
@@ -1,0 +1,14 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.zh-CN.resx
@@ -1,0 +1,3490 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ConfigExternalTools_LblInfo1" xml:space="preserve">
+    <value>This page allows you to configure bindings with external tools.</value>
+  </data>
+  <data name="ConfigExternalTools_LblBrowserName" xml:space="preserve">
+    <value>Browser Name</value>
+  </data>
+  <data name="ConfigExternalTools_LblInfo2" xml:space="preserve">
+	  <value>By default HASS.Agent will launch URLs using your default browser. You can also configure
+a specific browser to be used instead along with launch arguments to run in private mode.</value>
+  </data>
+  <data name="ConfigExternalTools_LblBrowserBinary" xml:space="preserve">
+    <value>Browser Binary</value>
+  </data>
+  <data name="ConfigExternalTools_LblLaunchIncogArg" xml:space="preserve">
+    <value>Additional Launch Arguments</value>
+  </data>
+  <data name="ConfigExternalTools_LblCustomExecutorBinary" xml:space="preserve">
+    <value>Custom Executor Binary</value>
+  </data>
+  <data name="ConfigExternalTools_LblInfo3" xml:space="preserve">
+	  <value>You can configure the HASS.Agent to use a specific interpreter such as Perl or Python.
+Use the 'custom executor' command to launch this executor.</value>
+  </data>
+  <data name="ConfigExternalTools_LblCustomExecutorName" xml:space="preserve">
+    <value>Custom Executor Name</value>
+  </data>
+  <data name="ConfigExternalTools_LblTip1" xml:space="preserve">
+    <value>Tip: Double-click to Browse</value>
+  </data>
+  <data name="ConfigExternalTools_BtnExternalBrowserIncognitoTest" xml:space="preserve">
+    <value>&amp;Test</value>
+  </data>
+  <data name="ConfigGeneral_LblInfo4" xml:space="preserve">
+	  <value>HASS.Agent will wait a grace period before notifying you of disconnects from MQTT or HA's API.
+You can set the amount of seconds to wait in this grace period below.</value>
+  </data>
+  <data name="ConfigGeneral_LblDisconGraceSeconds" xml:space="preserve">
+    <value>Seconds</value>
+  </data>
+  <data name="ConfigGeneral_LblDisconGracePeriod" xml:space="preserve">
+    <value>Disconnected Grace &amp;Period</value>
+  </data>
+  <data name="ConfigGeneral_LblInfo3" xml:space="preserve">
+	  <value>IMPORTANT: if you change this value, HASS.Agent will unpublish all your sensors, commands and force a restart of itself so they can be republished under the new device name.
+Your automations and scripts will keep working.</value>
+  </data>
+  <data name="ConfigGeneral_LblInfo2" xml:space="preserve">
+	  <value>The device name is used to identify your machine on Home Assistant.
+It is also used as a prefix for your command/sensor names (this can be changed per entity).</value>
+  </data>
+  <data name="ConfigGeneral_LblInfo1" xml:space="preserve">
+    <value>This page contains general configuration settings, for more settings you can browse the tabs on the left.</value>
+  </data>
+  <data name="ConfigGeneral_LblDeviceName" xml:space="preserve">
+    <value>Device &amp;Name</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_LblTip1" xml:space="preserve">
+    <value>Tip: Double-click this field to browse</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_LblClientCertificate" xml:space="preserve">
+    <value>Client &amp;Certificate</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_CbHassAutoClientCertificate" xml:space="preserve">
+    <value>Use &amp;automatic client certificate selection</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_BtnTestApi" xml:space="preserve">
+    <value>&amp;Test Connection</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_LblInfo1" xml:space="preserve">
+	  <value>To learn which entities you have configured and to send quick actions, HASS.Agent uses
+Home Assistant's API.
+
+Please provide a long-lived access token and the address of your Home Assistant instance.
+You can get a token in Home Assistant by clicking your profile picture at the bottom-left
+and navigating to the bottom of the page until you see the 'CREATE TOKEN' button.
+
+Please note, that for actionable notification functionality you need to provide admin account token.</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_LblApiToken" xml:space="preserve">
+    <value>&amp;API Token</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_LblServerUri" xml:space="preserve">
+    <value>Server &amp;URI</value>
+  </data>
+  <data name="ConfigHotKey_BtnClearHotKey" xml:space="preserve">
+    <value>&amp;Clear</value>
+  </data>
+  <data name="ConfigHotKey_LblInfo1" xml:space="preserve">
+	  <value>An easy way to pull up your quick actions is to use a global hotkey.
+
+This way, whatever you're doing on your machine, you can always interact with Home Assistant.</value>
+  </data>
+  <data name="ConfigHotKey_CbEnableQuickActionsHotkey" xml:space="preserve">
+    <value>&amp;Enable Quick Actions Hotkey</value>
+  </data>
+  <data name="ConfigHotKey_LblHotkeyCombo" xml:space="preserve">
+    <value>&amp;Hotkey Combination</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearImageCache" xml:space="preserve">
+    <value>Clear Image Cache</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnOpenImageCache" xml:space="preserve">
+    <value>Open Folder</value>
+  </data>
+  <data name="ConfigLocalStorage_LblCacheLocations" xml:space="preserve">
+    <value>Image Cache Location</value>
+  </data>
+  <data name="ConfigLocalStorage_LblCacheDays" xml:space="preserve">
+    <value>days</value>
+  </data>
+  <data name="ConfigLocalStorage_LblInfo1" xml:space="preserve">
+	  <value>Some items like images shown in notifications have to be temporarily stored locally. You can
+configure the amount of days they should be kept before HASS.Agent deletes them.
+
+Enter '0' to keep them permanently.</value>
+  </data>
+  <data name="ConfigLogging_LblInfo1" xml:space="preserve">
+	  <value>Extended logging provides more verbose and in-depth logging, in case the default logging isn't
+sufficient. Please note that enabling this can cause the logfiles to grow large, and should only be
+used when you suspect something's wrong with HASS.Agent itself or when asked by the
+developers.</value>
+  </data>
+  <data name="ConfigLogging_CbExtendedLogging" xml:space="preserve">
+    <value>&amp;Enable Extended Logging</value>
+  </data>
+  <data name="ConfigLogging_BtnShowLogs" xml:space="preserve">
+    <value>&amp;Open Logs Folder</value>
+  </data>
+  <data name="ConfigMqtt_LblTip3" xml:space="preserve">
+    <value>Tip: Double-click these fields to browse</value>
+  </data>
+  <data name="ConfigMqtt_LblClientCert" xml:space="preserve">
+    <value>Client Certificate</value>
+  </data>
+  <data name="ConfigMqtt_LblRootCert" xml:space="preserve">
+    <value>Root Certificate</value>
+  </data>
+  <data name="ConfigMqtt_CbUseRetainFlag" xml:space="preserve">
+    <value>Use &amp;Retain Flag</value>
+  </data>
+  <data name="ConfigMqtt_CbAllowUntrustedCertificates" xml:space="preserve">
+    <value>&amp;Allow Untrusted Certificates</value>
+  </data>
+  <data name="ConfigMqtt_BtnMqttClearConfig" xml:space="preserve">
+    <value>&amp;Clear Configuration</value>
+  </data>
+  <data name="ConfigMqtt_LblTip1" xml:space="preserve">
+    <value>(leave default if unsure)</value>
+  </data>
+  <data name="ConfigMqtt_LblInfo1" xml:space="preserve">
+	  <value>Commands and sensors use MQTT, as well as notifications and media player functions when using the new integration. 
+
+Please provide credentials for your broker, if you're using the HA Mosquitto addon, you can probably use the preset address.
+
+Note: these settings (excluding the Client ID) will also be applied to the satellite service.</value>
+  </data>
+  <data name="ConfigMqtt_LblDiscoPrefix" xml:space="preserve">
+    <value>Discovery Prefix</value>
+  </data>
+  <data name="ConfigMqtt_LblBrokerPassword" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="ConfigMqtt_LblBrokerUsername" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="ConfigMqtt_LblBrokerPort" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="ConfigMqtt_LblBrokerIp" xml:space="preserve">
+    <value>Broker IP Address or Hostname</value>
+  </data>
+  <data name="ConfigMqtt_LblTip2" xml:space="preserve">
+    <value>(leave empty to auto generate)</value>
+  </data>
+  <data name="ConfigMqtt_LblClientId" xml:space="preserve">
+    <value>Client ID</value>
+  </data>
+  <data name="ConfigNotifications_LblInfo2" xml:space="preserve">
+	  <value>If something is not working, make sure you try the following steps:
+
+- Install the HASS.Agent integration
+- Restart Home Assistant
+- Make sure HASS.Agent is active with MQTT enabled!
+- Your device should get detected and added as an entity automatically
+- Optionally: manually add it using the local API</value>
+  </data>
+  <data name="ConfigNotifications_LblInfo1" xml:space="preserve">
+    <value>HASS.Agent can receive notifications from Home Assistant, using text, images and actions. If you have MQTT enabled, your device will automatically get added. Otherwise, manually configure the integration to use the local API.</value>
+  </data>
+  <data name="ConfigNotifications_BtnNotificationsReadme" xml:space="preserve">
+    <value>Notifications &amp;Documentation</value>
+  </data>
+  <data name="ConfigNotifications_LblPort" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="ConfigNotifications_CbAcceptNotifications" xml:space="preserve">
+    <value>&amp;Accept Notifications</value>
+  </data>
+  <data name="ConfigNotifications_BtnSendTestNotification" xml:space="preserve">
+    <value>Show Test Notification</value>
+  </data>
+  <data name="ConfigNotifications_BtnExecutePortReservation" xml:space="preserve">
+    <value>Execute Port Reservation</value>
+  </data>
+  <data name="ConfigNotifications_CbNotificationsIgnoreImageCertErrors" xml:space="preserve">
+    <value>&amp;Ignore certificate errors for images</value>
+  </data>
+  <data name="ConfigService_LblInfo1" xml:space="preserve">
+	  <value>The satellite service allows you to run sensors and commands even when no user's logged in. 
+Use the 'satellite service' button on the main window to manage it.</value>
+  </data>
+  <data name="ConfigService_LblServiceStatusInfo" xml:space="preserve">
+    <value>Service Status:</value>
+  </data>
+  <data name="ConfigService_BtnStartService" xml:space="preserve">
+    <value>S&amp;tart Service</value>
+  </data>
+  <data name="ConfigService_BtnDisableService" xml:space="preserve">
+    <value>&amp;Disable Service</value>
+  </data>
+  <data name="ConfigService_BtnStopService" xml:space="preserve">
+    <value>&amp;Stop Service</value>
+  </data>
+  <data name="ConfigService_BtnEnableService" xml:space="preserve">
+    <value>&amp;Enable Service</value>
+  </data>
+  <data name="ConfigService_BtnReinstallService" xml:space="preserve">
+    <value>&amp;Reinstall Service</value>
+  </data>
+  <data name="ConfigService_LblInfo2" xml:space="preserve">
+	  <value>If you do not configure the service, it won't do anything. However, you can still decide to disable it as well.
+The installer will leave the disabled service alone(if you remove the service, the installer will reinstall it).</value>
+  </data>
+  <data name="ConfigService_LblInfo3" xml:space="preserve">
+	  <value>You can try reinstalling the service if it's not working correctly.
+Your configuration and entities won't be removed.</value>
+  </data>
+  <data name="ConfigService_BtnShowLogs" xml:space="preserve">
+    <value>Open Service &amp;Logs Folder</value>
+  </data>
+  <data name="ConfigService_LblInfo4" xml:space="preserve">
+    <value>If the service still fails after reinstalling, please open a ticket and send the content of the latest log.</value>
+  </data>
+  <data name="ConfigStartup_LblInfo1" xml:space="preserve">
+	  <value>HASS.Agent can start when you login by creating an entry in your user profile's registry.
+
+Since HASS.Agent is user based, if you want to launch for another user, just install and config
+HASS.Agent there.</value>
+  </data>
+  <data name="ConfigStartup_BtnSetStartOnLogin" xml:space="preserve">
+    <value>&amp;Enable Start-on-Login</value>
+  </data>
+  <data name="ConfigStartup_LblStartOnLoginStatusInfo" xml:space="preserve">
+    <value>Start-on-Login Status:</value>
+  </data>
+  <data name="ConfigUpdates_CbBetaUpdates" xml:space="preserve">
+    <value>Notify me of &amp;beta releases</value>
+  </data>
+  <data name="ConfigUpdates_LblInfo2" xml:space="preserve">
+	  <value>When a new update is available, HASS.Agent can download the installer and launch it for you.
+
+The certificate of the downloaded file will get checked before running,you will still get to review the release notes and manually approve the update.</value>
+  </data>
+  <data name="ConfigUpdates_CbExecuteUpdater" xml:space="preserve">
+    <value>Automatically &amp;download future updates</value>
+  </data>
+  <data name="ConfigUpdates_LblInfo1" xml:space="preserve">
+	  <value>HASS.Agent checks for updates in the background if enabled.
+
+You will be sent a push notification if a new update is discovered, letting you know a
+new version is ready to be installed.</value>
+  </data>
+  <data name="ConfigUpdates_CbUpdates" xml:space="preserve">
+    <value>Notify me when a new &amp;release is available</value>
+  </data>
+  <data name="OnboardingWelcome_LblInfo1" xml:space="preserve">
+	  <value>Welcome to the HASS.Agent! It looks like this is the first time you are launching the agent.
+
+To assist you with a first time setup, proceed with the configuration steps below
+or alternatively, click 'Close'.</value>
+  </data>
+  <data name="OnboardingWelcome_LblInfo2" xml:space="preserve">
+    <value>The device name is used to identify your machine on Home Assistant, it is also used as a suggested prefix for your commands and sensors.</value>
+  </data>
+  <data name="OnboardingWelcome_LblDeviceName" xml:space="preserve">
+    <value>Device &amp;Name</value>
+  </data>
+  <data name="OnboardingStartup_BtnSetLaunchOnLogin" xml:space="preserve">
+    <value>Yes, &amp;start HASS.Agent on System Login</value>
+  </data>
+  <data name="OnboardingStartup_LblInfo1" xml:space="preserve">
+	  <value>HASS.Agent can start with your system, this allows for any sensors and data transmission between your device and Home Assistant to begin as soon as you login.
+
+This setting can be changed any time later in the HASS.Agent configuration window.</value>
+  </data>
+  <data name="OnboardingStartup_LblCreateInfo" xml:space="preserve">
+    <value>Fetching current state, please wait..</value>
+  </data>
+  <data name="OnboardingNotifications_LblTip1" xml:space="preserve">
+    <value>Note: 5115 is the default port, only change it if you changed it in Home Assistant.</value>
+  </data>
+  <data name="OnboardingNotifications_CbAcceptNotifications" xml:space="preserve">
+    <value>Yes, accept notifications on port</value>
+  </data>
+  <data name="OnboardingNotifications_LblInfo1" xml:space="preserve">
+	  <value>HASS.Agent can receive notifications from Home Assistant, using text and/or images.
+
+Do you want to enable this function?</value>
+  </data>
+  <data name="OnboardingIntegration_LblIntegration" xml:space="preserve">
+    <value>HASS.Agent-Notifier GitHub Page</value>
+  </data>
+  <data name="OnboardingIntegration_LblInfo2" xml:space="preserve">
+	  <value>Make sure you follow these steps:
+
+- Install HASS.Agent-Notifier integration
+- Restart Home Assistant
+- Configure a notifier entity
+- Restart Home Assistant</value>
+  </data>
+  <data name="OnboardingIntegration_LblInfo1" xml:space="preserve">
+	  <value>To use notifications, you need to install and configure the HASS.Agent-notifier integration in
+Home Assistant.
+
+This is very easy using HACS but may also be installed manually, visit the link below for more
+information.</value>
+  </data>
+  <data name="OnboardingApi_LblApiToken" xml:space="preserve">
+    <value>API &amp;Token</value>
+  </data>
+  <data name="OnboardingApi_LblServerUri" xml:space="preserve">
+    <value>Server &amp;URI (should be ok like this)</value>
+  </data>
+  <data name="OnboardingApi_LblInfo1" xml:space="preserve">
+	  <value>To learn which entities you have configured and to send quick actions, HASS.Agent uses
+Home Assistant's API.
+
+Please provide a long-lived access token and the address of your Home Assistant instance.
+You can get a token in Home Assistant by clicking your profile picture at the bottom-left
+and navigating to the bottom of the page until you see the 'CREATE TOKEN' button.</value>
+  </data>
+  <data name="OnboardingApi_BtnTest" xml:space="preserve">
+    <value>Test &amp;Connection</value>
+  </data>
+  <data name="OnboardingApi_LblTip1" xml:space="preserve">
+    <value>Tip: Specialized settings can be found in the Configuration Window.</value>
+  </data>
+  <data name="OnboardingMqtt_LblPassword" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="OnboardingMqtt_LblUsername" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="OnboardingMqtt_LblPort" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="OnboardingMqtt_LblIpAdress" xml:space="preserve">
+    <value>IP Address or Hostname</value>
+  </data>
+  <data name="OnboardingMqtt_LblInfo1" xml:space="preserve">
+	  <value>Commands and sensors are sent through MQTT. The notifications- and media player integration also make use of them.
+
+Tip: if you're using the HA addon, you can probably use the preset address - just provide credentials.
+</value>
+  </data>
+  <data name="OnboardingMqtt_LblDiscoveryPrefix" xml:space="preserve">
+    <value>Discovery Prefix</value>
+  </data>
+  <data name="OnboardingMqtt_LblTip1" xml:space="preserve">
+    <value>(leave default if not sure)</value>
+  </data>
+  <data name="OnboardingMqtt_LblTip2" xml:space="preserve">
+    <value>Tip: Specialized settings can be found in the Configuration Window.</value>
+  </data>
+  <data name="OnboardingHotKey_LblHotkeyCombo" xml:space="preserve">
+    <value>&amp;Hotkey Combination</value>
+  </data>
+  <data name="OnboardingHotKey_LblInfo1" xml:space="preserve">
+	  <value>An easy way to pull up your quick actions is to use a global hotkey.
+
+This way, whatever you're doing on your machine, you can always interact with Home Assistant.
+</value>
+  </data>
+  <data name="OnboardingHotKey_BtnClear" xml:space="preserve">
+    <value>&amp;Clear</value>
+  </data>
+  <data name="OnboardingUpdates_LblInfo1" xml:space="preserve">
+	  <value>HASS.Agent checks for updates in the background if enabled.
+
+You will be sent a push notification if a new update is discovered, letting you know a
+new version is ready to be installed.
+
+Do you want to enable this automatic update checks?</value>
+  </data>
+  <data name="OnboardingUpdates_CbNofityOnUpdate" xml:space="preserve">
+    <value>Yes, notify me on new &amp;updates</value>
+  </data>
+  <data name="OnboardingUpdates_CbExecuteUpdater" xml:space="preserve">
+    <value>Yes, &amp;download and launch the installer for me</value>
+  </data>
+  <data name="OnboardingUpdates_LblInfo2" xml:space="preserve">
+	  <value>When a new update is available, HASS.Agent can download the installer and launch it for you.
+
+The certificate of the downloaded file will get checked before running,you will still get to review the release notes and manually approve the update.</value>
+  </data>
+  <data name="OnboardingDone_LblGitHub" xml:space="preserve">
+    <value>HASS.Agent GitHub page</value>
+  </data>
+  <data name="OnboardingDone_LblInfo3" xml:space="preserve">
+	  <value>There's a lot more to tinker with, so make sure you take a look at the Configuration Window!
+
+
+Thank you for using HASS.Agent, hopefully it'll be useful for you :-)
+</value>
+  </data>
+  <data name="OnboardingDone_LblInfo2" xml:space="preserve">
+    <value>HASS.Agent will now restart to apply your configuration changes.</value>
+  </data>
+  <data name="OnboardingDone_LblInfo1" xml:space="preserve">
+    <value>Yay, done!</value>
+  </data>
+  <data name="ServiceCommands_LblLowIntegrity" xml:space="preserve">
+    <value>Low Integrity</value>
+  </data>
+  <data name="ServiceCommands_ClmName" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="ServiceCommands_ClmType" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="ServiceCommands_BtnRemove" xml:space="preserve">
+    <value>&amp;Remove</value>
+  </data>
+  <data name="ServiceCommands_BtnModify" xml:space="preserve">
+    <value>&amp;Modify</value>
+  </data>
+  <data name="ServiceCommands_BtnAdd" xml:space="preserve">
+    <value>&amp;Add New</value>
+  </data>
+  <data name="ServiceCommands_BtnStore" xml:space="preserve">
+    <value>&amp;Send &amp;&amp; Activate Commands</value>
+  </data>
+  <data name="ServiceCommands_LblStored" xml:space="preserve">
+    <value>commands stored!</value>
+  </data>
+  <data name="ServiceConnect_BtnRetryAuthId" xml:space="preserve">
+    <value>&amp;Apply</value>
+  </data>
+  <data name="ServiceConnect_LblRetryAuthId" xml:space="preserve">
+    <value>Auth &amp;ID</value>
+  </data>
+  <data name="ServiceConnect_LblAuthenticate" xml:space="preserve">
+    <value>Authenticate</value>
+  </data>
+  <data name="ServiceConnect_LblConnect" xml:space="preserve">
+    <value>Connect with service</value>
+  </data>
+  <data name="ServiceConnect_LblLoading" xml:space="preserve">
+    <value>Connecting satellite service, please wait..</value>
+  </data>
+  <data name="ServiceConnect_LblFetchConfig" xml:space="preserve">
+    <value>Fetch Configuration</value>
+  </data>
+  <data name="ServiceGeneral_LblInfo1" xml:space="preserve">
+    <value>This page contains general configuration settings, for MQTT settings, commands, and sensors, browse the different tabs above.</value>
+  </data>
+  <data name="ServiceGeneral_LblAuthId" xml:space="preserve">
+    <value>Auth &amp;ID</value>
+  </data>
+  <data name="ServiceGeneral_LblDeviceName" xml:space="preserve">
+    <value>Device &amp;Name</value>
+  </data>
+  <data name="ServiceGeneral_LblTip1" xml:space="preserve">
+    <value>Tip: Double-click these fields to browse</value>
+  </data>
+  <data name="ServiceGeneral_LblCustomExecBinary" xml:space="preserve">
+    <value>Custom Executor &amp;Binary</value>
+  </data>
+  <data name="ServiceGeneral_LblCustomExecName" xml:space="preserve">
+    <value>Custom &amp;Executor Name</value>
+  </data>
+  <data name="ServiceGeneral_LblSeconds" xml:space="preserve">
+    <value>seconds</value>
+  </data>
+  <data name="ServiceGeneral_LblDisconGrace" xml:space="preserve">
+    <value>Disconnected Grace &amp;Period</value>
+  </data>
+  <data name="ServiceGeneral_Apply" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="ServiceGeneral_LblVersionInfo" xml:space="preserve">
+    <value>Version</value>
+  </data>
+  <data name="ServiceGeneral_LblTip2" xml:space="preserve">
+    <value>Tip: Double-click to generate random</value>
+  </data>
+  <data name="ServiceGeneral_Stored" xml:space="preserve">
+    <value>Stored!</value>
+  </data>
+  <data name="ServiceMqtt_LblTip2" xml:space="preserve">
+    <value>(leave empty to auto generate)</value>
+  </data>
+  <data name="ServiceMqtt_LblClientId" xml:space="preserve">
+    <value>Client ID</value>
+  </data>
+  <data name="ServiceMqtt_LblTip3" xml:space="preserve">
+    <value>Tip: Double-click these fields to browse</value>
+  </data>
+  <data name="ServiceMqtt_LblClientCert" xml:space="preserve">
+    <value>Client Certificate</value>
+  </data>
+  <data name="ServiceMqtt_LblRootCert" xml:space="preserve">
+    <value>Root Certificate</value>
+  </data>
+  <data name="ServiceMqtt_CbUseRetainFlag" xml:space="preserve">
+    <value>Use &amp;Retain Flag</value>
+  </data>
+  <data name="ServiceMqtt_CbAllowUntrustedCertificates" xml:space="preserve">
+    <value>&amp;Allow Untrusted Certificates</value>
+  </data>
+  <data name="ServiceMqtt_BtnMqttClearConfig" xml:space="preserve">
+    <value>&amp;Clear Configuration</value>
+  </data>
+  <data name="ServiceMqtt_LblTip1" xml:space="preserve">
+    <value>(leave default if not sure)</value>
+  </data>
+  <data name="ServiceMqtt_LblInfo1" xml:space="preserve">
+	  <value>Commands and sensors are sent through MQTT. Please provide credentials for your server. If you're using the HA addon,
+you can probably use the preset address.</value>
+  </data>
+  <data name="ServiceMqtt_LblDiscoPrefix" xml:space="preserve">
+    <value>Discovery Prefix</value>
+  </data>
+  <data name="ServiceMqtt_LblBrokerPassword" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="ServiceMqtt_LblBrokerUsername" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="ServiceMqtt_LblBrokerPort" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="ServiceMqtt_LblBrokerIp" xml:space="preserve">
+    <value>Broker IP Address or Hostname</value>
+  </data>
+  <data name="ServiceMqtt_BtnStore" xml:space="preserve">
+    <value>&amp;Send &amp;&amp; Activate Configuration</value>
+  </data>
+  <data name="ServiceMqtt_BtnCopy" xml:space="preserve">
+    <value>Copy from &amp;HASS.Agent</value>
+  </data>
+  <data name="ServiceMqtt_LblStored" xml:space="preserve">
+    <value>Configuration stored!</value>
+  </data>
+  <data name="ServiceMqtt_LblStatusInfo" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="ServiceMqtt_LblStatus" xml:space="preserve">
+    <value>Querying..</value>
+  </data>
+  <data name="ServiceSensors_ClmName" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="ServiceSensors_ClmType" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="ServiceSensors_LblRefresh" xml:space="preserve">
+    <value>Refresh</value>
+  </data>
+  <data name="ServiceSensors_BtnRemove" xml:space="preserve">
+    <value>&amp;Remove</value>
+  </data>
+  <data name="ServiceSensors_BtnAdd" xml:space="preserve">
+    <value>&amp;Add New</value>
+  </data>
+  <data name="ServiceSensors_BtnModify" xml:space="preserve">
+    <value>&amp;Modify</value>
+  </data>
+  <data name="ServiceSensors_BtnStore" xml:space="preserve">
+    <value>&amp;Send &amp;&amp; Activate Sensors</value>
+  </data>
+  <data name="ServiceSensors_LblStored" xml:space="preserve">
+    <value>Sensors stored!</value>
+  </data>
+  <data name="PortReservation_LblInfo1" xml:space="preserve">
+    <value>Please wait a bit while the task is performed ..</value>
+  </data>
+  <data name="PortReservation_LblTask1" xml:space="preserve">
+    <value>Create API Port Binding</value>
+  </data>
+  <data name="PortReservation_LblTask2" xml:space="preserve">
+    <value>Set Firewall Rule</value>
+  </data>
+  <data name="PortReservation_Title" xml:space="preserve">
+    <value>HASS.Agent Port Reservation</value>
+  </data>
+  <data name="PostUpdate_LblInfo1" xml:space="preserve">
+    <value>Please wait a bit while some post-update tasks are performed ..</value>
+  </data>
+  <data name="PostUpdate_LblTask1" xml:space="preserve">
+    <value>Configuring Satellite Service</value>
+  </data>
+  <data name="PostUpdate_LblTask2" xml:space="preserve">
+    <value>Create API Port Binding</value>
+  </data>
+  <data name="PostUpdate_Title" xml:space="preserve">
+    <value>HASS.Agent Post Update</value>
+  </data>
+  <data name="Restart_LblInfo1" xml:space="preserve">
+    <value>Please wait while HASS.Agent restarts..</value>
+  </data>
+  <data name="Restart_LblTask1" xml:space="preserve">
+    <value>Waiting for previous instance to close..</value>
+  </data>
+  <data name="Restart_LblTask2" xml:space="preserve">
+    <value>Relaunch HASS.Agent</value>
+  </data>
+  <data name="Restart_Title" xml:space="preserve">
+    <value>HASS.Agent Restarter</value>
+  </data>
+  <data name="ServiceReinstall_LblInfo1" xml:space="preserve">
+    <value>Please wait while the satellite service is re-installed..</value>
+  </data>
+  <data name="ServiceReinstall_LblTask1" xml:space="preserve">
+    <value>Remove Satellite Service</value>
+  </data>
+  <data name="ServiceReinstall_LblTask2" xml:space="preserve">
+    <value>Install Satellite Service</value>
+  </data>
+  <data name="ServiceReinstall_Title" xml:space="preserve">
+    <value>HASS.Agent Reinstall Satellite Service</value>
+  </data>
+  <data name="ServiceSetState_LblInfo1" xml:space="preserve">
+    <value>Please wait while the satellite service is configured..</value>
+  </data>
+  <data name="ServiceSetState_LblTask1" xml:space="preserve">
+    <value>Enable Satellite Service</value>
+  </data>
+  <data name="ServiceSetState_Title" xml:space="preserve">
+    <value>HASS.Agent Configure Satellite Service</value>
+  </data>
+  <data name="CommandMqttTopic_BtnClose" xml:space="preserve">
+    <value>&amp;Close</value>
+  </data>
+  <data name="CommandMqttTopic_LblInfo1" xml:space="preserve">
+    <value>This is the MQTT topic on which you can publish action commands:</value>
+  </data>
+  <data name="CommandMqttTopic_BtnCopyClipboard" xml:space="preserve">
+    <value>Copy &amp;to Clipboard</value>
+  </data>
+  <data name="CommandMqttTopic_LblHelp" xml:space="preserve">
+    <value>help and examples</value>
+  </data>
+  <data name="CommandMqttTopic_Title" xml:space="preserve">
+    <value>MQTT Action Topic</value>
+  </data>
+  <data name="CommandsConfig_BtnRemove" xml:space="preserve">
+    <value>&amp;Remove</value>
+  </data>
+  <data name="CommandsConfig_BtnModify" xml:space="preserve">
+    <value>&amp;Modify</value>
+  </data>
+  <data name="CommandsConfig_BtnAdd" xml:space="preserve">
+    <value>&amp;Add New</value>
+  </data>
+  <data name="CommandsConfig_BtnStore" xml:space="preserve">
+    <value>&amp;Store and Activate Commands</value>
+  </data>
+  <data name="CommandsConfig_ClmName" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="CommandsConfig_ClmType" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="CommandsConfig_LblLowIntegrity" xml:space="preserve">
+    <value>Low Integrity</value>
+  </data>
+  <data name="CommandsConfig_LblActionInfo" xml:space="preserve">
+    <value>Action</value>
+  </data>
+  <data name="CommandsConfig_Title" xml:space="preserve">
+    <value>Commands Config</value>
+  </data>
+  <data name="CommandsMod_BtnStore" xml:space="preserve">
+    <value>&amp;Store Command</value>
+  </data>
+  <data name="CommandsMod_LblSetting" xml:space="preserve">
+    <value>&amp;Configuration</value>
+  </data>
+  <data name="CommandsMod_LblName" xml:space="preserve">
+    <value>&amp;Name</value>
+  </data>
+  <data name="CommandsMod_LblDescription" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="CommandsMod_CbRunAsLowIntegrity" xml:space="preserve">
+    <value>&amp;Run as 'Low Integrity'</value>
+  </data>
+  <data name="CommandsMod_LblIntegrityInfo" xml:space="preserve">
+    <value>What's this?</value>
+  </data>
+  <data name="CommandsMod_ClmSensorName" xml:space="preserve">
+    <value>  Type</value>
+  </data>
+  <data name="CommandsMod_LblSelectedType" xml:space="preserve">
+    <value>Selected Type</value>
+  </data>
+  <data name="CommandsMod_LblService" xml:space="preserve">
+    <value>Service</value>
+  </data>
+  <data name="CommandsMod_LblAgent" xml:space="preserve">
+    <value>agent</value>
+  </data>
+  <data name="CommandsMod_LblSpecificClient" xml:space="preserve">
+    <value>HASS.Agent only!</value>
+  </data>
+  <data name="CommandsMod_LblEntityType" xml:space="preserve">
+    <value>&amp;Entity Type</value>
+  </data>
+  <data name="CommandsMod_LblMqttTopic" xml:space="preserve">
+    <value>Show MQTT Action Topic</value>
+  </data>
+  <data name="CommandsMod_LblActionInfo" xml:space="preserve">
+    <value>Action</value>
+  </data>
+  <data name="CommandsMod_Title" xml:space="preserve">
+    <value>Command</value>
+  </data>
+  <data name="QuickActions_LblLoading" xml:space="preserve">
+    <value>Retrieving entities, please wait..</value>
+  </data>
+  <data name="QuickActions_Title" xml:space="preserve">
+    <value>Quick Actions</value>
+  </data>
+  <data name="QuickActionsConfig_BtnStore" xml:space="preserve">
+    <value>&amp;Store Quick Actions</value>
+  </data>
+  <data name="QuickActionsConfig_BtnAdd" xml:space="preserve">
+    <value>&amp;Add New</value>
+  </data>
+  <data name="QuickActionsConfig_BtnModify" xml:space="preserve">
+    <value>&amp;Modify</value>
+  </data>
+  <data name="QuickActionsConfig_BtnRemove" xml:space="preserve">
+    <value>&amp;Remove</value>
+  </data>
+  <data name="QuickActionsConfig_BtnPreview" xml:space="preserve">
+    <value>&amp;Preview</value>
+  </data>
+  <data name="QuickActionsConfig_ClmDomain" xml:space="preserve">
+    <value>Domain</value>
+  </data>
+  <data name="QuickActionsConfig_ClmEntity" xml:space="preserve">
+    <value>Entity</value>
+  </data>
+  <data name="QuickActionsConfig_ClmAction" xml:space="preserve">
+    <value>Action</value>
+  </data>
+  <data name="QuickActionsConfig_ClmHotKey" xml:space="preserve">
+    <value>Hotkey</value>
+  </data>
+  <data name="QuickActionsConfig_ClmDescription" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="QuickActionsConfig_LblHotkey" xml:space="preserve">
+	  <value>Hotkey Enabled</value>
+  </data>
+  <data name="QuickActionsConfig_Title" xml:space="preserve">
+    <value>Quick Actions Configuration</value>
+  </data>
+  <data name="QuickActionsMod_BtnStore" xml:space="preserve">
+    <value>&amp;Store Quick Action</value>
+  </data>
+  <data name="QuickActionsMod_LblDomain" xml:space="preserve">
+    <value>Domain</value>
+  </data>
+  <data name="QuickActionsMod_LblEntityInfo" xml:space="preserve">
+    <value>&amp;Entity</value>
+  </data>
+  <data name="QuickActionsMod_LblAction" xml:space="preserve">
+    <value>Desired &amp;Action</value>
+  </data>
+  <data name="QuickActionsMod_LblDescription" xml:space="preserve">
+    <value>&amp;Description</value>
+  </data>
+  <data name="QuickActionsMod_LblLoading" xml:space="preserve">
+    <value>Retrieving entities, please wait..</value>
+  </data>
+  <data name="QuickActionsMod_CbEnableHotkey" xml:space="preserve">
+    <value>enable hotkey</value>
+  </data>
+  <data name="QuickActionsMod_LblHotkey" xml:space="preserve">
+    <value>&amp;hotkey combination</value>
+  </data>
+  <data name="QuickActionsMod_LblTip1" xml:space="preserve">
+    <value>(optional, will be used instead of entity name)</value>
+  </data>
+  <data name="QuickActionsMod_Title" xml:space="preserve">
+    <value>Quick Action</value>
+  </data>
+  <data name="SensorsConfig_BtnRemove" xml:space="preserve">
+    <value>&amp;Remove</value>
+  </data>
+  <data name="SensorsConfig_BtnModify" xml:space="preserve">
+    <value>&amp;Modify</value>
+  </data>
+  <data name="SensorsConfig_BtnAdd" xml:space="preserve">
+    <value>&amp;Add New</value>
+  </data>
+  <data name="SensorsConfig_BtnStore" xml:space="preserve">
+    <value>&amp;Store &amp;&amp; Activate Sensors</value>
+  </data>
+  <data name="SensorsConfig_ClmName" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="SensorsConfig_ClmType" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="SensorsConfig_LblRefresh" xml:space="preserve">
+    <value>Refresh</value>
+  </data>
+  <data name="SensorsConfig_Title" xml:space="preserve">
+    <value>Sensors Configuration</value>
+  </data>
+  <data name="SensorsMod_BtnStore" xml:space="preserve">
+    <value>&amp;Store Sensor</value>
+  </data>
+  <data name="SensorsMod_LblSetting1" xml:space="preserve">
+    <value>setting 1</value>
+  </data>
+  <data name="SensorsMod_LblType" xml:space="preserve">
+    <value>Selected Type</value>
+  </data>
+  <data name="SensorsMod_LblName" xml:space="preserve">
+    <value>&amp;Name</value>
+  </data>
+  <data name="SensorsMod_LblUpdate" xml:space="preserve">
+    <value>&amp;Update every</value>
+  </data>
+  <data name="SensorsMod_LblSeconds" xml:space="preserve">
+    <value>seconds</value>
+  </data>
+  <data name="SensorsMod_LblDescription" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="SensorsMod_LblSetting2" xml:space="preserve">
+    <value>Setting 2</value>
+  </data>
+  <data name="SensorsMod_LblSetting3" xml:space="preserve">
+    <value>Setting 3</value>
+  </data>
+  <data name="SensorsMod_ClmSensorName" xml:space="preserve">
+    <value>  Type</value>
+  </data>
+  <data name="SensorsMod_LblMultiValue" xml:space="preserve">
+	  <value>Multivalue</value>
+  </data>
+  <data name="SensorsMod_LblAgent" xml:space="preserve">
+    <value>Agent</value>
+  </data>
+  <data name="SensorsMod_LblService" xml:space="preserve">
+    <value>Service</value>
+  </data>
+  <data name="SensorsMod_LblSpecificClient" xml:space="preserve">
+    <value>HASS.Agent only!</value>
+  </data>
+  <data name="SensorsMod_Title" xml:space="preserve">
+    <value>Sensor</value>
+  </data>
+  <data name="ServiceConfig_TabGeneral" xml:space="preserve">
+    <value>     General     </value>
+  </data>
+  <data name="ServiceConfig_TabMqtt" xml:space="preserve">
+    <value>     MQTT     </value>
+  </data>
+  <data name="ServiceConfig_TabCommands" xml:space="preserve">
+    <value>     Commands     </value>
+  </data>
+  <data name="ServiceConfig_TabSensors" xml:space="preserve">
+    <value>     Sensors     </value>
+  </data>
+  <data name="ServiceConfig_Title" xml:space="preserve">
+    <value>Satellite Service Configuration</value>
+  </data>
+  <data name="About_BtnClose" xml:space="preserve">
+    <value>&amp;Close</value>
+  </data>
+  <data name="About_LblInfo1" xml:space="preserve">
+    <value>A Windows-based client for the Home Assistant platform.</value>
+  </data>
+  <data name="About_LblInfo3" xml:space="preserve">
+	  <value>This application is open source and completely free, please check the project pages of 
+the used components for their individual licenses:</value>
+  </data>
+  <data name="About_LblInfo4" xml:space="preserve">
+	  <value>A big 'thank you' to the developers of these projects, who were kind enough to share
+their hard work with the rest of us mere mortals. </value>
+  </data>
+  <data name="About_LblInfo5" xml:space="preserve">
+	  <value>And of course; thanks to Paulus Shoutsen and the entire team of developers that 
+created and maintain Home Assistant :-)</value>
+  </data>
+  <data name="About_LblInfo2" xml:space="preserve">
+    <value>Original created with even more love by</value>
+  </data>
+  <data name="About_LblInfo6" xml:space="preserve">
+    <value>HASS.Agent Team does not currently accept donations.
+If you like this tool however, support original (LAB02 Research) developers by buying them a cup of coffee:</value>
+  </data>
+  <data name="About_Title" xml:space="preserve">
+    <value>About</value>
+  </data>
+  <data name="Configuration_TabGeneral" xml:space="preserve">
+    <value>General</value>
+  </data>
+  <data name="Configuration_TabExternalTools" xml:space="preserve">
+    <value>External Tools</value>
+  </data>
+  <data name="Configuration_TabHassApi" xml:space="preserve">
+    <value>Home Assistant API</value>
+  </data>
+  <data name="Configuration_TabHotKey" xml:space="preserve">
+    <value>Hotkey</value>
+  </data>
+  <data name="Configuration_TabLocalStorage" xml:space="preserve">
+    <value>Local Storage</value>
+  </data>
+  <data name="Configuration_TabLogging" xml:space="preserve">
+    <value>Logging</value>
+  </data>
+  <data name="Configuration_TabMQTT" xml:space="preserve">
+    <value>MQTT</value>
+  </data>
+  <data name="Configuration_TabNotifications" xml:space="preserve">
+    <value>Notifications</value>
+  </data>
+  <data name="Configuration_TabService" xml:space="preserve">
+    <value>Satellite Service</value>
+  </data>
+  <data name="Configuration_TabStartup" xml:space="preserve">
+    <value>Startup</value>
+  </data>
+  <data name="Configuration_TabUpdates" xml:space="preserve">
+    <value>Updates</value>
+  </data>
+  <data name="Configuration_BtnAbout" xml:space="preserve">
+    <value>&amp;About</value>
+  </data>
+  <data name="Configuration_BtnHelp" xml:space="preserve">
+    <value>&amp;Help &amp;&amp; Contact</value>
+  </data>
+  <data name="Configuration_BtnStore" xml:space="preserve">
+    <value>&amp;Save Configuration</value>
+  </data>
+  <data name="Configuration_BtnClose" xml:space="preserve">
+    <value>Close &amp;Without Saving</value>
+  </data>
+  <data name="Configuration_Title" xml:space="preserve">
+    <value>Configuration</value>
+  </data>
+  <data name="ExitDialog_LblInfo1" xml:space="preserve">
+    <value>What would you like to do?</value>
+  </data>
+  <data name="ExitDialog_BtnRestart" xml:space="preserve">
+    <value>&amp;Restart</value>
+  </data>
+  <data name="ExitDialog_BtnHide" xml:space="preserve">
+    <value>&amp;Hide</value>
+  </data>
+  <data name="ExitDialog_BtnExit" xml:space="preserve">
+    <value>&amp;Exit</value>
+  </data>
+  <data name="ExitDialog_Title" xml:space="preserve">
+    <value>Exit Dialog</value>
+  </data>
+  <data name="Help_BtnClose" xml:space="preserve">
+    <value>&amp;Close</value>
+  </data>
+  <data name="Help_LblInfo1" xml:space="preserve">
+	  <value>If you are having trouble with HASS.Agent and require support
+with any sensors, commands, or for general support and feedback,
+there are few ways you can reach us:</value>
+  </data>
+  <data name="Help_LblAbout" xml:space="preserve">
+    <value>About</value>
+  </data>
+  <data name="Help_LblHAForum" xml:space="preserve">
+    <value>Home Assistant Forum</value>
+  </data>
+  <data name="Help_LblGitHub" xml:space="preserve">
+    <value>GitHub Issues</value>
+  </data>
+  <data name="Help_LblHAInfo" xml:space="preserve">
+	  <value>Bit of everything, with the addition that other
+HA users can help you out too!</value>
+  </data>
+  <data name="Help_LblGitHubInfo" xml:space="preserve">
+    <value>Report bugs, post feature requests, see latest changes, etc.</value>
+  </data>
+  <data name="Help_LblDiscordInfo" xml:space="preserve">
+	  <value>Get help with setting up and using HASS.Agent, 
+report bugs or get involved in general chit-chat!</value>
+  </data>
+  <data name="Help_LblWikiInfo" xml:space="preserve">
+    <value>Browse HASS.Agent documentation and usage examples.</value>
+  </data>
+  <data name="Help_Title" xml:space="preserve">
+    <value>Help</value>
+  </data>
+  <data name="Main_TsShow" xml:space="preserve">
+    <value>Show HASS.Agent</value>
+  </data>
+  <data name="Main_TsShowQuickActions" xml:space="preserve">
+    <value>Show Quick Actions</value>
+  </data>
+  <data name="Main_TsConfig" xml:space="preserve">
+    <value>Configuration</value>
+  </data>
+  <data name="Main_TsQuickItemsConfig" xml:space="preserve">
+    <value>Manage Quick Actions</value>
+  </data>
+  <data name="Main_TsLocalSensors" xml:space="preserve">
+    <value>Manage Local Sensors</value>
+  </data>
+  <data name="Main_TsCommands" xml:space="preserve">
+    <value>Manage Commands</value>
+  </data>
+  <data name="Main_CheckForUpdates" xml:space="preserve">
+    <value>Check for Updates</value>
+  </data>
+  <data name="Main_TsDonate" xml:space="preserve">
+    <value>Donate</value>
+  </data>
+  <data name="Main_TsHelp" xml:space="preserve">
+    <value>Help &amp;&amp; Contact</value>
+  </data>
+  <data name="Main_TsAbout" xml:space="preserve">
+    <value>About</value>
+  </data>
+  <data name="Main_TsExit" xml:space="preserve">
+    <value>Exit HASS.Agent</value>
+  </data>
+  <data name="Main_BtnHide" xml:space="preserve">
+    <value>&amp;Hide</value>
+  </data>
+  <data name="Main_GpControls" xml:space="preserve">
+    <value>Controls</value>
+  </data>
+  <data name="Main_BtnServiceManager" xml:space="preserve">
+    <value>S&amp;atellite Service</value>
+  </data>
+  <data name="Main_BtnAppSettings" xml:space="preserve">
+    <value>C&amp;onfiguration</value>
+  </data>
+  <data name="Main_BtnActionsManager" xml:space="preserve">
+    <value>&amp;Quick Actions</value>
+  </data>
+  <data name="Main_BtnCommandsManager" xml:space="preserve">
+    <value>Loading..</value>
+  </data>
+  <data name="Main_BtnSensorsManager" xml:space="preserve">
+    <value>Loading..</value>
+  </data>
+  <data name="Main_GpStatus" xml:space="preserve">
+    <value>System Status</value>
+  </data>
+  <data name="Main_LblService" xml:space="preserve">
+    <value>Satellite Service:</value>
+  </data>
+  <data name="Main_LblCommands" xml:space="preserve">
+    <value>Commands:</value>
+  </data>
+  <data name="Main_LblSensors" xml:space="preserve">
+    <value>Sensors:</value>
+  </data>
+  <data name="Main_LblQuickActions" xml:space="preserve">
+    <value>Quick Actions:</value>
+  </data>
+  <data name="Main_LblHomeAssistantApi" xml:space="preserve">
+    <value>Home Assistant API:</value>
+  </data>
+  <data name="Main_LblNotificationApi" xml:space="preserve">
+    <value>notification api:</value>
+  </data>
+  <data name="Onboarding_BtnNext" xml:space="preserve">
+    <value>&amp;Next</value>
+  </data>
+  <data name="Onboarding_BtnClose" xml:space="preserve">
+    <value>&amp;Close</value>
+  </data>
+  <data name="Onboarding_BtnPrevious" xml:space="preserve">
+    <value>&amp;Previous</value>
+  </data>
+  <data name="Onboarding_Onboarding" xml:space="preserve">
+    <value>HASS.Agent Onboarding</value>
+  </data>
+  <data name="UpdatePending_BtnDownload" xml:space="preserve">
+    <value>Fetching info, please wait..</value>
+  </data>
+  <data name="UpdatePending_LblNewReleaseInfo" xml:space="preserve">
+    <value>There's a new release available:</value>
+  </data>
+  <data name="UpdatePending_LblInfo1" xml:space="preserve">
+    <value>Release notes</value>
+  </data>
+  <data name="UpdatePending_BtnIgnore" xml:space="preserve">
+    <value>&amp;Ignore Update</value>
+  </data>
+  <data name="UpdatePending_LblRelease" xml:space="preserve">
+    <value>Release Page</value>
+  </data>
+  <data name="UpdatePending_Title" xml:space="preserve">
+    <value>HASS.Agent Update</value>
+  </data>
+  <data name="CommandsManager_CustomCommandDescription" xml:space="preserve">
+	  <value>Execute a custom command.
+
+These commands run without special elevation. To run elevated, create a Scheduled Task, and use 'schtasks /Run /TN "TaskName"' as the command to execute your task.
+
+Or enable 'run as low integrity' for even stricter execution.</value>
+  </data>
+  <data name="CommandsManager_CustomExecutorCommandDescription" xml:space="preserve">
+	  <value>Executes the command through the configured custom executor (in Configuration -&gt; External Tools).
+
+Your command is provided as an argument 'as is', so you have to supply your own quotes etc. if necessary.</value>
+  </data>
+  <data name="CommandsManager_HibernateCommandDescription" xml:space="preserve">
+    <value>Sets the machine in hibernation.</value>
+  </data>
+  <data name="CommandsManager_KeyCommandDescription" xml:space="preserve">
+	  <value>Simulates a single keypress.
+Making this command a "switch" type will make the button pressed as long as the switch is turned on.
+
+Click on the 'keycode' textbox and press the key you want simulated. The corresponding keycode will be entered for you.
+For TAB key please use LCTRL+TAB.
+
+If you need more keys and/or modifiers like CTRL, use the MultipleKeys command.</value>
+  </data>
+  <data name="CommandsManager_LaunchUrlCommandDescription" xml:space="preserve">
+	  <value>Launches the provided URL, by default in your default browser.
+
+To use 'incognito', provide a specific browser in Configuration -&gt; External Tools.
+
+If you just want a window with a specific URL (not an entire browser), use a 'WebView' command.</value>
+  </data>
+  <data name="CommandsManager_LockCommandDescription" xml:space="preserve">
+    <value>Locks the current session.</value>
+  </data>
+  <data name="CommandsManager_LogOffCommandDescription" xml:space="preserve">
+    <value>Logs off the current session.</value>
+  </data>
+  <data name="CommandsManager_MediaMuteCommandDescription" xml:space="preserve">
+    <value>Simulates 'Mute' key.</value>
+  </data>
+  <data name="CommandsManager_MediaNextCommandDescription" xml:space="preserve">
+    <value>Simulates 'Media Next' key.</value>
+  </data>
+  <data name="CommandsManager_MediaPlayPauseCommandDescription" xml:space="preserve">
+    <value>Simulates 'Media Pause/Play' key.</value>
+  </data>
+  <data name="CommandsManager_MediaPreviousCommandDescription" xml:space="preserve">
+    <value>Simulates 'Media Previous' key.</value>
+  </data>
+  <data name="CommandsManager_MediaVolumeDownCommandDescription" xml:space="preserve">
+    <value>Simulates 'Volume Down' key.</value>
+  </data>
+  <data name="CommandsManager_MediaVolumeUpCommandDescription" xml:space="preserve">
+    <value>Simulates 'Volume Up' key.</value>
+  </data>
+  <data name="CommandsManager_MultipleKeysCommandDescription" xml:space="preserve">
+	  <value>Simulates pressing mulitple keys.
+
+You need to put [ ] between every key, otherwise HASS.Agent can't tell them apart. So say you want to press X TAB Y SHIFT-Z, it'd be [X] [{TAB}] [Y] [+Z].
+
+There are a few tricks you can use:
+
+- If you want a bracket pressed, escape it, so [ is [\[] and ] is [\]] 
+
+- Special keys go between { }, like {TAB} or {UP}
+
+- Put a + in front of a key to add SHIFT, ^ for CTRL and % for ALT. So, +C is SHIFT-C. Or, +(CD) is SHIFT-C and SHIFT-D, while +CD is SHIFT-C and D
+
+- For multiple presses, use {z 15}, which means Z will get pressed 15 times.
+
+More info: https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.sendkeys</value>
+  </data>
+  <data name="CommandsManager_PowershellCommandDescription" xml:space="preserve">
+	  <value>Execute a Powershell command or script.
+
+You can either provide the location of a script (*.ps1), or a single-line command.
+
+This will run without special elevation.</value>
+  </data>
+  <data name="CommandsManager_PublishAllSensorsCommandDescription" xml:space="preserve">
+	  <value>Resets all sensor checks, forcing all sensors to process and send their value.
+
+Useful for example if you want to force HASS.Agent to update all your sensors after a HA reboot.</value>
+  </data>
+  <data name="CommandsManager_RestartCommandDescription" xml:space="preserve">
+	  <value>Restarts the machine after one minute.
+
+Tip: Accidentally triggered? Run 'shutdown /a' to abort shutdown.</value>
+  </data>
+  <data name="CommandsManager_ShutdownCommandDescription" xml:space="preserve">
+	  <value>Shuts down the machine after one minute.
+
+Tip: Accidentally triggered? Run 'shutdown /a' to abort shutdown.</value>
+  </data>
+  <data name="CommandsManager_SleepCommandDescription" xml:space="preserve">
+	  <value>Puts the machine to sleep.
+
+Note: due to a limitation in Windows, this only works if hibernation is disabled, otherwise it will just hibernate.
+
+You can use something like NirCmd (http://www.nirsoft.net/utils/nircmd.html) to circumvent this.</value>
+  </data>
+  <data name="ConfigExternalTools_BtnExternalBrowserIncognitoTest_MessageBox1" xml:space="preserve">
+    <value>Please enter the location of your browser's binary! (.exe file)</value>
+  </data>
+  <data name="ConfigExternalTools_ConfigExternalTools_BtnExternalBrowserIncognitoTest_MessageBox2" xml:space="preserve">
+    <value>The browser binary provided could not be found, please ensure the path is correct and try again.</value>
+  </data>
+  <data name="ConfigExternalTools_BtnExternalBrowserIncognitoTest_MessageBox3" xml:space="preserve">
+	  <value>No incognito arguments were provided so the browser will likely launch normally.
+
+Do you want to continue?</value>
+  </data>
+  <data name="ConfigExternalTools_BtnExternalBrowserIncognitoTest_MessageBox4" xml:space="preserve">
+	  <value>Something went wrong while launching your browser in incognito mode!
+
+Please check the logs for more information.</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox1" xml:space="preserve">
+    <value>Please enter a valid API key!</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox2" xml:space="preserve">
+    <value>Please enter a value for your Home Assistant's URI.</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox3" xml:space="preserve">
+	  <value>Unable to connect, the following error was returned:
+
+{0}</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox4" xml:space="preserve">
+	  <value>Connection OK!
+
+Home Assistant version: {0}</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearImageCache_MessageBox1" xml:space="preserve">
+    <value>Image cache has been cleared!</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearImageCache_InfoText1" xml:space="preserve">
+    <value>Cleaning..</value>
+  </data>
+  <data name="ConfigNotifications_BtnSendTestNotification_MessageBox1" xml:space="preserve">
+    <value>Notifications are currently disabled, please enable them and restart the HASS.Agent, then try again.</value>
+  </data>
+  <data name="ConfigNotifications_BtnSendTestNotification_MessageBox2" xml:space="preserve">
+	  <value>The test notification should have appeared, if you did not receive it please check the logs or consult the documentation for troubleshooting tips.
+
+Note: This only tests locally whether notifications can be shown!</value>
+  </data>
+  <data name="ConfigNotifications_TestNotification" xml:space="preserve">
+    <value>This is a test notification!</value>
+  </data>
+  <data name="ConfigNotifications_BtnExecutePortReservation_Busy" xml:space="preserve">
+    <value>Executing, please wait..</value>
+  </data>
+  <data name="ConfigNotifications_BtnExecutePortReservation_MessageBox1" xml:space="preserve">
+	  <value>Something went wrong whilst reserving the port!
+
+Manual execution is required and a command has been copied to your clipboard, please open an elevated terminal and paste the command.
+
+Additionally, remember to change your Firewall Rules port!</value>
+  </data>
+  <data name="ConfigService_NotInstalled" xml:space="preserve">
+    <value>Not Installed</value>
+  </data>
+  <data name="ConfigService_Disabled" xml:space="preserve">
+    <value>Disabled</value>
+  </data>
+  <data name="ConfigService_Running" xml:space="preserve">
+    <value>Running</value>
+  </data>
+  <data name="ConfigService_Stopped" xml:space="preserve">
+    <value>Stopped</value>
+  </data>
+  <data name="ConfigService_Failed" xml:space="preserve">
+    <value>Failed</value>
+  </data>
+  <data name="ConfigService_BtnStopService_MessageBox1" xml:space="preserve">
+	  <value>Something went wrong whilst stopping the service, did you allow the UAC prompt?
+
+Check the HASS.Agent (not the service) logs for more information.</value>
+  </data>
+  <data name="ConfigService_BtnStartService_MessageBox1" xml:space="preserve">
+	  <value>The service is set to 'disabled', so it cannot be started.
+
+Please enable the service first and try again.</value>
+  </data>
+  <data name="ConfigService_BtnStartService_MessageBox2" xml:space="preserve">
+	  <value>Something went wrong whilst starting the service, did you allow the UAC prompt?
+
+Check the HASS.Agent (not the service) logs for more information.</value>
+  </data>
+  <data name="ConfigService_BtnDisableService_MessageBox1" xml:space="preserve">
+	  <value>Something went wrong whilst disabling the service, did you allow the UAC prompt?
+
+Check the HASS.Agent (not the service) logs for more information.</value>
+  </data>
+  <data name="ConfigService_BtnEnableService_MessageBox1" xml:space="preserve">
+	  <value>Something went wrong whilst enabling the service, did you allow the UAC prompt?
+
+Check the HASS.Agent (not the service) logs for more information.</value>
+  </data>
+  <data name="ConfigService_BtnShowLogs_MessageBox1" xml:space="preserve">
+	  <value>Something went wrong whilst reinstalling the service, did you allow the UAC prompt?
+
+Check the HASS.Agent (not the service) logs for more information.</value>
+  </data>
+  <data name="ConfigStartup_BtnSetStartOnLogin_MessageBox1" xml:space="preserve">
+    <value>Something went wrong whilst disabling Start-on-Login, please check the logs for more information.</value>
+  </data>
+  <data name="ConfigStartup_BtnSetStartOnLogin_MessageBox2" xml:space="preserve">
+    <value>Something went wrong whilst disabling Start-on-Login, please check the logs for more information.</value>
+  </data>
+  <data name="ConfigStartup_Enabled" xml:space="preserve">
+    <value>Enabled</value>
+  </data>
+  <data name="ConfigStartup_Disable" xml:space="preserve">
+    <value>Disable Start-on-Login</value>
+  </data>
+  <data name="ConfigStartup_Disabled" xml:space="preserve">
+    <value>Disabled</value>
+  </data>
+  <data name="ConfigStartup_Enable" xml:space="preserve">
+    <value>Enable Start-on-Login</value>
+  </data>
+  <data name="OnboardingStartup_Activated" xml:space="preserve">
+    <value>Start-on-Login has been activated!</value>
+  </data>
+  <data name="OnboardingStartup_EnableNow" xml:space="preserve">
+    <value>Do you want to enable Start-on-Login now?</value>
+  </data>
+  <data name="OnboardingStartup_AlreadyActivated" xml:space="preserve">
+    <value>Start-on-Login is already activated, all set!</value>
+  </data>
+  <data name="OnboardingStartup_Activating" xml:space="preserve">
+    <value>Activating Start-on-Login..</value>
+  </data>
+  <data name="OnboardingStartup_Failed" xml:space="preserve">
+    <value>Something went wrong. You can try again, or skip to the next page and retry after HASS.Agent's restart.</value>
+  </data>
+  <data name="OnboardingStartup_BtnSetLaunchOnLogin_2" xml:space="preserve">
+    <value>Enable Start-on-Login</value>
+  </data>
+  <data name="OnboardingApi_BtnTest_MessageBox1" xml:space="preserve">
+    <value>Please provide a valid API key.</value>
+  </data>
+  <data name="OnboardingApi_BtnTest_MessageBox2" xml:space="preserve">
+    <value>Please enter your Home Assistant's URI.</value>
+  </data>
+  <data name="OnboardingApi_BtnTest_MessageBox3" xml:space="preserve">
+	  <value>Unable to connect, the following error was returned:
+
+{0}</value>
+  </data>
+  <data name="OnboardingApi_BtnTest_MessageBox4" xml:space="preserve">
+	  <value>Connection OK!
+
+Home Assistant version: {0}</value>
+  </data>
+  <data name="OnboardingApi_BtnTest_Testing" xml:space="preserve">
+    <value>Testing..</value>
+  </data>
+  <data name="ServiceCommands_BtnStore_MessageBox1" xml:space="preserve">
+    <value>An error occurred whilst saving your commands, please check the logs for more information.</value>
+  </data>
+  <data name="ServiceCommands_BtnStore_Storing" xml:space="preserve">
+    <value>Storing and registering, please wait..</value>
+  </data>
+  <data name="ServiceConnect_Connecting" xml:space="preserve">
+    <value>Connecting with satellite service, please wait..</value>
+  </data>
+  <data name="ServiceConnect_Failed" xml:space="preserve">
+    <value>Connecting to the service has failed!</value>
+  </data>
+  <data name="ServiceConnect_FailedMessage" xml:space="preserve">
+	  <value>The service hasn't been found! You can install and manage it from the configuration panel.
+
+When it's up and running, come back here to configure the commands and sensors.</value>
+  </data>
+  <data name="ServiceConnect_CommunicationFailed" xml:space="preserve">
+    <value>Communicating with the service has failed!</value>
+  </data>
+  <data name="ServiceConnect_CommunicationFailedMessage" xml:space="preserve">
+	  <value>Unable to communicate with the service. Check the logs for more info.
+
+You can open the logs and manage the service from the configuration panel.</value>
+  </data>
+  <data name="ServiceConnect_Unauthorized" xml:space="preserve">
+    <value>Unauthorized</value>
+  </data>
+  <data name="ServiceConnect_UnauthorizedMessage" xml:space="preserve">
+	  <value>You are not authorized to contact the service.
+
+If you have the correct auth ID, you can set it now and try again.</value>
+  </data>
+  <data name="ServiceConnect_SettingsFailed" xml:space="preserve">
+    <value>Fetching settings failed!</value>
+  </data>
+  <data name="ServiceConnect_SettingsFailedMessage" xml:space="preserve">
+	  <value>The service returned an error while requesting its settings. Check the logs for more info.
+
+You can open the logs and manage the service from the configuration panel.</value>
+  </data>
+  <data name="ServiceConnect_MqttFailed" xml:space="preserve">
+    <value>Fetching MQTT settings failed!</value>
+  </data>
+  <data name="ServiceConnect_MqttFailedMessage" xml:space="preserve">
+	  <value>The service returned an error while requesting its MQTT settings. Check the logs for more info.
+
+You can open the logs and manage the service from the configuration panel.</value>
+  </data>
+  <data name="ServiceConnect_CommandsFailed" xml:space="preserve">
+    <value>Fetching configured commands failed!</value>
+  </data>
+  <data name="ServiceConnect_CommandsFailedMessage" xml:space="preserve">
+	  <value>The service returned an error while requesting its configured commands. Check the logs for more info.
+
+You can open the logs and manage the service from the configuration panel.</value>
+  </data>
+  <data name="ServiceConnect_SensorsFailed" xml:space="preserve">
+    <value>Fetching configured sensors failed!</value>
+  </data>
+  <data name="ServiceConnect_SensorsFailedMessage" xml:space="preserve">
+	  <value>The service returned an error while requesting its configured sensors. Check the logs for more info.
+
+You can open the logs and manage the service from the configuration panel.</value>
+  </data>
+  <data name="ServiceGeneral_TbAuthId_MessageBox1" xml:space="preserve">
+	  <value>Storing an empty auth ID will allow all HASS.Agent to access the service.
+
+Are you sure you want this?</value>
+  </data>
+  <data name="ServiceGeneral_SavingFailedMessageBox" xml:space="preserve">
+    <value>An error occurred whilst saving, check the logs for more information.</value>
+  </data>
+  <data name="ServiceGeneral_BtnStoreDeviceName_MessageBox1" xml:space="preserve">
+    <value>Please provide a device name!</value>
+  </data>
+  <data name="ServiceGeneral_BtnStoreCustomExecutor_MessageBox1" xml:space="preserve">
+    <value>Please select an executor first. (Tip: Double click to Browse)</value>
+  </data>
+  <data name="ServiceGeneral_BtnStoreCustomExecutor_MessageBox2" xml:space="preserve">
+    <value>The selected executor could not be found, please ensure the path provided is correct and try again.</value>
+  </data>
+  <data name="ServiceGeneral_LblAuthIdInfo_MessageBox1" xml:space="preserve">
+	  <value>Set an auth ID if you don't want every instance of HASS.Agent on this PC to connect with the satellite service.
+
+Only the instances that have the correct ID, can connect.
+
+Leave empty to allow all to connect.</value>
+  </data>
+  <data name="ServiceGeneral_LblDeviceNameInfo_MessageBox1" xml:space="preserve">
+	  <value>This is the name with which the satellite service registers itself on Home Assistant.
+
+By default, it's your PC's name plus '-satellite'.</value>
+  </data>
+  <data name="ServiceGeneral_LblDisconGraceInfo_MessageBox1" xml:space="preserve">
+    <value>The amount of time the satellite service will wait before reporting a lost connection to the MQTT broker.</value>
+  </data>
+  <data name="ServiceMqtt_StatusError" xml:space="preserve">
+    <value>Error fetching status, please check logs for information.</value>
+  </data>
+  <data name="ServiceMqtt_BtnStore_MessageBox1" xml:space="preserve">
+    <value>An error occurred whilst saving the configuration, please check the logs for more information.</value>
+  </data>
+  <data name="ServiceMqtt_BtnStore_Storing" xml:space="preserve">
+    <value>Storing and registering, please wait..</value>
+  </data>
+  <data name="ServiceSensors_BtnStore_MessageBox1" xml:space="preserve">
+    <value>An error occurred whilst saving the sensors, please check the logs for more information.</value>
+  </data>
+  <data name="ServiceSensors_BtnStore_Storing" xml:space="preserve">
+    <value>Storing and registering, please wait..</value>
+  </data>
+  <data name="PortReservation_ProcessPostUpdate_MessageBox1" xml:space="preserve">
+    <value>Not all steps completed succesfully. Please consult the logs for more information.</value>
+  </data>
+  <data name="PostUpdate_ProcessPostUpdate_MessageBox1" xml:space="preserve">
+    <value>Not all steps completed succesfully. Please consult the logs for more information.</value>
+  </data>
+  <data name="Restart_ProcessRestart_MessageBox1" xml:space="preserve">
+	  <value>HASS.Agent is still active after {0} seconds. Please close all instances and restart manually.
+
+Check the logs for more info, and optionally inform the developers.</value>
+  </data>
+  <data name="ServiceReinstall_ProcessReinstall_MessageBox1" xml:space="preserve">
+    <value>Not all steps completed successfully, please check the logs for more information.</value>
+  </data>
+  <data name="ServiceSetState_Enabled" xml:space="preserve">
+    <value>Enable Satellite Service</value>
+  </data>
+  <data name="ServiceSetState_Disabled" xml:space="preserve">
+    <value>Disable Satellite Service</value>
+  </data>
+  <data name="ServiceSetState_Started" xml:space="preserve">
+    <value>Start Satellite Service</value>
+  </data>
+  <data name="ServiceSetState_Stopped" xml:space="preserve">
+    <value>Stop Satellite Service</value>
+  </data>
+  <data name="ServiceSetState_ProcessState_MessageBox1" xml:space="preserve">
+	  <value>Something went wrong while processing the desired service state.
+
+Please consult the logs for more information.</value>
+  </data>
+  <data name="CommandMqttTopic_BtnCopyClipboard_Copied" xml:space="preserve">
+    <value>Topic copied to clipboard!</value>
+  </data>
+  <data name="CommandsConfig_BtnStore_Storing" xml:space="preserve">
+    <value>Storing and registering, please wait..</value>
+  </data>
+  <data name="CommandsConfig_BtnStore_MessageBox1" xml:space="preserve">
+    <value>An error occurred whilst saving commands, please check the logs for more information.</value>
+  </data>
+  <data name="CommandsMod_Title_NewCommand" xml:space="preserve">
+    <value>New Command</value>
+  </data>
+  <data name="CommandsMod_Title_ModCommand" xml:space="preserve">
+    <value>Mod Command</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox1" xml:space="preserve">
+    <value>Please select a command type!</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox2" xml:space="preserve">
+    <value>Please select a valid command type!</value>
+  </data>
+  <data name="CommandsMod_MessageBox_EntityType" xml:space="preserve">
+    <value>Select a valid entity type first.</value>
+  </data>
+  <data name="CommandsMod_MessageBox_Name" xml:space="preserve">
+    <value>Please provide a name!</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox3" xml:space="preserve">
+    <value>A command with that name already exists, are you sure you want to continue?</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox4" xml:space="preserve">
+	  <value>If a command is not provided, you may only use this entity with an 'action' value via Home Assistant, running it as-is will have no action.
+
+Are you sure you want to proceed?</value>
+  </data>
+  <data name="CommandsMod_MessageBox_Action" xml:space="preserve">
+	  <value>If you don't enter a command or script, you can only use this entity with an 'action' value through Home Assistant. Running it as-is won't do anything.
+
+Are you sure you want this?</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox5" xml:space="preserve">
+    <value>Please enter a key code!</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox6" xml:space="preserve">
+    <value>Checking keys failed: {0}</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox7" xml:space="preserve">
+	  <value>If a URL is not provided, you may only use this entity with an 'action' value via Home Assistant, running it as-is will have no action.
+
+Are you sure you want to proceed?</value>
+  </data>
+  <data name="CommandsMod_LblSetting_Command" xml:space="preserve">
+    <value>Command</value>
+  </data>
+  <data name="CommandsMod_LblSetting_CommandScript" xml:space="preserve">
+    <value>Command or Script</value>
+  </data>
+  <data name="CommandsMod_LblSetting_KeyCode" xml:space="preserve">
+    <value>Keycode</value>
+  </data>
+  <data name="CommandsMod_LblSetting_KeyCodes" xml:space="preserve">
+    <value>Keycodes</value>
+  </data>
+  <data name="CommandsMod_CbCommandSpecific_Incognito" xml:space="preserve">
+    <value>Launch in Incognito Mode</value>
+  </data>
+  <data name="CommandsMod_LblInfo_Browser" xml:space="preserve">
+	  <value>Browser: Default
+
+Please configure a custom browser to enable incognito mode.</value>
+  </data>
+  <data name="CommandsMod_LblSetting_Url" xml:space="preserve">
+    <value>URL</value>
+  </data>
+  <data name="CommandsMod_LblInfo_BrowserSpecific" xml:space="preserve">
+    <value>Browser: {0}</value>
+  </data>
+  <data name="CommandsMod_LblInfo_Executor" xml:space="preserve">
+	  <value>Executor: None
+
+Please configure an executor or your command will not run.</value>
+  </data>
+  <data name="CommandsMod_LblInfo_ExecutorSpecific" xml:space="preserve">
+    <value>Executor: {0}</value>
+  </data>
+  <data name="CommandsMod_LblIntegrityInfo_InfoMsg1" xml:space="preserve">
+    <value>Low integrity means your command will be executed with restricted privileges.</value>
+  </data>
+  <data name="CommandsMod_LblIntegrityInfo_InfoMsg2" xml:space="preserve">
+    <value>This means it will only be able to save and modify files in certain locations,</value>
+  </data>
+  <data name="CommandsMod_LblIntegrityInfo_InfoMsg3" xml:space="preserve">
+    <value>such as the '%USERPROFILE%\AppData\LocalLow' folder or</value>
+  </data>
+  <data name="CommandsMod_LblIntegrityInfo_InfoMsg4" xml:space="preserve">
+    <value>the 'HKEY_CURRENT_USER\Software\AppDataLow' registry key.</value>
+  </data>
+  <data name="CommandsMod_LblIntegrityInfo_InfoMsg5" xml:space="preserve">
+    <value>You should test your command to make sure it's not influenced by this!</value>
+  </data>
+  <data name="CommandsMod_SpecificClient" xml:space="preserve">
+    <value>{0} only!</value>
+  </data>
+  <data name="CommandsMod_LblMqttTopic_MessageBox1" xml:space="preserve">
+    <value>The MQTT manager hasn't been configured properly, or hasn't yet completed its startup.</value>
+  </data>
+  <data name="QuickActions_CheckHassManager_MessageBox1" xml:space="preserve">
+    <value>Unable to fetch your entities because of missing config, please enter the required values in the config screen.</value>
+  </data>
+  <data name="QuickActions_MessageBox_EntityFailed" xml:space="preserve">
+    <value>There was an error trying to fetch your entities!</value>
+  </data>
+  <data name="QuickActionsMod_Title_New" xml:space="preserve">
+    <value>New Quick Action</value>
+  </data>
+  <data name="QuickActionsMod_Title_Mod" xml:space="preserve">
+    <value>Mod Quick Action</value>
+  </data>
+  <data name="QuickActionsMod_CheckHassManager_MessageBox1" xml:space="preserve">
+    <value>Unable to fetch your entities because of missing config, please enter the required values in the config screen.</value>
+  </data>
+  <data name="QuickActionsMod_MessageBox_Entities" xml:space="preserve">
+    <value>There was an error trying to fetch your entities.</value>
+  </data>
+  <data name="QuickActionsMod_BtnStore_MessageBox1" xml:space="preserve">
+    <value>Please select an entity!</value>
+  </data>
+  <data name="QuickActionsMod_BtnStore_MessageBox2" xml:space="preserve">
+    <value>Please select an domain!</value>
+  </data>
+  <data name="QuickActionsMod_BtnStore_MessageBox3" xml:space="preserve">
+    <value>Unknown action, please select a valid one.</value>
+  </data>
+  <data name="SensorsConfig_BtnStore_Storing" xml:space="preserve">
+    <value>Storing and registering, please wait..</value>
+  </data>
+  <data name="SensorsConfig_BtnStore_MessageBox1" xml:space="preserve">
+    <value>An error occurred whilst saving the sensors, please check the logs for more information.</value>
+  </data>
+  <data name="SensorsMod_Title_New" xml:space="preserve">
+    <value>New Sensor</value>
+  </data>
+  <data name="SensorsMod_Title_Mod" xml:space="preserve">
+    <value>Mod Sensor</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_WindowName" xml:space="preserve">
+    <value>Window Name</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_Wmi" xml:space="preserve">
+    <value>WMI Query</value>
+  </data>
+  <data name="SensorsMod_LblSetting2_Wmi" xml:space="preserve">
+    <value>WMI Scope (optional)</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_Category" xml:space="preserve">
+    <value>Category</value>
+  </data>
+  <data name="SensorsMod_LblSetting2_Counter" xml:space="preserve">
+    <value>Counter</value>
+  </data>
+  <data name="SensorsMod_LblSetting3_Instance" xml:space="preserve">
+    <value>Instance (optional)</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_Process" xml:space="preserve">
+    <value>Process</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_Service" xml:space="preserve">
+    <value>Service</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox1" xml:space="preserve">
+    <value>Please select a sensor type!</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox2" xml:space="preserve">
+    <value>Please select a valid sensor type!</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox3" xml:space="preserve">
+    <value>Please provide a name!</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox4" xml:space="preserve">
+    <value>A single-value sensor already exists with that name, are you sure you want to proceed?</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox5" xml:space="preserve">
+    <value>A multi-value sensor already exists with that name, are you sure you want to proceed?</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox6" xml:space="preserve">
+    <value>Please provide an interval between 1 and 43200 (12 hours)!</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox7" xml:space="preserve">
+    <value>Please enter a window name!</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox8" xml:space="preserve">
+    <value>Please enter a query!</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox9" xml:space="preserve">
+    <value>Please enter a category and instance!</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox10" xml:space="preserve">
+    <value>Please enter the name of a process!</value>
+  </data>
+  <data name="SensorsMod_BtnStore_MessageBox11" xml:space="preserve">
+    <value>Please enter the name of a service!</value>
+  </data>
+  <data name="SensorsMod_SpecificClient" xml:space="preserve">
+    <value>{0} only!</value>
+  </data>
+  <data name="Configuration_ProcessChanges_MessageBox1" xml:space="preserve">
+	  <value>You've changed your device's name.
+
+All your sensors and commands will now be unpublished, and HASS.Agent will restart afterwards to republish them.
+
+Don't worry, they'll keep their current names, so your automations or scripts will keep working.
+
+Note: the name will get 'sanitized', which means everything except letters, digits and whitespace get replaced by an underscore. This is required by HA.</value>
+  </data>
+  <data name="Configuration_ProcessChanges_MessageBox2" xml:space="preserve">
+	  <value>You've changed the local API's port. This new port needs to be reserved.
+
+You'll get an UAC request to do so, please approve.</value>
+  </data>
+  <data name="Configuration_ProcessChanges_MessageBox3" xml:space="preserve">
+	  <value>Something went wrong!
+
+Please manually execute the required command. It has been copied onto your clipboard, you just need to paste it into an elevated command prompt.
+
+Remember to change your firewall rule's port as well.</value>
+  </data>
+  <data name="Configuration_ProcessChanges_MessageBox4" xml:space="preserve">
+	  <value>The port has succesfully been reserved!
+
+HASS.Agent will now restart to activate the new configuration.</value>
+  </data>
+  <data name="Configuration_MessageBox_RestartManually" xml:space="preserve">
+	  <value>Something went wrong while preparing to restart.
+Please restart manually.</value>
+  </data>
+  <data name="Configuration_ProcessChanges_MessageBox5" xml:space="preserve">
+	  <value>Your configuration has been saved. Most changes require HASS.Agent to restart before they take effect.
+
+Do you want to restart now?</value>
+  </data>
+  <data name="Main_Load_MessageBox1" xml:space="preserve">
+	  <value>Something went wrong while loading your settings.
+
+Check appsettings.json in the 'config' subfolder, or just delete it to start fresh.</value>
+  </data>
+  <data name="Main_Load_MessageBox2" xml:space="preserve">
+	  <value>There was an error launching HASS.Agent.
+Please check the logs and make a bug report on GitHub.</value>
+  </data>
+  <data name="Main_BtnSensorsManage_Ready" xml:space="preserve">
+	  <value>&amp;Sensors</value>
+  </data>
+  <data name="Main_BtnCommandsManager_Ready" xml:space="preserve">
+    <value>&amp;Commands</value>
+  </data>
+  <data name="Main_Checking" xml:space="preserve">
+    <value>Checking..</value>
+  </data>
+  <data name="Main_CheckForUpdate_MessageBox1" xml:space="preserve">
+    <value>You're running the latest version: {0}{1}</value>
+  </data>
+  <data name="UpdatePending_NewBetaRelease" xml:space="preserve">
+    <value>There's a new BETA release available:</value>
+  </data>
+  <data name="UpdatePending_Title_Beta" xml:space="preserve">
+    <value>HASS.Agent BETA Update</value>
+  </data>
+  <data name="UpdatePending_LblUpdateQuestion_Download" xml:space="preserve">
+    <value>Do you want to &amp;download and launch the installer?</value>
+  </data>
+  <data name="UpdatePending_LblUpdateQuestion_Navigate" xml:space="preserve">
+    <value>Do you want to &amp;navigate to the release page?</value>
+  </data>
+  <data name="UpdatePending_InstallUpdate" xml:space="preserve">
+    <value>Install Update</value>
+  </data>
+  <data name="UpdatePending_InstallBetaRelease" xml:space="preserve">
+    <value>Install Beta Release</value>
+  </data>
+  <data name="UpdatePending_OpenReleasePage" xml:space="preserve">
+    <value>Open Release Page</value>
+  </data>
+  <data name="UpdatePending_OpenBetaReleasePage" xml:space="preserve">
+    <value>Open Beta Release Page</value>
+  </data>
+  <data name="UpdatePending_LblUpdateQuestion_Processing" xml:space="preserve">
+    <value>Processing request, please wait..</value>
+  </data>
+  <data name="UpdatePending_BtnDownload_Processing" xml:space="preserve">
+    <value>Processing..</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_Start" xml:space="preserve">
+    <value>HASS.Agent Onboarding: Start [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_Startup" xml:space="preserve">
+    <value>HASS.Agent Onboarding: Startup [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_Notifications" xml:space="preserve">
+    <value>HASS.Agent Onboarding: Notifications [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_Integration" xml:space="preserve">
+    <value>HASS.Agent Onboarding: Integration [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_Api" xml:space="preserve">
+    <value>HASS.Agent Onboarding: API [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_Mqtt" xml:space="preserve">
+    <value>HASS.Agent Onboarding: MQTT [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_HotKey" xml:space="preserve">
+    <value>HASS.Agent Onboarding: HotKey [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_Updates" xml:space="preserve">
+    <value>HASS.Agent Onboarding: Updates [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_OnboardingTitle_Completed" xml:space="preserve">
+    <value>HASS.Agent Onboarding: Completed [{0}/{1}]</value>
+  </data>
+  <data name="OnboardingManager_ConfirmBeforeClose_MessageBox1" xml:space="preserve">
+	  <value>Are you sure you want to abort the onboarding process?
+
+Your progress will not be saved, and it will not be shown again on next launch.</value>
+  </data>
+  <data name="UpdateManager_GetLatestVersionInfo_Error" xml:space="preserve">
+    <value>Error fetching info, please check logs for more information.</value>
+  </data>
+  <data name="UpdateManager_DownloadAndExecuteUpdate_MessageBox1" xml:space="preserve">
+	  <value>Unable to prepare downloading the update, check the logs for more info.
+
+The release page will now open instead.</value>
+  </data>
+  <data name="UpdateManager_DownloadAndExecuteUpdate_MessageBox2" xml:space="preserve">
+	  <value>Unable to download the update, check the logs for more info.
+
+The release page will now open instead.</value>
+  </data>
+  <data name="UpdateManager_DownloadAndExecuteUpdate_MessageBox3" xml:space="preserve">
+	  <value>The downloaded file FAILED the certificate check.
+
+This could be a technical error, but also a tampered file!
+
+Please check the logs, and post a ticket with the findings.</value>
+  </data>
+  <data name="UpdateManager_DownloadAndExecuteUpdate_MessageBox4" xml:space="preserve">
+	  <value>Unable to launch the installer (did you approve the UAC prompt?), check the logs for more info.
+
+The release page will now open instead.</value>
+  </data>
+  <data name="HassApiManager_ToolTip_ConnectionSetupFailed" xml:space="preserve">
+    <value>HASS API: Connection setup failed.</value>
+  </data>
+  <data name="HassApiManager_ToolTip_InitialConnectionFailed" xml:space="preserve">
+    <value>HASS API: Initial connection failed.</value>
+  </data>
+  <data name="HassApiManager_ToolTip_ConnectionFailed" xml:space="preserve">
+    <value>HASS API: Connection failed.</value>
+  </data>
+  <data name="HassApiManager_CheckHassConfig_CertNotFound" xml:space="preserve">
+    <value>Client certificate file not found.</value>
+  </data>
+  <data name="HassApiManager_CheckHassConfig_UnableToConnect" xml:space="preserve">
+    <value>Unable to connect, check URI.</value>
+  </data>
+  <data name="HassApiManager_CheckHassConfig_ConfigFailed" xml:space="preserve">
+    <value>Unable to fetch configuration, please check API key.</value>
+  </data>
+  <data name="HassApiManager_ConnectionFailed" xml:space="preserve">
+    <value>Unable to connect, please check URI and configuration.</value>
+  </data>
+  <data name="HassApiManager_ToolTip_QuickActionFailed" xml:space="preserve">
+    <value>quick action: action failed, check the logs for info</value>
+  </data>
+  <data name="HassApiManager_ToolTip_QuickActionFailedOnEntity" xml:space="preserve">
+    <value>quick action: action failed, entity not found</value>
+  </data>
+  <data name="MqttManager_ToolTip_ConnectionError" xml:space="preserve">
+    <value>MQTT: Error while connecting</value>
+  </data>
+  <data name="MqttManager_ToolTip_ConnectionFailed" xml:space="preserve">
+    <value>MQTT: Failed to connect</value>
+  </data>
+  <data name="MqttManager_ToolTip_Disconnected" xml:space="preserve">
+    <value>MQTT: Disconnected</value>
+  </data>
+  <data name="NotifierManager_Initialize_MessageBox1" xml:space="preserve">
+	  <value>Error trying to bind the API to port {0}.
+
+Make sure no other instance of HASS.Agent is running and the port is available and registered.</value>
+  </data>
+  <data name="SensorsManager_ActiveWindowSensorDescription" xml:space="preserve">
+    <value>Provides the title of the current active window.</value>
+  </data>
+  <data name="SensorsManager_AudioSensorsDescription" xml:space="preserve">
+	  <value>Provides information various aspects of your device's audio:
+
+Current peak volume level (can be used as a simple 'is something playing' value).
+
+Default audio device: name, state and volume.
+
+Summary of your audio sessions: application name, muted state, volume and current peak volume.</value>
+  </data>
+  <data name="SensorsManager_BatterySensorsDescription" xml:space="preserve">
+    <value>Provides a sensor with the current charging status, estimated amount of minutes on a full charge, remaining charge as a percentage, remaining charge in minutes and the powerline status.</value>
+  </data>
+  <data name="SensorsManager_CpuLoadSensorDescription" xml:space="preserve">
+    <value>Provides the current load of the first CPU as a percentage.</value>
+  </data>
+  <data name="SensorsManager_CurrentClockSpeedSensorDescription" xml:space="preserve">
+    <value>Provides the current clockspeed of the first CPU.</value>
+  </data>
+  <data name="SensorsManager_CurrentVolumeSensorDescription" xml:space="preserve">
+	  <value>Provides the current volume level as a percentage.
+
+Currently takes the volume of your default device.</value>
+  </data>
+  <data name="SensorsManager_DisplaySensorsDescription" xml:space="preserve">
+    <value>Provides a sensor with the amount of displays, name of the primary display, and per display its name, resolution and bits per pixel.</value>
+  </data>
+  <data name="SensorsManager_DummySensorDescription" xml:space="preserve">
+    <value>Dummy sensor for testing purposes, sends a random integer value between 0 and 100.</value>
+  </data>
+  <data name="SensorsManager_GpuLoadSensorDescription" xml:space="preserve">
+    <value>Provides the current load of the first GPU as a percentage.</value>
+  </data>
+  <data name="SensorsManager_GpuTemperatureSensorDescription" xml:space="preserve">
+    <value>NOTE: This is a non-functioning sensor.
+
+Due to the security concerns regarding Libre Hardware Monitor (library allowing HASS.Agent to access GPU temperature data) this sensor is left for backward compatibility reasons and will always return 0.
+Please see documentation for alternative options.</value>
+  </data>
+  <data name="SensorsManager_LastActiveSensorDescription" xml:space="preserve">
+    <value>Provides a datetime value containing the last moment the user provided input.
+
+Optionally updates the sensor with current date, when system has been woken from sleep/hibernation in configuerd time window and no user activity was performed.</value>
+  </data>
+  <data name="SensorsManager_LastBootSensorDescription" xml:space="preserve">
+	  <value>Provides a datetime value containing the last moment the system (re)booted.
+
+Important: Windows' FastBoot option can throw this value off, because that's a form of hibernation. You can disable it through Power Options -&gt; 'Choose what the power buttons do' -&gt; uncheck 'Turn on fast start-up'. It doesn't make much difference for modern machines with SSDs, but disabling makes sure you get a clean state after rebooting.</value>
+  </data>
+  <data name="SensorsManager_LastSystemStateChangeSensorDescription" xml:space="preserve">
+	  <value>Provides the last system state change:
+
+ApplicationStarted, Logoff, SystemShutdown, Resume, Suspend, ConsoleConnect, ConsoleDisconnect, RemoteConnect, RemoteDisconnect, SessionLock, SessionLogoff, SessionLogon, SessionRemoteControl and SessionUnlock.</value>
+  </data>
+  <data name="SensorsManager_LoggedUserSensorDescription" xml:space="preserve">
+	  <value>Returns the name of the currently logged user.
+
+This will only show active users, and falls back to 'Empty' if there are none. If there are multiple, the first will be used.</value>
+  </data>
+  <data name="SensorsManager_LoggedUsersSensorDescription" xml:space="preserve">
+	  <value>Returns a json-formatted list of currently logged users.
+
+This will also contain users that aren't active. If you only want the current active user, use the LoggedUser sensor instead.</value>
+  </data>
+  <data name="SensorsManager_MemoryUsageSensorDescription" xml:space="preserve">
+    <value>Provides the amount of used memory as a percentage.</value>
+  </data>
+  <data name="SensorsManager_MicrophoneActiveSensorDescription" xml:space="preserve">
+	  <value>Provides a bool value based on whether the microphone is currently being used.
+
+Note: if used in the satellite service, it won't detect userspace applications.</value>
+  </data>
+  <data name="SensorsManager_NamedWindowSensorDescription" xml:space="preserve">
+    <value>Provides an ON/OFF value based on whether the window is currently open (doesn't have to be active).</value>
+  </data>
+  <data name="SensorsManager_NetworkSensorsDescription" xml:space="preserve">
+	  <value>Provides card info, configuration, transfer- &amp; package statistics and addresses (ip, mac, dhcp, dns) of the selected network card(s).
+
+This is a multi-value sensor.</value>
+  </data>
+  <data name="SensorsManager_PerformanceCounterSensorDescription" xml:space="preserve">
+	  <value>Provides the values of a performance counter.
+
+For example, the built-in CPU load sensor uses these values:
+
+Category: Processor
+Counter: % Processor Time
+Instance: _Total
+
+You can explore the counters through Windows' 'perfmon.exe' tool.</value>
+  </data>
+  <data name="SensorsManager_ProcessActiveSensorDescription" xml:space="preserve">
+	  <value>Provides the number of active instances of the process.
+
+Note: don't add the extension (eg. notepad.exe becomes notepad).</value>
+  </data>
+  <data name="SensorsManager_ServiceStateSensorDescription" xml:space="preserve">
+	  <value>Returns the state of the provided service: NotFound, Stopped, StartPending, StopPending, Running, ContinuePending, PausePending or Paused.
+
+Make sure to provide the 'Service name', not the 'Display name'.</value>
+  </data>
+  <data name="SensorsManager_SessionStateSensorDescription" xml:space="preserve">
+	  <value>Provides the current session state:
+
+Locked, Unlocked or Unknown.
+
+Use a LastSystemStateChangeSensor to monitor session state changes.</value>
+  </data>
+  <data name="SensorsManager_StorageSensorsDescription" xml:space="preserve">
+    <value>Provides the labels, total size (MB), available space (MB), used space (MB) and file system of all present non-removable disks.</value>
+  </data>
+  <data name="SensorsManager_UserNotificationStateSensorDescription" xml:space="preserve">
+	  <value>Provides the current user state:
+
+NotPresent, Busy, RunningDirect3dFullScreen, PresentationMode, AcceptsNotifications, QuietTime or RunningWindowsStoreApp.
+
+Can for instance be used to determine whether to send notifications or TTS messages.</value>
+  </data>
+  <data name="SensorsManager_WebcamActiveSensorDescription" xml:space="preserve">
+	  <value>Provides a bool value based on whether the webcam is currently being used.
+
+Note: if used in the satellite service, it won't detect userspace applications.</value>
+  </data>
+  <data name="SensorsManager_WindowsUpdatesSensorsDescription" xml:space="preserve">
+	  <value>Provides a sensor with the amount of pending driver updates, a sensor with the amount of pending software updates, a sensor containing all pending driver updates information (title, kb article id's, hidden, type and categories) and a sensor containing the same for pending software updates.
+
+This is a costly request, so the recommended interval is 15 minutes (900 seconds). But it's capped at 10 minutes, if you provide a lower value, you'll get the last known list.</value>
+  </data>
+  <data name="SensorsManager_WmiQuerySensorDescription" xml:space="preserve">
+    <value>Provides the result of the WMI query.</value>
+  </data>
+  <data name="SettingsManager_LoadAppSettings_MessageBox1" xml:space="preserve">
+	  <value>Error loading settings:
+
+{0}</value>
+  </data>
+  <data name="SettingsManager_StoreInitialSettings_MessageBox1" xml:space="preserve">
+	  <value>Error storing initial settings:
+
+{0}</value>
+  </data>
+  <data name="SettingsManager_StoreAppSettings_MessageBox1" xml:space="preserve">
+	  <value>Error storing settings:
+
+{0}</value>
+  </data>
+  <data name="StoredCommands_Load_MessageBox1" xml:space="preserve">
+	  <value>Error loading commands:
+
+{0}</value>
+  </data>
+  <data name="StoredCommands_Store_MessageBox1" xml:space="preserve">
+	  <value>Error storing commands:
+
+{0}</value>
+  </data>
+  <data name="StoredQuickActions_Load_MessageBox1" xml:space="preserve">
+	  <value>Error loading quick actions:
+
+{0}</value>
+  </data>
+  <data name="StoredQuickActions_Store_MessageBox1" xml:space="preserve">
+	  <value>Error storing quick actions:
+
+{0}</value>
+  </data>
+  <data name="StoredSensors_Load_MessageBox1" xml:space="preserve">
+	  <value>Error loading sensors:
+
+{0}</value>
+  </data>
+  <data name="StoredSensors_Store_MessageBox1" xml:space="preserve">
+	  <value>Error storing sensors:
+
+{0}</value>
+  </data>
+  <data name="Main_LblMqtt" xml:space="preserve">
+    <value>MQTT:</value>
+  </data>
+  <data name="Help_LblWiki" xml:space="preserve">
+    <value>Wiki</value>
+  </data>
+  <data name="Configuration_BtnStore_Busy" xml:space="preserve">
+    <value>Busy, please wait..</value>
+  </data>
+  <data name="ConfigGeneral_LblInterfaceLangauge" xml:space="preserve">
+    <value>Interface &amp;Language</value>
+  </data>
+  <data name="About_LblOr" xml:space="preserve">
+    <value>or</value>
+  </data>
+  <data name="OnboardingManager_BtnNext_Finish" xml:space="preserve">
+    <value>Finish</value>
+  </data>
+  <data name="OnboardingWelcome_LblInterfaceLangauge" xml:space="preserve">
+    <value>Interface &amp;Language</value>
+  </data>
+  <data name="ServiceMqtt_SetMqttStatus_ConfigError" xml:space="preserve">
+    <value>Configuration missing</value>
+  </data>
+  <data name="ServiceMqtt_SetMqttStatus_Connected" xml:space="preserve">
+    <value>Connected</value>
+  </data>
+  <data name="ServiceMqtt_SetMqttStatus_Connecting" xml:space="preserve">
+    <value>Connecting..</value>
+  </data>
+  <data name="ServiceMqtt_SetMqttStatus_Disconnected" xml:space="preserve">
+    <value>Disconnected</value>
+  </data>
+  <data name="ServiceMqtt_SetMqttStatus_Error" xml:space="preserve">
+    <value>Error</value>
+  </data>
+  <data name="CommandType_CustomCommand" xml:space="preserve">
+    <value>Custom</value>
+  </data>
+  <data name="CommandType_CustomExecutorCommand" xml:space="preserve">
+    <value>CustomExecutor</value>
+  </data>
+  <data name="CommandType_HibernateCommand" xml:space="preserve">
+    <value>Hibernate</value>
+  </data>
+  <data name="CommandType_KeyCommand" xml:space="preserve">
+    <value>Key</value>
+  </data>
+  <data name="CommandType_LaunchUrlCommand" xml:space="preserve">
+    <value>LaunchUrl</value>
+  </data>
+  <data name="CommandType_LockCommand" xml:space="preserve">
+    <value>Lock</value>
+  </data>
+  <data name="CommandType_LogOffCommand" xml:space="preserve">
+    <value>LogOff</value>
+  </data>
+  <data name="CommandType_MediaMuteCommand" xml:space="preserve">
+    <value>MediaMute</value>
+  </data>
+  <data name="CommandType_MediaNextCommand" xml:space="preserve">
+    <value>MediaNext</value>
+  </data>
+  <data name="CommandType_MediaPlayPauseCommand" xml:space="preserve">
+    <value>MediaPlayPause</value>
+  </data>
+  <data name="CommandType_MediaPreviousCommand" xml:space="preserve">
+    <value>MediaPrevious</value>
+  </data>
+  <data name="CommandType_MediaVolumeDownCommand" xml:space="preserve">
+    <value>MediaVolumeDown</value>
+  </data>
+  <data name="CommandType_MediaVolumeUpCommand" xml:space="preserve">
+    <value>MediaVolumeUp</value>
+  </data>
+  <data name="CommandType_MultipleKeysCommand" xml:space="preserve">
+    <value>MultipleKeys</value>
+  </data>
+  <data name="CommandType_PowershellCommand" xml:space="preserve">
+    <value>Powershell</value>
+  </data>
+  <data name="CommandType_PublishAllSensorsCommand" xml:space="preserve">
+    <value>PublishAllSensors</value>
+  </data>
+  <data name="CommandType_RestartCommand" xml:space="preserve">
+    <value>Restart</value>
+  </data>
+  <data name="CommandType_ShutdownCommand" xml:space="preserve">
+    <value>Shutdown</value>
+  </data>
+  <data name="CommandType_SleepCommand" xml:space="preserve">
+    <value>Sleep</value>
+  </data>
+  <data name="UserNotificationState_AcceptsNotifications" xml:space="preserve">
+    <value>AcceptsNotifications</value>
+  </data>
+  <data name="UserNotificationState_Busy" xml:space="preserve">
+    <value>Busy</value>
+  </data>
+  <data name="UserNotificationState_NotPresent" xml:space="preserve">
+    <value>NotPresent</value>
+  </data>
+  <data name="UserNotificationState_PresentationMode" xml:space="preserve">
+    <value>PresentationMode</value>
+  </data>
+  <data name="UserNotificationState_QuietTime" xml:space="preserve">
+    <value>QuietTime</value>
+  </data>
+  <data name="UserNotificationState_RunningDirect3dFullScreen" xml:space="preserve">
+    <value>RunningDirect3dFullScreen</value>
+  </data>
+  <data name="UserNotificationState_RunningWindowsStoreApp" xml:space="preserve">
+    <value>RunningWindowsStoreApp</value>
+  </data>
+  <data name="SystemStateEvent_ConsoleConnect" xml:space="preserve">
+    <value>ConsoleConnect</value>
+  </data>
+  <data name="SystemStateEvent_ConsoleDisconnect" xml:space="preserve">
+    <value>ConsoleDisconnect</value>
+  </data>
+  <data name="SystemStateEvent_HassAgentSatelliteServiceStarted" xml:space="preserve">
+    <value>HassAgentSatelliteServiceStarted</value>
+  </data>
+  <data name="SystemStateEvent_HassAgentStarted" xml:space="preserve">
+    <value>HassAgentStarted</value>
+  </data>
+  <data name="SystemStateEvent_Logoff" xml:space="preserve">
+    <value>Logoff</value>
+  </data>
+  <data name="SystemStateEvent_RemoteConnect" xml:space="preserve">
+    <value>RemoteConnect</value>
+  </data>
+  <data name="SystemStateEvent_RemoteDisconnect" xml:space="preserve">
+    <value>RemoteDisconnect</value>
+  </data>
+  <data name="SystemStateEvent_Resume" xml:space="preserve">
+    <value>Resume</value>
+  </data>
+  <data name="SystemStateEvent_SessionLock" xml:space="preserve">
+    <value>SessionLock</value>
+  </data>
+  <data name="SystemStateEvent_SessionLogoff" xml:space="preserve">
+    <value>SessionLogoff</value>
+  </data>
+  <data name="SystemStateEvent_SessionLogon" xml:space="preserve">
+    <value>SessionLogon</value>
+  </data>
+  <data name="SystemStateEvent_SessionRemoteControl" xml:space="preserve">
+    <value>SessionRemoteControl</value>
+  </data>
+  <data name="SystemStateEvent_SessionUnlock" xml:space="preserve">
+    <value>SessionUnlock</value>
+  </data>
+  <data name="SystemStateEvent_Suspend" xml:space="preserve">
+    <value>Suspend</value>
+  </data>
+  <data name="SystemStateEvent_SystemShutdown" xml:space="preserve">
+    <value>SystemShutdown</value>
+  </data>
+  <data name="SensorType_ActiveWindowSensor" xml:space="preserve">
+    <value>ActiveWindow</value>
+  </data>
+  <data name="SensorType_AudioSensors" xml:space="preserve">
+    <value>Audio</value>
+  </data>
+  <data name="SensorType_BatterySensors" xml:space="preserve">
+    <value>Battery</value>
+  </data>
+  <data name="SensorType_CpuLoadSensor" xml:space="preserve">
+    <value>CpuLoad</value>
+  </data>
+  <data name="SensorType_CurrentClockSpeedSensor" xml:space="preserve">
+    <value>CurrentClockSpeed</value>
+  </data>
+  <data name="SensorType_CurrentVolumeSensor" xml:space="preserve">
+    <value>CurrentVolume</value>
+  </data>
+  <data name="SensorType_DisplaySensors" xml:space="preserve">
+    <value>Display</value>
+  </data>
+  <data name="SensorType_DummySensor" xml:space="preserve">
+    <value>Dummy</value>
+  </data>
+  <data name="SensorType_GpuLoadSensor" xml:space="preserve">
+    <value>GpuLoad</value>
+  </data>
+  <data name="SensorType_GpuTemperatureSensor" xml:space="preserve">
+    <value>GpuTemperature</value>
+  </data>
+  <data name="SensorType_LastActiveSensor" xml:space="preserve">
+    <value>LastActive</value>
+  </data>
+  <data name="SensorType_LastBootSensor" xml:space="preserve">
+    <value>LastBoot</value>
+  </data>
+  <data name="SensorType_LastSystemStateChangeSensor" xml:space="preserve">
+    <value>LastSystemStateChange</value>
+  </data>
+  <data name="SensorType_LoggedUserSensor" xml:space="preserve">
+    <value>LoggedUser</value>
+  </data>
+  <data name="SensorType_LoggedUsersSensor" xml:space="preserve">
+    <value>LoggedUsers</value>
+  </data>
+  <data name="SensorType_MemoryUsageSensor" xml:space="preserve">
+    <value>MemoryUsage</value>
+  </data>
+  <data name="SensorType_MicrophoneActiveSensor" xml:space="preserve">
+    <value>MicrophoneActive</value>
+  </data>
+  <data name="SensorType_NamedWindowSensor" xml:space="preserve">
+    <value>NamedWindow</value>
+  </data>
+  <data name="SensorType_NetworkSensors" xml:space="preserve">
+    <value>Network</value>
+  </data>
+  <data name="SensorType_PerformanceCounterSensor" xml:space="preserve">
+    <value>PerformanceCounter</value>
+  </data>
+  <data name="SensorType_ProcessActiveSensor" xml:space="preserve">
+    <value>ProcessActive</value>
+  </data>
+  <data name="SensorType_ServiceStateSensor" xml:space="preserve">
+    <value>ServiceState</value>
+  </data>
+  <data name="SensorType_SessionStateSensor" xml:space="preserve">
+    <value>SessionState</value>
+  </data>
+  <data name="SensorType_StorageSensors" xml:space="preserve">
+    <value>Storage</value>
+  </data>
+  <data name="SensorType_UserNotificationStateSensor" xml:space="preserve">
+    <value>UserNotification</value>
+  </data>
+  <data name="SensorType_WebcamActiveSensor" xml:space="preserve">
+    <value>WebcamActive</value>
+  </data>
+  <data name="SensorType_WindowsUpdatesSensors" xml:space="preserve">
+    <value>WindowsUpdates</value>
+  </data>
+  <data name="SensorType_WmiQuerySensor" xml:space="preserve">
+    <value>WmiQuery</value>
+  </data>
+  <data name="HassDomain_Automation" xml:space="preserve">
+    <value>Automation</value>
+  </data>
+  <data name="HassDomain_Climate" xml:space="preserve">
+    <value>Climate</value>
+  </data>
+  <data name="HassDomain_Cover" xml:space="preserve">
+    <value>Cover</value>
+  </data>
+  <data name="HassDomain_InputBoolean" xml:space="preserve">
+    <value>InputBoolean</value>
+  </data>
+  <data name="HassDomain_Light" xml:space="preserve">
+    <value>Light</value>
+  </data>
+  <data name="HassDomain_MediaPlayer" xml:space="preserve">
+    <value>MediaPlayer</value>
+  </data>
+  <data name="HassDomain_Scene" xml:space="preserve">
+    <value>Scene</value>
+  </data>
+  <data name="HassDomain_Script" xml:space="preserve">
+    <value>Script</value>
+  </data>
+  <data name="HassDomain_Switch" xml:space="preserve">
+    <value>Switch</value>
+  </data>
+  <data name="HassAction_Close" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="HassAction_Off" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="HassAction_On" xml:space="preserve">
+    <value>On</value>
+  </data>
+  <data name="HassAction_Open" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="HassAction_Pause" xml:space="preserve">
+    <value>Pause</value>
+  </data>
+  <data name="HassAction_Play" xml:space="preserve">
+    <value>Play</value>
+  </data>
+  <data name="HassAction_Stop" xml:space="preserve">
+    <value>Stop</value>
+  </data>
+  <data name="HassAction_Toggle" xml:space="preserve">
+    <value>Toggle</value>
+  </data>
+  <data name="CommandEntityType_Button" xml:space="preserve">
+    <value>Button</value>
+  </data>
+  <data name="CommandEntityType_Light" xml:space="preserve">
+    <value>Light</value>
+  </data>
+  <data name="CommandEntityType_Lock" xml:space="preserve">
+    <value>Lock</value>
+  </data>
+  <data name="CommandEntityType_Siren" xml:space="preserve">
+    <value>Siren</value>
+  </data>
+  <data name="CommandEntityType_Switch" xml:space="preserve">
+    <value>Switch</value>
+  </data>
+  <data name="ComponentStatus_Connecting" xml:space="preserve">
+    <value>Connecting..</value>
+  </data>
+  <data name="ComponentStatus_Disabled" xml:space="preserve">
+    <value>Disabled</value>
+  </data>
+  <data name="ComponentStatus_Failed" xml:space="preserve">
+    <value>Failed</value>
+  </data>
+  <data name="ComponentStatus_Loading" xml:space="preserve">
+    <value>Loading..</value>
+  </data>
+  <data name="ComponentStatus_Ok" xml:space="preserve">
+	  <value>Running</value>
+  </data>
+  <data name="ComponentStatus_Stopped" xml:space="preserve">
+    <value>Stopped</value>
+  </data>
+  <data name="LockState_Locked" xml:space="preserve">
+    <value>Locked</value>
+  </data>
+  <data name="LockState_Unknown" xml:space="preserve">
+    <value>Unknown</value>
+  </data>
+  <data name="LockState_Unlocked" xml:space="preserve">
+    <value>Unlocked</value>
+  </data>
+  <data name="SensorType_GeoLocationSensor" xml:space="preserve">
+    <value>GeoLocation</value>
+  </data>
+  <data name="SensorsMod_All" xml:space="preserve">
+    <value>All</value>
+  </data>
+  <data name="SensorsMod_BtnTest" xml:space="preserve">
+    <value>&amp;Test</value>
+  </data>
+  <data name="SensorsMod_BtnTest_PerformanceCounter" xml:space="preserve">
+    <value>Test Performance Counter</value>
+  </data>
+  <data name="SensorsMod_BtnTest_Wmi" xml:space="preserve">
+    <value>Test WMI Query</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_Network" xml:space="preserve">
+    <value>Network Card</value>
+  </data>
+  <data name="SensorsMod_TestPerformanceCounter_MessageBox1" xml:space="preserve">
+    <value>Enter a category and counter first.</value>
+  </data>
+  <data name="SensorsMod_TestPerformanceCounter_MessageBox2" xml:space="preserve">
+	  <value>Test succesfully executed, result value:
+
+{0}</value>
+  </data>
+  <data name="SensorsMod_TestPerformanceCounter_MessageBox3" xml:space="preserve">
+	  <value>The test failed to execute:
+
+{0}
+
+Do you want to open the logs folder?</value>
+  </data>
+  <data name="SensorsMod_TestWmi_MessageBox1" xml:space="preserve">
+    <value>Enter a WMI query first.</value>
+  </data>
+  <data name="SensorsMod_TestWmi_MessageBox2" xml:space="preserve">
+	  <value>Query succesfully executed, result value:
+
+{0}</value>
+  </data>
+  <data name="SensorsMod_TestWmi_MessageBox3" xml:space="preserve">
+	  <value>The query failed to execute:
+
+{0}
+
+Do you want to open the logs folder?</value>
+  </data>
+  <data name="SensorsMod_WmiTestFailed" xml:space="preserve">
+	  <value>It looks like your scope is malformed, it should probably start like this:
+
+\\.\ROOT\
+
+The scope you entered:
+
+{0}
+
+Tip: make sure you haven't switched the scope and query fields around.
+
+Do you still want to use the current values?</value>
+  </data>
+  <data name="SystemStateEvent_ApplicationStarted" xml:space="preserve">
+    <value>ApplicationStarted</value>
+  </data>
+  <data name="ServiceGeneral_LblInfo2" xml:space="preserve">
+    <value>You can use the satellite service to run sensors and commands without having to be logged in. Not all types are available, for instance the 'LaunchUrl' command can only be added as a regular command.</value>
+  </data>
+  <data name="SensorsConfig_ClmValue" xml:space="preserve">
+    <value>Last Known Value</value>
+  </data>
+  <data name="LocalApiManager_Initialize_MessageBox1" xml:space="preserve">
+	  <value>Error trying to bind the API to port {0}.
+
+Make sure no other instance of HASS.Agent is running and the port is available and registered.</value>
+  </data>
+  <data name="CommandType_SendWindowToFrontCommand" xml:space="preserve">
+    <value>SendWindowToFront</value>
+  </data>
+  <data name="CommandType_WebViewCommand" xml:space="preserve">
+    <value>WebView</value>
+  </data>
+  <data name="CommandsManager_WebViewCommandDescription" xml:space="preserve">
+	  <value>Shows a window with the provided URL.
+
+This differs from the 'LaunchUrl' command in that it doesn't load a full-fledged browser, just the provided URL in its own window.
+
+You can use this to for instance quickly show Home Assistant's dashboard.
+
+By default, it stores cookies indefinitely so you only have to log in once.</value>
+  </data>
+  <data name="HassDomain_HASSAgentCommands" xml:space="preserve">
+    <value>HASS.Agent Commands</value>
+  </data>
+  <data name="CommandsManager_CommandsManager_SendWindowToFrontCommandDescription" xml:space="preserve">
+	  <value>Looks for the specified process, and tries to send its main window to the front.
+
+If the application is minimized, it'll get restored.
+
+Example: if you want to send VLC to the foreground, use 'vlc'.</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox8" xml:space="preserve">
+	  <value>If you do not configure the command, you may only use this entity with an 'action' value via Home Assistant and it will appear using the default settings, running it as-is will have no action.
+
+Are you sure you want to do this?</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearAudioCache" xml:space="preserve">
+    <value>Clear Audio Cache</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearAudioCache_InfoText1" xml:space="preserve">
+    <value>Cleaning..</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearAudioCache_MessageBox1" xml:space="preserve">
+    <value>The audio cache has been cleared!</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearWebViewCache" xml:space="preserve">
+    <value>Clear WebView Cache</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearWebViewCache_InfoText1" xml:space="preserve">
+    <value>Cleaning..</value>
+  </data>
+  <data name="ConfigLocalStorage_BtnClearWebViewCache_MessageBox1" xml:space="preserve">
+    <value>The WebView cache has been cleared!</value>
+  </data>
+  <data name="Main_CheckDpiScalingFactor_MessageBox1" xml:space="preserve">
+	  <value>It looks like you're using an alternative scaling. This may result in some parts of HASS.Agent not looking as intended.
+
+Please report any unusable aspects on GitHub. Thanks!
+
+Note: this message only shows once.</value>
+  </data>
+  <data name="WebViewCommandConfig_SetStoredVariables_MessageBox1" xml:space="preserve">
+    <value>Unable to load the stored command settings, resetting to default.</value>
+  </data>
+  <data name="CommandsMod_BtnConfigureCommand" xml:space="preserve">
+    <value>Configure Command &amp;Parameters</value>
+  </data>
+  <data name="ConfigLocalApi_BtnExecutePortReservation" xml:space="preserve">
+    <value>Execute Port &amp;Reservation</value>
+  </data>
+  <data name="ConfigLocalApi_CbLocalApiActive" xml:space="preserve">
+    <value>&amp;Enable Local API</value>
+  </data>
+  <data name="ConfigLocalApi_LblInfo1" xml:space="preserve">
+	  <value>HASS.Agent has its own local API, so Home Assistant can send requests (for instance to send a notification). You can configure it globally here, and afterwards you can configure the dependent sections (currently notifications and mediaplayer).
+
+Note: this is not required for the new integration to function. Only enable and use it if you don't use MQTT.</value>
+  </data>
+  <data name="ConfigLocalApi_LblInfo2" xml:space="preserve">
+    <value>To be able to listen to the requests, HASS.Agent needs to have its port reserved and opened in your firewall. You can use this button to have it done for you.</value>
+  </data>
+  <data name="ConfigLocalApi_LblPort" xml:space="preserve">
+    <value>&amp;Port</value>
+  </data>
+  <data name="ConfigLocalStorage_LblAudioCacheLocation" xml:space="preserve">
+    <value>Audio Cache Location</value>
+  </data>
+  <data name="ConfigLocalStorage_LblImageCacheDays" xml:space="preserve">
+    <value>days</value>
+  </data>
+  <data name="ConfigLocalStorage_LblImageCacheLocation" xml:space="preserve">
+    <value>Image Cache Location</value>
+  </data>
+  <data name="ConfigLocalStorage_LblKeepAudio" xml:space="preserve">
+    <value>Keep audio for</value>
+  </data>
+  <data name="ConfigLocalStorage_LblKeepImages" xml:space="preserve">
+    <value>Keep images for</value>
+  </data>
+  <data name="ConfigLocalStorage_LblKeepWebView" xml:space="preserve">
+    <value>Clear cache every</value>
+  </data>
+  <data name="ConfigLocalStorage_LblWebViewCacheLocation" xml:space="preserve">
+    <value>WebView Cache Location</value>
+  </data>
+  <data name="ConfigMediaPlayer_BtnMediaPlayerReadme" xml:space="preserve">
+    <value>Media Player &amp;Documentation</value>
+  </data>
+  <data name="ConfigMediaPlayer_CbEnableMediaPlayer" xml:space="preserve">
+    <value>&amp;Enable Media Player Functionality</value>
+  </data>
+  <data name="ConfigMediaPlayer_LblInfo1" xml:space="preserve">
+    <value>HASS.Agent can act as a media player for Home Assistant, so you'll be able to see and control any media that's playing, and send text-to-speech. If you have MQTT enabled, your device will automatically get added. Otherwise, manually configure the integration to use the local API.</value>
+  </data>
+  <data name="ConfigMediaPlayer_LblInfo2" xml:space="preserve">
+	  <value>If something is not working, make sure you try the following steps:
+
+- Install the HASS.Agent integration
+- Restart Home Assistant
+- Make sure HASS.Agent is active with MQTT enabled!
+- Your device should get detected and added as an entity automatically
+- Optionally: manually add it using the local API</value>
+  </data>
+  <data name="ConfigMediaPlayer_LblLocalApiDisabled" xml:space="preserve">
+    <value>The local API is disabled however the media player requires it in order to function.</value>
+  </data>
+  <data name="ConfigMqtt_CbMqttTls" xml:space="preserve">
+    <value>&amp;TLS</value>
+  </data>
+  <data name="ConfigNotifications_LblLocalApiDisabled" xml:space="preserve">
+    <value>The local API is disabled however the media player requires it in order to function.</value>
+  </data>
+  <data name="ConfigTrayIcon_BtnShowWebViewPreview" xml:space="preserve">
+    <value>Show &amp;Preview</value>
+  </data>
+  <data name="ConfigTrayIcon_CbDefaultMenu" xml:space="preserve">
+    <value>Show &amp;Default Menu</value>
+  </data>
+  <data name="ConfigTrayIcon_CbShowWebView" xml:space="preserve">
+    <value>Show &amp;WebView</value>
+  </data>
+  <data name="ConfigTrayIcon_CbWebViewKeepLoaded" xml:space="preserve">
+    <value>&amp;Keep page loaded in the background</value>
+  </data>
+  <data name="ConfigTrayIcon_LblInfo1" xml:space="preserve">
+    <value>Control the behaviour of the tray icon when it is right-clicked.</value>
+  </data>
+  <data name="ConfigTrayIcon_LblInfo2" xml:space="preserve">
+    <value>(This uses extra resources, but reduces loading time.)</value>
+  </data>
+  <data name="ConfigTrayIcon_LblWebViewSize" xml:space="preserve">
+    <value>Size (px)</value>
+  </data>
+  <data name="ConfigTrayIcon_LblWebViewUrl" xml:space="preserve">
+    <value>&amp;WebView URL (For instance, your Home Assistant Dashboard URL)</value>
+  </data>
+  <data name="Configuration_TablLocalApi" xml:space="preserve">
+    <value>Local API</value>
+  </data>
+  <data name="Configuration_TabMediaPlayer" xml:space="preserve">
+    <value>Media Player</value>
+  </data>
+  <data name="Configuration_TabTrayIcon" xml:space="preserve">
+    <value>Tray Icon</value>
+  </data>
+  <data name="HelperFunctions_InputLanguageCheckDiffers_ErrorMsg1" xml:space="preserve">
+    <value>Your input language '{0}' is known to collide with the default CTRL-ALT-Q hotkey. Please set your own.</value>
+  </data>
+  <data name="HelperFunctions_InputLanguageCheckDiffers_ErrorMsg2" xml:space="preserve">
+    <value>Your input language '{0}' is unknown, and might collide with the default CTRL-ALT-Q hotkey. Please check to be sure. If it does, consider opening a ticket on GitHub so it can be added to the list.</value>
+  </data>
+  <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg1" xml:space="preserve">
+    <value>No keys found</value>
+  </data>
+  <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg2" xml:space="preserve">
+    <value>brackets missing, start and close all keys with [ ]</value>
+  </data>
+  <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg3" xml:space="preserve">
+    <value>Error while parsing keys, please check the logs for more information.</value>
+  </data>
+  <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg4" xml:space="preserve">
+    <value>The number of open brackets ('[') does not correspond to the number of closed brackets. (']')! ({0} to {1})</value>
+  </data>
+  <data name="Help_LblDocumentation" xml:space="preserve">
+    <value>Documentation</value>
+  </data>
+  <data name="Help_LblDocumentationInfo" xml:space="preserve">
+    <value>Documentation and Usage Examples</value>
+  </data>
+  <data name="Main_BtnCheckForUpdate" xml:space="preserve">
+    <value>Check for &amp;Updates</value>
+  </data>
+  <data name="Main_LblLocalApi" xml:space="preserve">
+    <value>Local API:</value>
+  </data>
+  <data name="Main_TsSatelliteService" xml:space="preserve">
+    <value>Manage Satellite Service</value>
+  </data>
+  <data name="OnboardingIntegrations_LblInfo1" xml:space="preserve">
+	  <value>To use notifications, you need to install and configure the HASS.Agent integration in
+Home Assistant.
+
+This is very easy using HACS, but you can also install manually. Visit the link below for more
+information.</value>
+  </data>
+  <data name="OnboardingIntegrations_LblInfo2" xml:space="preserve">
+	  <value>Make sure you follow these steps:
+
+- Install the HASS.Agent-Notifier and / or HASS.Agent-MediaPlayer integration
+- Restart Home Assistant
+-Configure a notifier and / or media_player entity
+-Restart Home Assistant</value>
+  </data>
+  <data name="OnboardingIntegrations_LblInfo3" xml:space="preserve">
+    <value>The same goes for the media player, this integration allows you to control your device as a media_player entity, see what's playing and send text-to-speech.</value>
+  </data>
+  <data name="OnboardingIntegrations_LblMediaPlayerIntegration" xml:space="preserve">
+    <value>HASS.Agent-MediaPlayer GitHub Page</value>
+  </data>
+  <data name="OnboardingIntegrations_LblNotifierIntegration" xml:space="preserve">
+    <value>HASS.Agent-Integration GitHub Page</value>
+  </data>
+  <data name="OnboardingLocalApi_CbEnableLocalApi" xml:space="preserve">
+    <value>Yes, &amp;enable the local API on port</value>
+  </data>
+  <data name="OnboardingLocalApi_CbEnableMediaPlayer" xml:space="preserve">
+    <value>Enable &amp;Media Player and text-to-speech (TTS)</value>
+  </data>
+  <data name="OnboardingLocalApi_CbEnableNotifications" xml:space="preserve">
+    <value>Enable &amp;Notifications</value>
+  </data>
+  <data name="OnboardingLocalApi_LblInfo1" xml:space="preserve">
+	  <value>HASS.Agent has its own internal API, so Home Assistant can send requests (like notifications or text-to-speech).
+
+Do you want to enable it?</value>
+  </data>
+  <data name="OnboardingLocalApi_LblInfo2" xml:space="preserve">
+    <value>You can choose what modules you want to enable. They require HA integrations, but don't worry, the next page will give you more info on how to set them up.</value>
+  </data>
+  <data name="OnboardingLocalApi_LblTip1" xml:space="preserve">
+    <value>Note: 5115 is the default port, only change it if you changed it in Home Assistant.</value>
+  </data>
+  <data name="OnboardingMqtt_CbMqttTls" xml:space="preserve">
+    <value>&amp;TLS</value>
+  </data>
+  <data name="OnboardingWelcome_Store_MessageBox1" xml:space="preserve">
+	  <value>Your device name contained some characters that are not allowed by HA (only letters, digits and whitespace).
+
+The final name is: {0}
+
+Do you want to use that version?</value>
+  </data>
+  <data name="Onboarding_Title" xml:space="preserve">
+    <value>HASS.Agent Onboarding</value>
+  </data>
+  <data name="ServiceGeneral_LblAuthStored" xml:space="preserve">
+    <value>stored!</value>
+  </data>
+  <data name="ServiceMqtt_CbMqttTls" xml:space="preserve">
+    <value>&amp;TLS</value>
+  </data>
+  <data name="WebViewCommandConfig_BtnSave" xml:space="preserve">
+    <value>&amp;Save</value>
+  </data>
+  <data name="WebViewCommandConfig_CbCenterScreen" xml:space="preserve">
+    <value>&amp;Always show centered in screen</value>
+  </data>
+  <data name="WebViewCommandConfig_CbShowTitleBar" xml:space="preserve">
+    <value>Show the window's &amp;title bar</value>
+  </data>
+  <data name="WebViewCommandConfig_CbTopMost" xml:space="preserve">
+    <value>Set window as 'Always on &amp;Top'</value>
+  </data>
+  <data name="WebViewCommandConfig_LblInfo1" xml:space="preserve">
+    <value>Drag and resize this window to set the size and location of your webview command.</value>
+  </data>
+  <data name="WebViewCommandConfig_LblLocation" xml:space="preserve">
+    <value>Location</value>
+  </data>
+  <data name="WebViewCommandConfig_LblSize" xml:space="preserve">
+    <value>Size</value>
+  </data>
+  <data name="WebViewCommandConfig_LblTip1" xml:space="preserve">
+    <value>Tip: Press ESCAPE to close a WebView.</value>
+  </data>
+  <data name="WebViewCommandConfig_LblUrl" xml:space="preserve">
+    <value>&amp;URL</value>
+  </data>
+  <data name="WebViewCommandConfig_Title" xml:space="preserve">
+    <value>WebView Configuration</value>
+  </data>
+  <data name="WebView_Title" xml:space="preserve">
+    <value>WebView</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox9" xml:space="preserve">
+	  <value>The keycode you have provided is not a valid number!
+
+Please ensure the keycode field is in focus and press the key you want simulated, the keycode should then be generated for you.</value>
+  </data>
+  <data name="ConfigGeneral_CbEnableDeviceNameSanitation" xml:space="preserve">
+    <value>Enable Device Name &amp;Sanitation</value>
+  </data>
+  <data name="ConfigGeneral_CbEnableStateNotifications" xml:space="preserve">
+    <value>Enable State Notifications</value>
+  </data>
+  <data name="ConfigGeneral_LblInfo5" xml:space="preserve">
+    <value>HASS.Agent will sanitize your device name to make sure HA will accept it, you can overrule this rule below if you're sure that your name will be accepted as-is.</value>
+  </data>
+  <data name="ConfigGeneral_LblInfo6" xml:space="preserve">
+    <value>HASS.Agent sends notifications when the state of a module changes, you can adjust whether or not you want to receive these notifications below.</value>
+  </data>
+  <data name="Configuration_ProcessChanges_MessageBox6" xml:space="preserve">
+	  <value>You've changed your device's name.
+
+All your sensors and commands will now be unpublished and published again after the HASS.Agent restarts.
+
+Don't worry! they'll keep their current names so your automations and scripts will continue to work.
+
+Note: You disabled sanitation, so make sure your device name is accepted by Home Assistant.</value>
+  </data>
+  <data name="SensorType_PrintersSensors" xml:space="preserve">
+    <value>Printers</value>
+  </data>
+  <data name="CommandType_MonitorSleepCommand" xml:space="preserve">
+    <value>MonitorSleep</value>
+  </data>
+  <data name="CommandType_MonitorWakeCommand" xml:space="preserve">
+    <value>MonitorWake</value>
+  </data>
+  <data name="MonitorPowerEvent_PowerOn" xml:space="preserve">
+    <value>PowerOn</value>
+  </data>
+  <data name="MonitorPowerEvent_PowerOff" xml:space="preserve">
+    <value>PowerOff</value>
+  </data>
+  <data name="MonitorPowerEvent_Dimmed" xml:space="preserve">
+    <value>Dimmed</value>
+  </data>
+  <data name="MonitorPowerEvent_Unknown" xml:space="preserve">
+    <value>Unknown</value>
+  </data>
+  <data name="SensorType_MonitorPowerStateSensor" xml:space="preserve">
+    <value>MonitorPowerState</value>
+  </data>
+  <data name="SensorType_PowershellSensor" xml:space="preserve">
+    <value>PowershellSensor</value>
+  </data>
+  <data name="CommandType_SetVolumeCommand" xml:space="preserve">
+    <value>SetVolume</value>
+  </data>
+  <data name="WindowState_Maximized" xml:space="preserve">
+    <value>Maximized</value>
+  </data>
+  <data name="WindowState_Minimized" xml:space="preserve">
+    <value>Minimized</value>
+  </data>
+  <data name="WindowState_Normal" xml:space="preserve">
+    <value>Normal</value>
+  </data>
+  <data name="WindowState_Unknown" xml:space="preserve">
+    <value>Unknown</value>
+  </data>
+  <data name="WindowState_Hidden" xml:space="preserve">
+    <value>Hidden</value>
+  </data>
+  <data name="SensorType_WindowStateSensor" xml:space="preserve">
+    <value>WindowState</value>
+  </data>
+  <data name="SensorType_WebcamProcessSensor" xml:space="preserve">
+    <value>WebcamProcess</value>
+  </data>
+  <data name="SensorType_MicrophoneProcessSensor" xml:space="preserve">
+    <value>MicrophoneProcess</value>
+  </data>
+  <data name="CommandsManager_MonitorSleepCommandDescription" xml:space="preserve">
+    <value>Puts all monitors in sleep (low power) mode.</value>
+  </data>
+  <data name="CommandsManager_MonitorWakeCommandDescription" xml:space="preserve">
+    <value>Tries to wake up all monitors by simulating a 'arrow up' keypress.</value>
+  </data>
+  <data name="CommandsManager_SetVolumeCommandDescription" xml:space="preserve">
+    <value>Sets the volume of the current default audiodevice to the specified level.</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox10" xml:space="preserve">
+    <value>Please enter a value between 0-100 as the desired volume level!</value>
+  </data>
+  <data name="CommandsMod_CommandsMod" xml:space="preserve">
+    <value>Command</value>
+  </data>
+  <data name="CommandsMod_MessageBox_Action2" xml:space="preserve">
+	  <value>If you don't enter a volume value, you can only use this entity with an 'action' value through Home Assistant. Running it as-is won't do anything.
+
+Are you sure you want this?</value>
+  </data>
+  <data name="CommandsMod_MessageBox_Sanitize" xml:space="preserve">
+	  <value>The name you provided contains unsupported characters and won't work. The suggested version is:
+
+{0}
+
+Do you want to use this version?</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox5" xml:space="preserve">
+	  <value>The API token you have provided doesn't appear to be valid, please ensure you selected the entire token (Don't use CTRL + A or double-click). A valid API key contains three sections, separated by two dots.
+
+Are you sure you want to use this key anyway?</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox6" xml:space="preserve">
+	  <value>The URI you have provided does not appear to be valid, a valid URI may look like either of the following:
+- http://homeassistant.local:8123
+- http://192.168.0.1:8123
+
+Are you sure you want to use this URI anyway?</value>
+  </data>
+  <data name="ConfigHomeAssistantApi_BtnTestApi_Testing" xml:space="preserve">
+    <value>Testing..</value>
+  </data>
+  <data name="ConfigMediaPlayer_LblConnectivityDisabled" xml:space="preserve">
+    <value>both the local API and MQTT are disabled, but the integration needs at least one for it to work</value>
+  </data>
+  <data name="ConfigMqtt_CbEnableMqtt" xml:space="preserve">
+    <value>Enable MQTT</value>
+  </data>
+  <data name="ConfigMqtt_LblMqttDisabledWarning" xml:space="preserve">
+    <value>If MQTT is not enabled, commands and sensors will not work!</value>
+  </data>
+  <data name="ConfigNotifications_LblConnectivityDisabled" xml:space="preserve">
+    <value>both the local API and MQTT are disabled, but the integration needs at least one for it to work</value>
+  </data>
+  <data name="ConfigService_BtnManageService" xml:space="preserve">
+    <value>&amp;Manage Service</value>
+  </data>
+  <data name="ConfigService_BtnManageService_MessageBox1" xml:space="preserve">
+	  <value>The service is currently stopped and cannot be configured.
+
+Please start the service first in order to configure it.</value>
+  </data>
+  <data name="ConfigService_LblInfo5" xml:space="preserve">
+    <value>If you want to manage the service (add commands and sensor, change settings) you can do so here, or by using the 'satellite service' button on the main window.</value>
+  </data>
+  <data name="ConfigTrayIcon_CbWebViewShowMenuOnLeftClick" xml:space="preserve">
+    <value>Show default menu on mouse left-click</value>
+  </data>
+  <data name="Configuration_CheckValues_MessageBox1" xml:space="preserve">
+	  <value>Your Home Assistant API token doesn't look right. Make sure you selected the entire token (don't use CTRL+A or doubleclick).
+It should contain three sections (seperated by two dots).
+
+Are you sure you want to use it like this?</value>
+  </data>
+  <data name="Configuration_CheckValues_MessageBox2" xml:space="preserve">
+	  <value>Your Home Assistant URI doesn't look right. It should look something like 'http://homeassistant.local:8123' or 'https://192.168.0.1:8123'.
+
+Are you sure you want to use it like this?</value>
+  </data>
+  <data name="Configuration_CheckValues_MessageBox3" xml:space="preserve">
+	  <value>Your MQTT broker URI doesn't look right. It should look something like 'homeassistant.local' or '192.168.0.1'.
+
+Are you sure you want to use it like this?</value>
+  </data>
+  <data name="Donate_BtnClose" xml:space="preserve">
+    <value>&amp;Close</value>
+  </data>
+  <data name="Donate_CbHideDonateButton" xml:space="preserve">
+    <value>I already donated, hide the button on the main window.</value>
+  </data>
+  <data name="Donate_LblInfo" xml:space="preserve">
+	  <value>HASS.Agent is completely free, and will always stay that way without restrictions!
+
+However, developing and maintaining this tool (and everything that surrounds it, like support and the docs) takes up a lot of time. 
+
+Like most developers, I run on caffeïne - so if you can spare it, a cup of coffee is always very much appreciated!</value>
+  </data>
+  <data name="Donate_Title" xml:space="preserve">
+    <value>Donate</value>
+  </data>
+  <data name="Main_NotifyIcon_MouseClick_MessageBox1" xml:space="preserve">
+    <value>No URL has been set! Please configure the webview through Configuration -&gt; Tray Icon.</value>
+  </data>
+  <data name="Main_TsCheckForUpdates" xml:space="preserve">
+    <value>Check for Updates</value>
+  </data>
+  <data name="OnboardingApi_BtnTest_MessageBox5" xml:space="preserve">
+	  <value>The API token you have provided doesn't appear to be valid, please ensure you selected the entire token (Don't use CTRL + A or double-click). A valid API key contains three sections, separated by two dots.
+
+Are you sure you want to use this key anyway?</value>
+  </data>
+  <data name="OnboardingApi_BtnTest_MessageBox6" xml:space="preserve">
+	  <value>The URI you have provided does not appear to be valid, a valid URI may look like either of the following:
+- http://homeassistant.local:8123
+- http://192.168.0.1:8123
+
+Are you sure you want to use this URI anyway?</value>
+  </data>
+  <data name="OnboardingDone_LblInfo6" xml:space="preserve">
+    <value>Currently, we (HASS.Agent Team maintaining the fork) do not accept donations in any form :)
+Please however feel free to donate to the original author of HASS.Agent - Sam! Wherever they currently are, cup of coffee might brighten their day.</value>
+  </data>
+  <data name="OnboardingDone_LblTip2" xml:space="preserve">
+    <value>Tip: Other donation methods are available on the About Window.</value>
+  </data>
+  <data name="OnboardingIntegrations_CbEnableMediaPlayer" xml:space="preserve">
+    <value>Enable &amp;Media Player (including text-to-speech)</value>
+  </data>
+  <data name="OnboardingIntegrations_CbEnableNotifications" xml:space="preserve">
+    <value>Enable &amp;Notifications</value>
+  </data>
+  <data name="OnboardingMqtt_CbEnableMqtt" xml:space="preserve">
+    <value>Enable MQTT</value>
+  </data>
+  <data name="PostUpdate_PostUpdate" xml:space="preserve">
+    <value>HASS.Agent Post Update</value>
+  </data>
+  <data name="SensorsManager_BluetoothDevicesSensorDescription" xml:space="preserve">
+	  <value>Provides a sensor with the amount of bluetooth devices found.
+
+The devices and their connected state are added as attributes.</value>
+  </data>
+  <data name="SensorsManager_BluetoothLeDevicesSensorDescription" xml:space="preserve">
+	  <value>Provides a sensors with the amount of bluetooth LE devices found.
+
+The devices and their connected state are added as attributes.
+
+Only shows devices that were seen since the last report, ie. when the sensor publishes, the list clears.</value>
+  </data>
+  <data name="SensorsManager_GeoLocationSensorDescription" xml:space="preserve">
+	  <value>Returns your current latitude, longitude and altitude as a comma-seperated value.
+
+Make sure Windows' location services are enabled!
+
+Depending on your Windows version, this can be found in the new control panel -&gt; 'privacy and security' -&gt; 'location'.</value>
+  </data>
+  <data name="SensorsManager_MonitorPowerStateSensorDescription" xml:space="preserve">
+	  <value>Provides the last monitor power state change:
+
+Dimmed, PowerOff, PowerOn and Unkown.</value>
+  </data>
+  <data name="SensorsManager_PowershellSensorDescription" xml:space="preserve">
+	  <value>Returns the result of the provided Powershell command or script.
+Note: please keep in mind that Home Assistant accepts payload up to 255 characters.
+
+Converts the outcome to text.</value>
+  </data>
+  <data name="SensorsManager_PrintersSensorsDescription" xml:space="preserve">
+    <value>Provides information about all installed printers and their queues.</value>
+  </data>
+  <data name="SensorsManager_WebcamProcessSensorDescription" xml:space="preserve">
+	  <value>Provides the name of the process that's currently using the webcam.
+
+Note: if used in the satellite service, it won't detect userspace applications.</value>
+  </data>
+  <data name="SensorsManager_WindowStateSensorDescription" xml:space="preserve">
+	  <value>Provides the current state of the process' window:
+
+Hidden, Maximized, Minimized, Normal and Unknown.</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_Powershell" xml:space="preserve">
+    <value>powershell command or script</value>
+  </data>
+  <data name="SensorsMod_MessageBox_Sanitize" xml:space="preserve">
+	  <value>The name you provided contains unsupported characters and won't work. The suggested version is:
+
+{0}
+
+Do you want to use this version?</value>
+  </data>
+  <data name="SensorsMod_SensorsMod_BtnTest_Powershell" xml:space="preserve">
+    <value>Test Command/Script</value>
+  </data>
+  <data name="SensorsMod_TestPowershell_MessageBox1" xml:space="preserve">
+    <value>Please enter a command or script!</value>
+  </data>
+  <data name="SensorsMod_TestPowershell_MessageBox2" xml:space="preserve">
+	  <value>Test succesfully executed, result value:
+
+{0}</value>
+  </data>
+  <data name="SensorsMod_TestPowershell_MessageBox3" xml:space="preserve">
+	  <value>The test failed to execute:
+
+{0}
+
+Do you want to open the logs folder?</value>
+  </data>
+  <data name="SensorType_BluetoothDevicesSensor" xml:space="preserve">
+    <value>BluetoothDevices</value>
+  </data>
+  <data name="SensorType_BluetoothLeDevicesSensor" xml:space="preserve">
+    <value>BluetoothLeDevices</value>
+  </data>
+  <data name="ServiceControllerManager_Error_Fatal" xml:space="preserve">
+    <value>Fatal error, please check logs for information!</value>
+  </data>
+  <data name="ServiceControllerManager_Error_Timeout" xml:space="preserve">
+    <value>Timeout expired</value>
+  </data>
+  <data name="ServiceControllerManager_Error_Unknown" xml:space="preserve">
+    <value>unknown reason</value>
+  </data>
+  <data name="ServiceHelper_ChangeStartMode_Error1" xml:space="preserve">
+    <value>unable to open Service Manager</value>
+  </data>
+  <data name="ServiceHelper_ChangeStartMode_Error2" xml:space="preserve">
+    <value>unable to open service</value>
+  </data>
+  <data name="ServiceHelper_ChangeStartMode_Error3" xml:space="preserve">
+    <value>Error configuring startup mode, please check the logs for more information.</value>
+  </data>
+  <data name="ServiceHelper_ChangeStartMode_Error4" xml:space="preserve">
+    <value>Error setting startup mode, please check the logs for more information.</value>
+  </data>
+  <data name="WebView_InitializeAsync_MessageBox1" xml:space="preserve">
+	  <value>Microsoft's WebView2 runtime isn't found on your machine. Usually this is handled by the installer, but you can install it manually.
+
+Do you want to download the runtime installer?</value>
+  </data>
+  <data name="WebView_InitializeAsync_MessageBox2" xml:space="preserve">
+    <value>Something went wrong while initializing the WebView! Please check your logs and open a GitHub issue for further assistance.</value>
+  </data>
+  <data name="QuickActionsMod_ClmDomain" xml:space="preserve">
+	  <value>domain</value>
+  </data>
+  <data name="CommandsManager_SwitchDesktopCommandDescription" xml:space="preserve">
+    <value>Activates provided Virtual Desktop. Desktop ID can be retrieved from the "ActiveDesktop" sensor.</value>
+  </data>
+  <data name="SensorsManager_ActiveDesktopSensorDescription" xml:space="preserve">
+    <value>Provides the ID of the currently active virtual desktop.</value>
+  </data>
+  <data name="CommandsManager_RadioCommandDescription" xml:space="preserve">
+    <value>Switches selected radio device on/off. Availability of radio devices depends on the device HASS.Agent is installed on.</value>
+  </data>
+  <data name="CommandType_RadioCommand" xml:space="preserve">
+    <value>RadioCommand</value>
+  </data>
+  <data name="CommandsMod_LblSetting_Radio" xml:space="preserve">
+    <value>Radio device</value>
+  </data>
+  <data name="CommandsMod_BtnStore_MessageBox11" xml:space="preserve">
+    <value>Please select radio device!</value>
+  </data>
+  <data name="SensorsManager_InternalDeviceSensorDescription" xml:space="preserve">
+    <value>Provides data from the internal device sensor.
+Availability of the sensor depends on the device, in some cases no sensors will be available.</value>
+  </data>
+  <data name="SensorType_InternalDeviceSensor" xml:space="preserve">
+    <value>InternalDeviceSensor</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_InternalSensor" xml:space="preserve">
+    <value>Internal Sensor</value>
+  </data>
+  <data name="SensorsMod_None" xml:space="preserve">
+    <value>None</value>
+  </data>
+  <data name="SensorsMod_CbIgnoreAvailability" xml:space="preserve">
+    <value>&amp;Ignore availability</value>
+  </data>
+  <data name="SensorsMod_IgnoreAvailability_Info" xml:space="preserve">
+    <value>Please note that ignoring availability will cause Home Assistant to always display last value for a given sensor, even when HASS.Agent is offline.</value>
+  </data>
+  <data name="ConfigNotifications_CbNotificationsOpenActionUri" xml:space="preserve">
+    <value>&amp;Treat URI Action elements like Android Companion App (open)</value>
+  </data>
+  <data name="ConfigNotifications_TestNotification_No" xml:space="preserve">
+    <value>No</value>
+  </data>
+  <data name="ConfigNotifications_TestNotification_Yes" xml:space="preserve">
+    <value>Yes</value>
+  </data>
+  <data name="ConfigNotifications_TestNotification_InputText" xml:space="preserve">
+    <value>Notification Input Text</value>
+  </data>
+  <data name="ConfigNotifications_TestNotification_InputTitle" xml:space="preserve">
+    <value>Notification Input Title</value>
+  </data>
+  <data name="SensorsMod_BtnStore_DeviceNameInSensorName" xml:space="preserve">
+    <value>Device name in the sensor name might cause issues with Home Assistant versions starting with 2023.8.</value>
+  </data>
+  <data name="CommandsMod_BtnStore_DeviceNameInSensorName" xml:space="preserve">
+    <value>Device name in the command name might cause issues with Home Assistant versions starting with 2023.8.</value>
+  </data>
+  <data name="Compat_NameTask_Name" xml:space="preserve">
+    <value>Changing entity names
+to match Home Assistant 2023.8 requirements</value>
+  </data>
+  <data name="Compat_Error_CheckLogs" xml:space="preserve">
+    <value>Error, please check logs for more information.</value>
+  </data>
+  <data name="Compat_NameTask_Error_SingleValueSensors" xml:space="preserve">
+    <value>Error converting single value sensors!</value>
+  </data>
+  <data name="Compat_NameTask_Error_Commands" xml:space="preserve">
+    <value>Error converting commands!</value>
+  </data>
+  <data name="Compat_NameTask_Error_MultiValueSensors" xml:space="preserve">
+    <value>Error converting multi value sensors!</value>
+  </data>
+  <data name="SensorsMod_CbApplyRounding_LastActive" xml:space="preserve">
+    <value>Force action
+when system
+wakes from sleep/hibernation</value>
+  </data>
+  <data name="CommandsManager_SetApplicationVolumeCommandDescription" xml:space="preserve">
+    <value>Sets the volume and mute status of the provided application on provided audio device to the specified level.
+Command / payload needs to be in JSON format. Example of all possible options:
+{
+  "playbackDevice": "Speakers (THX Spatial Audio)",
+  "applicationName": "Discord",
+  "volume": 90,
+  "mute": true
+}
+
+If no "playbackDevice" is provided, HASS.Agent will use the default one.
+If no "volume" is provided, HASS.Agent will set only mute status.
+If no "mute" is provided, HASS.Agent will unmute the provided application.
+
+Advanced option: additional "sessionId" can be provided to set volume only for specific session of the application, session id can be obtained from "Audio Sessions" sensor:
+{
+   "playbackDevice":"Speakers (THX SpatialAudio)",
+   "applicationName":"Discord",
+   "volume":50,
+   "sessionid":"&lt;LONG SESSION ID FROM SENSOR&gt;"
+}Sets the volume and mute status of the provided application on provided audio device to the specified level.
+Command / payload needs to be in JSON format. Example of all possible options:
+{
+  "playbackDevice": "Speakers (THX Spatial Audio)",
+  "applicationName": "Discord",
+  "volume": 90,
+  "mute": true
+}
+
+If no "playbackDevice" is provided, HASS.Agent will use the default one.
+If no "volume" is provided, HASS.Agent will set only mute status.
+If no "mute" is provided, HASS.Agent will unmute the provided application.
+
+Advanced option: additional "sessionId" can be provided to set volume only for specific session of the application, session id can be obtained from "Audio Sessions" sensor:
+{
+   "playbackDevice":"Speakers (THX SpatialAudio)",
+   "applicationName":"Discord",
+   "volume":50,
+   "sessionid":"&lt;LONG SESSION ID FROM SENSOR&gt;"
+}</value>
+  </data>
+  <data name="CommandsMod_BtnStore_InvalidJson" xml:space="preserve">
+    <value>Please enter a valid JSON string!</value>
+  </data>
+  <data name="CommandsMod_BtnStore_VirtualDesktop_Unavailable" xml:space="preserve">
+    <value>Virtual Desktop management is unavailable on your machine.
+Usually this is due to the virtual desktop management library not being updated to support your version of Windows.</value>
+  </data>
+  <data name="Compat_MigrateTask_Name" xml:space="preserve">
+    <value>Migrating HASS.Agent configuration
+from the original version</value>
+  </data>
+  <data name="About_LblInfo2_1" xml:space="preserve">
+    <value>Updated and maintained with love by</value>
+  </data>
+  <data name="About_LblInfo4_1" xml:space="preserve">
+    <value>Even bigger 'thank you' for LAB02 Research and Sam for developing the original version of HASS.Agent - this would wouldn't exist without it!</value>
+  </data>
+  <data name="Compat_NameTask_Error_ServiceStart" xml:space="preserve">
+    <value>Error starting satellite service!</value>
+  </data>
+  <data name="Compat_NameTask_Error_ServiceCommunication" xml:space="preserve">
+    <value>Error communicating with the satellite service!</value>
+  </data>
+  <data name="CommandsManager_SetAudioOutputCommandDescription" xml:space="preserve">
+    <value>Sets the default audio output for the system.
+Requires audio device name as a payload.</value>
+  </data>
+  <data name="CommandsMod_LblSetting_AudioDeviceName" xml:space="preserve">
+    <value>Audio Device Name</value>
+  </data>
+  <data name="CommandsMod_LblSetting_JsonPayload" xml:space="preserve">
+    <value>JSON Command Payload</value>
+  </data>
+  <data name="CommandsMod_LblSetting_VolumeRange" xml:space="preserve">
+    <value>Volume (between 0 and 100)</value>
+  </data>
+  <data name="SensorsMod_LblSetting1_ScreenNumber" xml:space="preserve">
+    <value>Screen number</value>
+  </data>
+  <data name="SensorsManager_ScreenshotSensorDescription" xml:space="preserve">
+    <value>Provides a screenshot sensor in form of a camera entity.
+Screen number depends on system configuration - starts at 0.</value>
+  </data>
+  <data name="CommandsManager_SetAudioInputCommandDescription" xml:space="preserve">
+    <value>Sets the default audio input for the system (including default communication device).
+Requires audio device name as a payload.</value>
+  </data>
+  <data name="ConfigMqtt_CbIgnoreGracePeriod" xml:space="preserve">
+    <value>Ignore grace period after waking up from hibernation</value>
+  </data>
+  <data name="ConfigTrayIcon_CbUseModernIcon" xml:space="preserve">
+    <value>Use modern tray icon</value>
+  </data>
+  <data name="SensorsManager_MicrophoneProcessSensorDescription" xml:space="preserve">
+    <value>Provides the number of the processes that currently use the microphone - additionally provides name of the processes in the sensor's attributes.
+
+Note: if used in the satellite service, it won't detect userspace applications.</value>
+  </data>
+  <data name="Configuration_NFC" xml:space="preserve">
+    <value>NFC</value>
+  </data>
+  <data name="SensorsMod_BtnAdvancedSettings" xml:space="preserve">
+    <value>Ad&amp;vanced Settings</value>
+  </data>
+  <data name="AdvancedSensorConfig_Warning" xml:space="preserve">
+    <value>Warning, adding following settings (overrides) may break the sensor, use with caution!</value>
+  </data>
+  <data name="AdvancedSensorConfig_LblDeviceClass" xml:space="preserve">
+    <value>Device class</value>
+  </data>
+  <data name="AdvancedSensorConfig_LblUnitOfMeasurement" xml:space="preserve">
+    <value>Unit of measurement</value>
+  </data>
+  <data name="AdvancedSensorConfig_LblStateClass" xml:space="preserve">
+    <value>State class</value>
+  </data>
+  <data name="AdvancedSensorConfig_Title" xml:space="preserve">
+    <value>Advanced Settings</value>
+  </data>
+  <data name="CommandsManager_TrayWebViewCommandDescription" xml:space="preserve">
+    <value>Shows / hides the Tray Icon Web View.
+Requires it to be configured in "Configuration -&gt; Tray Icon"</value>
+  </data>
+  <data name="HassAction_Trigger" xml:space="preserve">
+    <value>Trigger</value>
+  </data>
+  <data name="HassDomain_Button" xml:space="preserve">
+    <value>Button</value>
+  </data>
+  <data name="HassAction_Press" xml:space="preserve">
+    <value>Press</value>
+  </data>
+  <data name="Notification_Dismiss" xml:space="preserve">
+    <value>Dismiss</value>
+  </data>
+  <data name="Main_CheckForUpdateFailed_MessageBox1" xml:space="preserve">
+    <value>Failed checking for update!</value>
+  </data>
+  <data name="SensorType_NamedActiveWindowSensor" xml:space="preserve">
+    <value>NamedActiveWindow</value>
+  </data>
+  <data name="SensorsManager_NamedActiveWindowSensorDescription" xml:space="preserve">
+    <value>Provides an ON/OFF value based on whether the focused window name contains configured string.</value>
+  </data>
+  <data name="SensorsManager_AccentColorSensorDescription" xml:space="preserve">
+    <value>Provides #RRGGBB color values for system accent colors.
+Main accent color is the sensor value, additional accent colors are available as attributes.</value>
+  </data>
+  <data name="ConfigMqtt_CbUseWebSocket" xml:space="preserve">
+    <value>Use &amp;WebSocket</value>
+  </data>
+  <data name="ServiceMqtt_CbUseWebSocket" xml:space="preserve">
+    <value>Use &amp;WebSocket</value>
+  </data>
+  <data name="HassDomain_InputButton" xml:space="preserve">
+    <value>InputButton</value>
+  </data>
+  <data name="HassDomain_Fan" xml:space="preserve">
+    <value>Fan</value>
+  </data>
+  <data name="CommandsManager_WinformsSleepCommandDescription" xml:space="preserve">
+    <value>Puts the machine to sleep using WinForms API.
+
+Note: due to "Modern Sleep" the sleep commands might behave differently depending on the device OEM and OS configuration.</value>
+  </data>
+  <data name="CommandType_WinformsSleepCommand" xml:space="preserve">
+    <value>WinformsSleep</value>
+  </data>
+  <data name="OnboardingMqtt_BtnTest_MessageOk" xml:space="preserve">
+    <value>Connection OK!</value>
+  </data>
+  <data name="OnboardingMqtt_BtnTest_MessageError" xml:space="preserve">
+    <value>Unable to connect.</value>
+  </data>
+  <data name="CommandType_MonitorSleepPowerPlanCommand" xml:space="preserve">
+    <value>MonitorSleepPowerPlan</value>
+  </data>
+  <data name="CommandsManager_MonitorSleepPowerPlanCommandDescription" xml:space="preserve">
+    <value>Puts all monitors in sleep (low power) mode using alternative approach of power plan modification.
+Should provide better experience with new systems with "modern S0ix sleep" and not put the system to sleep.</value>
+  </data>
+</root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.zh-CN.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -118,2086 +118,2084 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ConfigExternalTools_LblInfo1" xml:space="preserve">
-    <value>This page allows you to configure bindings with external tools.</value>
+    <value>此页面允许您配置与外部工具的绑定。</value>
   </data>
   <data name="ConfigExternalTools_LblBrowserName" xml:space="preserve">
-    <value>Browser Name</value>
+    <value>浏览器名称</value>
   </data>
   <data name="ConfigExternalTools_LblInfo2" xml:space="preserve">
-	  <value>By default HASS.Agent will launch URLs using your default browser. You can also configure
-a specific browser to be used instead along with launch arguments to run in private mode.</value>
+    <value>默认情况下，HASS.Agent 将使用您的默认浏览器打开 URL。您也可以配置
+一个特定的浏览器来替代使用，并附带启动参数以隐私模式运行。</value>
   </data>
   <data name="ConfigExternalTools_LblBrowserBinary" xml:space="preserve">
-    <value>Browser Binary</value>
+    <value>浏览器可执行文件</value>
   </data>
   <data name="ConfigExternalTools_LblLaunchIncogArg" xml:space="preserve">
-    <value>Additional Launch Arguments</value>
+    <value>额外的启动参数</value>
   </data>
   <data name="ConfigExternalTools_LblCustomExecutorBinary" xml:space="preserve">
-    <value>Custom Executor Binary</value>
+    <value>自定义执行器可执行文件</value>
   </data>
   <data name="ConfigExternalTools_LblInfo3" xml:space="preserve">
-	  <value>You can configure the HASS.Agent to use a specific interpreter such as Perl or Python.
-Use the 'custom executor' command to launch this executor.</value>
+    <value>您可以将 HASS.Agent 配置为使用特定的解释器，例如 Perl 或 Python。
+使用"自定义执行器"命令来启动此执行器。</value>
   </data>
   <data name="ConfigExternalTools_LblCustomExecutorName" xml:space="preserve">
-    <value>Custom Executor Name</value>
+    <value>自定义执行器名称</value>
   </data>
   <data name="ConfigExternalTools_LblTip1" xml:space="preserve">
-    <value>Tip: Double-click to Browse</value>
+    <value>提示：双击以浏览</value>
   </data>
   <data name="ConfigExternalTools_BtnExternalBrowserIncognitoTest" xml:space="preserve">
-    <value>&amp;Test</value>
+    <value>测试(&T)</value>
   </data>
   <data name="ConfigGeneral_LblInfo4" xml:space="preserve">
-	  <value>HASS.Agent will wait a grace period before notifying you of disconnects from MQTT or HA's API.
-You can set the amount of seconds to wait in this grace period below.</value>
+    <value>HASS.Agent 在通知您与 MQTT 或 HA 的 API 断开连接之前会等待一个宽限期。
+您可以在下方设置此宽限期内等待的秒数。</value>
   </data>
   <data name="ConfigGeneral_LblDisconGraceSeconds" xml:space="preserve">
-    <value>Seconds</value>
+    <value>秒</value>
   </data>
   <data name="ConfigGeneral_LblDisconGracePeriod" xml:space="preserve">
-    <value>Disconnected Grace &amp;Period</value>
+    <value>断开连接宽限期(&P)</value>
   </data>
   <data name="ConfigGeneral_LblInfo3" xml:space="preserve">
-	  <value>IMPORTANT: if you change this value, HASS.Agent will unpublish all your sensors, commands and force a restart of itself so they can be republished under the new device name.
-Your automations and scripts will keep working.</value>
+    <value>重要提示：如果您更改此值，HASS.Agent 将取消发布所有传感器和命令，并强制重启自身，以便它们可以在新设备名称下重新发布。
+您的自动化和脚本将继续工作。</value>
   </data>
   <data name="ConfigGeneral_LblInfo2" xml:space="preserve">
-	  <value>The device name is used to identify your machine on Home Assistant.
-It is also used as a prefix for your command/sensor names (this can be changed per entity).</value>
+    <value>设备名称用于在 Home Assistant 中标识您的机器。
+它还用作您的命令/传感器名称的前缀（可以按实体更改）。</value>
   </data>
   <data name="ConfigGeneral_LblInfo1" xml:space="preserve">
-    <value>This page contains general configuration settings, for more settings you can browse the tabs on the left.</value>
+    <value>此页面包含常规配置设置，如需更多设置，您可以浏览左侧的选项卡。</value>
   </data>
   <data name="ConfigGeneral_LblDeviceName" xml:space="preserve">
-    <value>Device &amp;Name</value>
+    <value>设备名称(&N)</value>
   </data>
   <data name="ConfigHomeAssistantApi_LblTip1" xml:space="preserve">
-    <value>Tip: Double-click this field to browse</value>
+    <value>提示：双击此字段以浏览</value>
   </data>
   <data name="ConfigHomeAssistantApi_LblClientCertificate" xml:space="preserve">
-    <value>Client &amp;Certificate</value>
+    <value>客户端证书(&C)</value>
   </data>
   <data name="ConfigHomeAssistantApi_CbHassAutoClientCertificate" xml:space="preserve">
-    <value>Use &amp;automatic client certificate selection</value>
+    <value>使用自动客户端证书选择(&A)</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi" xml:space="preserve">
-    <value>&amp;Test Connection</value>
+    <value>测试连接(&T)</value>
   </data>
   <data name="ConfigHomeAssistantApi_LblInfo1" xml:space="preserve">
-	  <value>To learn which entities you have configured and to send quick actions, HASS.Agent uses
-Home Assistant's API.
+    <value>为了解您配置了哪些实体以及发送快捷操作，HASS.Agent 使用
+Home Assistant 的 API。
 
-Please provide a long-lived access token and the address of your Home Assistant instance.
-You can get a token in Home Assistant by clicking your profile picture at the bottom-left
-and navigating to the bottom of the page until you see the 'CREATE TOKEN' button.
+请提供一个长期有效的访问令牌和您的 Home Assistant 实例地址。
+您可以在 Home Assistant 中点击左下角的个人资料图片，
+并导航到页面底部，直到您看到"创建令牌"按钮。
 
-Please note, that for actionable notification functionality you need to provide admin account token.</value>
+请注意，要使用可操作通知功能，您需要提供管理员账户令牌。</value>
   </data>
   <data name="ConfigHomeAssistantApi_LblApiToken" xml:space="preserve">
-    <value>&amp;API Token</value>
+    <value>API 令牌(&A)</value>
   </data>
   <data name="ConfigHomeAssistantApi_LblServerUri" xml:space="preserve">
-    <value>Server &amp;URI</value>
+    <value>服务器 URI(&U)</value>
   </data>
   <data name="ConfigHotKey_BtnClearHotKey" xml:space="preserve">
-    <value>&amp;Clear</value>
+    <value>清除(&C)</value>
   </data>
   <data name="ConfigHotKey_LblInfo1" xml:space="preserve">
-	  <value>An easy way to pull up your quick actions is to use a global hotkey.
+    <value>调出快捷操作的一种简单方式是使用全局热键。
 
-This way, whatever you're doing on your machine, you can always interact with Home Assistant.</value>
+这样，无论您在机器上做什么，都可以随时与 Home Assistant 交互。</value>
   </data>
   <data name="ConfigHotKey_CbEnableQuickActionsHotkey" xml:space="preserve">
-    <value>&amp;Enable Quick Actions Hotkey</value>
+    <value>启用快捷操作热键(&E)</value>
   </data>
   <data name="ConfigHotKey_LblHotkeyCombo" xml:space="preserve">
-    <value>&amp;Hotkey Combination</value>
+    <value>热键组合(&H)</value>
   </data>
   <data name="ConfigLocalStorage_BtnClearImageCache" xml:space="preserve">
-    <value>Clear Image Cache</value>
+    <value>清除图像缓存</value>
   </data>
   <data name="ConfigLocalStorage_BtnOpenImageCache" xml:space="preserve">
-    <value>Open Folder</value>
+    <value>打开文件夹</value>
   </data>
   <data name="ConfigLocalStorage_LblCacheLocations" xml:space="preserve">
-    <value>Image Cache Location</value>
+    <value>图像缓存位置</value>
   </data>
   <data name="ConfigLocalStorage_LblCacheDays" xml:space="preserve">
-    <value>days</value>
+    <value>天</value>
   </data>
   <data name="ConfigLocalStorage_LblInfo1" xml:space="preserve">
-	  <value>Some items like images shown in notifications have to be temporarily stored locally. You can
-configure the amount of days they should be kept before HASS.Agent deletes them.
+    <value>某些项目（如通知中显示的图像）需要临时存储在本地。您可以
+配置 HASS.Agent 删除它们之前保留的天数。
 
-Enter '0' to keep them permanently.</value>
+输入"0"以永久保留它们。</value>
   </data>
   <data name="ConfigLogging_LblInfo1" xml:space="preserve">
-	  <value>Extended logging provides more verbose and in-depth logging, in case the default logging isn't
-sufficient. Please note that enabling this can cause the logfiles to grow large, and should only be
-used when you suspect something's wrong with HASS.Agent itself or when asked by the
-developers.</value>
+    <value>扩展日志记录提供更详细和深入的日志，以防默认日志记录
+不够用。请注意，启用此功能可能会导致日志文件变大，并且仅应在您怀疑
+HASS.Agent 本身有问题或开发者要求时使用。</value>
   </data>
   <data name="ConfigLogging_CbExtendedLogging" xml:space="preserve">
-    <value>&amp;Enable Extended Logging</value>
+    <value>启用扩展日志记录(&E)</value>
   </data>
   <data name="ConfigLogging_BtnShowLogs" xml:space="preserve">
-    <value>&amp;Open Logs Folder</value>
+    <value>打开日志文件夹(&O)</value>
   </data>
   <data name="ConfigMqtt_LblTip3" xml:space="preserve">
-    <value>Tip: Double-click these fields to browse</value>
+    <value>提示：双击这些字段以浏览</value>
   </data>
   <data name="ConfigMqtt_LblClientCert" xml:space="preserve">
-    <value>Client Certificate</value>
+    <value>客户端证书</value>
   </data>
   <data name="ConfigMqtt_LblRootCert" xml:space="preserve">
-    <value>Root Certificate</value>
+    <value>根证书</value>
   </data>
   <data name="ConfigMqtt_CbUseRetainFlag" xml:space="preserve">
-    <value>Use &amp;Retain Flag</value>
+    <value>使用保留标志(&R)</value>
   </data>
   <data name="ConfigMqtt_CbAllowUntrustedCertificates" xml:space="preserve">
-    <value>&amp;Allow Untrusted Certificates</value>
+    <value>允许不受信任的证书(&A)</value>
   </data>
   <data name="ConfigMqtt_BtnMqttClearConfig" xml:space="preserve">
-    <value>&amp;Clear Configuration</value>
+    <value>清除配置(&C)</value>
   </data>
   <data name="ConfigMqtt_LblTip1" xml:space="preserve">
-    <value>(leave default if unsure)</value>
+    <value>（如果不确定，保持默认）</value>
   </data>
   <data name="ConfigMqtt_LblInfo1" xml:space="preserve">
-	  <value>Commands and sensors use MQTT, as well as notifications and media player functions when using the new integration. 
+    <value>命令和传感器使用 MQTT，使用新集成时通知和媒体播放器功能也使用它。 
 
-Please provide credentials for your broker, if you're using the HA Mosquitto addon, you can probably use the preset address.
+请为您的代理提供凭据，如果您使用 HA Mosquitto 插件，您可能可以使用预设地址。
 
-Note: these settings (excluding the Client ID) will also be applied to the satellite service.</value>
+注意：这些设置（不包括客户端 ID）也将应用于卫星服务。</value>
   </data>
   <data name="ConfigMqtt_LblDiscoPrefix" xml:space="preserve">
-    <value>Discovery Prefix</value>
+    <value>发现前缀</value>
   </data>
   <data name="ConfigMqtt_LblBrokerPassword" xml:space="preserve">
-    <value>Password</value>
+    <value>密码</value>
   </data>
   <data name="ConfigMqtt_LblBrokerUsername" xml:space="preserve">
-    <value>Username</value>
+    <value>用户名</value>
   </data>
   <data name="ConfigMqtt_LblBrokerPort" xml:space="preserve">
-    <value>Port</value>
+    <value>端口</value>
   </data>
   <data name="ConfigMqtt_LblBrokerIp" xml:space="preserve">
-    <value>Broker IP Address or Hostname</value>
+    <value>代理 IP 地址或主机名</value>
   </data>
   <data name="ConfigMqtt_LblTip2" xml:space="preserve">
-    <value>(leave empty to auto generate)</value>
+    <value>（留空以自动生成）</value>
   </data>
   <data name="ConfigMqtt_LblClientId" xml:space="preserve">
-    <value>Client ID</value>
+    <value>客户端 ID</value>
   </data>
   <data name="ConfigNotifications_LblInfo2" xml:space="preserve">
-	  <value>If something is not working, make sure you try the following steps:
+    <value>如果某些功能不正常，请确保您尝试以下步骤：
 
-- Install the HASS.Agent integration
-- Restart Home Assistant
-- Make sure HASS.Agent is active with MQTT enabled!
-- Your device should get detected and added as an entity automatically
-- Optionally: manually add it using the local API</value>
+- 安装 HASS.Agent 集成
+- 重启 Home Assistant
+- 确保 HASS.Agent 处于活动状态且 MQTT 已启用！
+- 您的设备应被自动检测并添加为实体
+- 可选：使用本地 API 手动添加</value>
   </data>
   <data name="ConfigNotifications_LblInfo1" xml:space="preserve">
-    <value>HASS.Agent can receive notifications from Home Assistant, using text, images and actions. If you have MQTT enabled, your device will automatically get added. Otherwise, manually configure the integration to use the local API.</value>
+    <value>HASS.Agent 可以接收来自 Home Assistant 的通知，使用文本、图像和操作。如果您已启用 MQTT，您的设备将自动被添加。否则，请手动配置集成以使用本地 API。</value>
   </data>
   <data name="ConfigNotifications_BtnNotificationsReadme" xml:space="preserve">
-    <value>Notifications &amp;Documentation</value>
+    <value>通知文档(&D)</value>
   </data>
   <data name="ConfigNotifications_LblPort" xml:space="preserve">
-    <value>Port</value>
+    <value>端口</value>
   </data>
   <data name="ConfigNotifications_CbAcceptNotifications" xml:space="preserve">
-    <value>&amp;Accept Notifications</value>
+    <value>接受通知(&A)</value>
   </data>
   <data name="ConfigNotifications_BtnSendTestNotification" xml:space="preserve">
-    <value>Show Test Notification</value>
+    <value>显示测试通知</value>
   </data>
   <data name="ConfigNotifications_BtnExecutePortReservation" xml:space="preserve">
-    <value>Execute Port Reservation</value>
+    <value>执行端口预留</value>
   </data>
   <data name="ConfigNotifications_CbNotificationsIgnoreImageCertErrors" xml:space="preserve">
-    <value>&amp;Ignore certificate errors for images</value>
+    <value>忽略图像的证书错误(&I)</value>
   </data>
   <data name="ConfigService_LblInfo1" xml:space="preserve">
-	  <value>The satellite service allows you to run sensors and commands even when no user's logged in. 
-Use the 'satellite service' button on the main window to manage it.</value>
+    <value>卫星服务允许您在没有用户登录时运行传感器和命令。 
+使用主窗口上的"卫星服务"按钮来管理它。</value>
   </data>
   <data name="ConfigService_LblServiceStatusInfo" xml:space="preserve">
-    <value>Service Status:</value>
+    <value>服务状态：</value>
   </data>
   <data name="ConfigService_BtnStartService" xml:space="preserve">
-    <value>S&amp;tart Service</value>
+    <value>启动服务(&T)</value>
   </data>
   <data name="ConfigService_BtnDisableService" xml:space="preserve">
-    <value>&amp;Disable Service</value>
+    <value>禁用服务(&D)</value>
   </data>
   <data name="ConfigService_BtnStopService" xml:space="preserve">
-    <value>&amp;Stop Service</value>
+    <value>停止服务(&S)</value>
   </data>
   <data name="ConfigService_BtnEnableService" xml:space="preserve">
-    <value>&amp;Enable Service</value>
+    <value>启用服务(&E)</value>
   </data>
   <data name="ConfigService_BtnReinstallService" xml:space="preserve">
-    <value>&amp;Reinstall Service</value>
+    <value>重新安装服务(&R)</value>
   </data>
   <data name="ConfigService_LblInfo2" xml:space="preserve">
-	  <value>If you do not configure the service, it won't do anything. However, you can still decide to disable it as well.
-The installer will leave the disabled service alone(if you remove the service, the installer will reinstall it).</value>
+    <value>如果您不配置服务，它将不会执行任何操作。不过，您也可以选择禁用它。
+安装程序将保留已禁用的服务（如果您删除了服务，安装程序将重新安装它）。</value>
   </data>
   <data name="ConfigService_LblInfo3" xml:space="preserve">
-	  <value>You can try reinstalling the service if it's not working correctly.
-Your configuration and entities won't be removed.</value>
+    <value>如果服务无法正常工作，您可以尝试重新安装服务。
+您的配置和实体不会被删除。</value>
   </data>
   <data name="ConfigService_BtnShowLogs" xml:space="preserve">
-    <value>Open Service &amp;Logs Folder</value>
+    <value>打开服务日志文件夹(&L)</value>
   </data>
   <data name="ConfigService_LblInfo4" xml:space="preserve">
-    <value>If the service still fails after reinstalling, please open a ticket and send the content of the latest log.</value>
+    <value>如果重新安装后服务仍然失败，请提交工单并发送最新日志的内容。</value>
   </data>
   <data name="ConfigStartup_LblInfo1" xml:space="preserve">
-	  <value>HASS.Agent can start when you login by creating an entry in your user profile's registry.
+    <value>HASS.Agent 可以通过在您的用户配置文件的注册表中创建条目，在您登录时启动。
 
-Since HASS.Agent is user based, if you want to launch for another user, just install and config
-HASS.Agent there.</value>
+由于 HASS.Agent 基于用户，如果您想为其他用户启动，只需在该用户处安装和配置
+HASS.Agent 即可。</value>
   </data>
   <data name="ConfigStartup_BtnSetStartOnLogin" xml:space="preserve">
-    <value>&amp;Enable Start-on-Login</value>
+    <value>启用登录时启动(&E)</value>
   </data>
   <data name="ConfigStartup_LblStartOnLoginStatusInfo" xml:space="preserve">
-    <value>Start-on-Login Status:</value>
+    <value>登录时启动状态：</value>
   </data>
   <data name="ConfigUpdates_CbBetaUpdates" xml:space="preserve">
-    <value>Notify me of &amp;beta releases</value>
+    <value>通知我测试版发布(&B)</value>
   </data>
   <data name="ConfigUpdates_LblInfo2" xml:space="preserve">
-	  <value>When a new update is available, HASS.Agent can download the installer and launch it for you.
+    <value>当有新更新可用时，HASS.Agent 可以下载安装程序并为您启动它。
 
-The certificate of the downloaded file will get checked before running,you will still get to review the release notes and manually approve the update.</value>
+在运行之前将检查下载文件的证书，您仍然可以查看发布说明并手动批准更新。</value>
   </data>
   <data name="ConfigUpdates_CbExecuteUpdater" xml:space="preserve">
-    <value>Automatically &amp;download future updates</value>
+    <value>自动下载未来更新(&D)</value>
   </data>
   <data name="ConfigUpdates_LblInfo1" xml:space="preserve">
-	  <value>HASS.Agent checks for updates in the background if enabled.
+    <value>如果启用，HASS.Agent 将在后台检查更新。
 
-You will be sent a push notification if a new update is discovered, letting you know a
-new version is ready to be installed.</value>
+如果发现新更新，您将收到推送通知，告知您有
+新版本已准备好安装。</value>
   </data>
   <data name="ConfigUpdates_CbUpdates" xml:space="preserve">
-    <value>Notify me when a new &amp;release is available</value>
+    <value>当有新版本可用时通知我(&R)</value>
   </data>
   <data name="OnboardingWelcome_LblInfo1" xml:space="preserve">
-	  <value>Welcome to the HASS.Agent! It looks like this is the first time you are launching the agent.
+    <value>欢迎使用 HASS.Agent！看起来这是您第一次启动代理。
 
-To assist you with a first time setup, proceed with the configuration steps below
-or alternatively, click 'Close'.</value>
+为了帮助您完成首次设置，请按照下面的配置步骤操作，
+或者点击"关闭"。</value>
   </data>
   <data name="OnboardingWelcome_LblInfo2" xml:space="preserve">
-    <value>The device name is used to identify your machine on Home Assistant, it is also used as a suggested prefix for your commands and sensors.</value>
+    <value>设备名称用于在 Home Assistant 中标识您的机器，它也用作您的命令和传感器的建议前缀。</value>
   </data>
   <data name="OnboardingWelcome_LblDeviceName" xml:space="preserve">
-    <value>Device &amp;Name</value>
+    <value>设备名称(&N)</value>
   </data>
   <data name="OnboardingStartup_BtnSetLaunchOnLogin" xml:space="preserve">
-    <value>Yes, &amp;start HASS.Agent on System Login</value>
+    <value>是的，在系统登录时启动 HASS.Agent(&S)</value>
   </data>
   <data name="OnboardingStartup_LblInfo1" xml:space="preserve">
-	  <value>HASS.Agent can start with your system, this allows for any sensors and data transmission between your device and Home Assistant to begin as soon as you login.
+    <value>HASS.Agent 可以随您的系统启动，这使得您的设备和 Home Assistant 之间的任何传感器和数据传输在您登录时立即开始。
 
-This setting can be changed any time later in the HASS.Agent configuration window.</value>
+此设置可以稍后在 HASS.Agent 配置窗口中随时更改。</value>
   </data>
   <data name="OnboardingStartup_LblCreateInfo" xml:space="preserve">
-    <value>Fetching current state, please wait..</value>
+    <value>正在获取当前状态，请稍候..</value>
   </data>
   <data name="OnboardingNotifications_LblTip1" xml:space="preserve">
-    <value>Note: 5115 is the default port, only change it if you changed it in Home Assistant.</value>
+    <value>注意：5115 是默认端口，只有在 Home Assistant 中更改过才需要更改它。</value>
   </data>
   <data name="OnboardingNotifications_CbAcceptNotifications" xml:space="preserve">
-    <value>Yes, accept notifications on port</value>
+    <value>是的，在端口上接受通知</value>
   </data>
   <data name="OnboardingNotifications_LblInfo1" xml:space="preserve">
-	  <value>HASS.Agent can receive notifications from Home Assistant, using text and/or images.
+    <value>HASS.Agent 可以接收来自 Home Assistant 的通知，使用文本和/或图像。
 
-Do you want to enable this function?</value>
+您想启用此功能吗？</value>
   </data>
   <data name="OnboardingIntegration_LblIntegration" xml:space="preserve">
-    <value>HASS.Agent-Notifier GitHub Page</value>
+    <value>HASS.Agent-Notifier GitHub 页面</value>
   </data>
   <data name="OnboardingIntegration_LblInfo2" xml:space="preserve">
-	  <value>Make sure you follow these steps:
+    <value>确保您按照以下步骤操作：
 
-- Install HASS.Agent-Notifier integration
-- Restart Home Assistant
-- Configure a notifier entity
-- Restart Home Assistant</value>
+- 安装 HASS.Agent-Notifier 集成
+- 重启 Home Assistant
+- 配置通知器实体
+- 重启 Home Assistant</value>
   </data>
   <data name="OnboardingIntegration_LblInfo1" xml:space="preserve">
-	  <value>To use notifications, you need to install and configure the HASS.Agent-notifier integration in
-Home Assistant.
+    <value>要使用通知，您需要在 Home Assistant 中安装和配置 HASS.Agent-notifier 集成。
 
-This is very easy using HACS but may also be installed manually, visit the link below for more
-information.</value>
+使用 HACS 非常简单，也可以手动安装，请访问下面的链接获取更多
+信息。</value>
   </data>
   <data name="OnboardingApi_LblApiToken" xml:space="preserve">
-    <value>API &amp;Token</value>
+    <value>API 令牌(&T)</value>
   </data>
   <data name="OnboardingApi_LblServerUri" xml:space="preserve">
-    <value>Server &amp;URI (should be ok like this)</value>
+    <value>服务器 URI(&U)（这样就很好）</value>
   </data>
   <data name="OnboardingApi_LblInfo1" xml:space="preserve">
-	  <value>To learn which entities you have configured and to send quick actions, HASS.Agent uses
-Home Assistant's API.
+    <value>为了解您配置了哪些实体以及发送快捷操作，HASS.Agent 使用
+Home Assistant 的 API。
 
-Please provide a long-lived access token and the address of your Home Assistant instance.
-You can get a token in Home Assistant by clicking your profile picture at the bottom-left
-and navigating to the bottom of the page until you see the 'CREATE TOKEN' button.</value>
+请提供一个长期有效的访问令牌和您的 Home Assistant 实例地址。
+您可以在 Home Assistant 中点击左下角的个人资料图片，
+并导航到页面底部，直到您看到"创建令牌"按钮。</value>
   </data>
   <data name="OnboardingApi_BtnTest" xml:space="preserve">
-    <value>Test &amp;Connection</value>
+    <value>测试连接(&C)</value>
   </data>
   <data name="OnboardingApi_LblTip1" xml:space="preserve">
-    <value>Tip: Specialized settings can be found in the Configuration Window.</value>
+    <value>提示：可以在配置窗口中找到专用设置。</value>
   </data>
   <data name="OnboardingMqtt_LblPassword" xml:space="preserve">
-    <value>Password</value>
+    <value>密码</value>
   </data>
   <data name="OnboardingMqtt_LblUsername" xml:space="preserve">
-    <value>Username</value>
+    <value>用户名</value>
   </data>
   <data name="OnboardingMqtt_LblPort" xml:space="preserve">
-    <value>Port</value>
+    <value>端口</value>
   </data>
   <data name="OnboardingMqtt_LblIpAdress" xml:space="preserve">
-    <value>IP Address or Hostname</value>
+    <value>IP 地址或主机名</value>
   </data>
   <data name="OnboardingMqtt_LblInfo1" xml:space="preserve">
-	  <value>Commands and sensors are sent through MQTT. The notifications- and media player integration also make use of them.
+    <value>命令和传感器通过 MQTT 发送。通知和媒体播放器集成也使用它们。
 
-Tip: if you're using the HA addon, you can probably use the preset address - just provide credentials.
+提示：如果您使用 HA 插件，您可能可以使用预设地址 - 只需提供凭据。
 </value>
   </data>
   <data name="OnboardingMqtt_LblDiscoveryPrefix" xml:space="preserve">
-    <value>Discovery Prefix</value>
+    <value>发现前缀</value>
   </data>
   <data name="OnboardingMqtt_LblTip1" xml:space="preserve">
-    <value>(leave default if not sure)</value>
+    <value>（如果不确定，保持默认）</value>
   </data>
   <data name="OnboardingMqtt_LblTip2" xml:space="preserve">
-    <value>Tip: Specialized settings can be found in the Configuration Window.</value>
+    <value>提示：可以在配置窗口中找到专用设置。</value>
   </data>
   <data name="OnboardingHotKey_LblHotkeyCombo" xml:space="preserve">
-    <value>&amp;Hotkey Combination</value>
+    <value>热键组合(&H)</value>
   </data>
   <data name="OnboardingHotKey_LblInfo1" xml:space="preserve">
-	  <value>An easy way to pull up your quick actions is to use a global hotkey.
+    <value>调出快捷操作的一种简单方式是使用全局热键。
 
-This way, whatever you're doing on your machine, you can always interact with Home Assistant.
+这样，无论您在机器上做什么，都可以随时与 Home Assistant 交互。
 </value>
   </data>
   <data name="OnboardingHotKey_BtnClear" xml:space="preserve">
-    <value>&amp;Clear</value>
+    <value>清除(&C)</value>
   </data>
   <data name="OnboardingUpdates_LblInfo1" xml:space="preserve">
-	  <value>HASS.Agent checks for updates in the background if enabled.
+    <value>如果启用，HASS.Agent 将在后台检查更新。
 
-You will be sent a push notification if a new update is discovered, letting you know a
-new version is ready to be installed.
+如果发现新更新，您将收到推送通知，告知您有
+新版本已准备好安装。
 
-Do you want to enable this automatic update checks?</value>
+您想启用此自动更新检查吗？</value>
   </data>
   <data name="OnboardingUpdates_CbNofityOnUpdate" xml:space="preserve">
     <value>Yes, notify me on new &amp;updates</value>
   </data>
   <data name="OnboardingUpdates_CbExecuteUpdater" xml:space="preserve">
-    <value>Yes, &amp;download and launch the installer for me</value>
+    <value>是的，为我下载并启动安装程序(&D)</value>
   </data>
   <data name="OnboardingUpdates_LblInfo2" xml:space="preserve">
-	  <value>When a new update is available, HASS.Agent can download the installer and launch it for you.
+    <value>当有新更新可用时，HASS.Agent 可以下载安装程序并为您启动它。
 
-The certificate of the downloaded file will get checked before running,you will still get to review the release notes and manually approve the update.</value>
+在运行之前将检查下载文件的证书，您仍然可以查看发布说明并手动批准更新。</value>
   </data>
   <data name="OnboardingDone_LblGitHub" xml:space="preserve">
-    <value>HASS.Agent GitHub page</value>
+    <value>HASS.Agent GitHub 页面</value>
   </data>
   <data name="OnboardingDone_LblInfo3" xml:space="preserve">
-	  <value>There's a lot more to tinker with, so make sure you take a look at the Configuration Window!
+    <value>还有更多内容可以探索，所以一定要看看配置窗口！
 
 
-Thank you for using HASS.Agent, hopefully it'll be useful for you :-)
+感谢您使用 HASS.Agent，希望它对您有用 :-)
 </value>
   </data>
   <data name="OnboardingDone_LblInfo2" xml:space="preserve">
-    <value>HASS.Agent will now restart to apply your configuration changes.</value>
+    <value>HASS.Agent 现在将重启以应用您的配置更改。</value>
   </data>
   <data name="OnboardingDone_LblInfo1" xml:space="preserve">
-    <value>Yay, done!</value>
+    <value>太好了，完成了！</value>
   </data>
   <data name="ServiceCommands_LblLowIntegrity" xml:space="preserve">
-    <value>Low Integrity</value>
+    <value>低完整性</value>
   </data>
   <data name="ServiceCommands_ClmName" xml:space="preserve">
-    <value>Name</value>
+    <value>名称</value>
   </data>
   <data name="ServiceCommands_ClmType" xml:space="preserve">
-    <value>Type</value>
+    <value>类型</value>
   </data>
   <data name="ServiceCommands_BtnRemove" xml:space="preserve">
-    <value>&amp;Remove</value>
+    <value>移除(&R)</value>
   </data>
   <data name="ServiceCommands_BtnModify" xml:space="preserve">
-    <value>&amp;Modify</value>
+    <value>修改(&M)</value>
   </data>
   <data name="ServiceCommands_BtnAdd" xml:space="preserve">
-    <value>&amp;Add New</value>
+    <value>添加新项(&A)</value>
   </data>
   <data name="ServiceCommands_BtnStore" xml:space="preserve">
-    <value>&amp;Send &amp;&amp; Activate Commands</value>
+    <value>发送并激活命令(&S)</value>
   </data>
   <data name="ServiceCommands_LblStored" xml:space="preserve">
-    <value>commands stored!</value>
+    <value>命令已存储！</value>
   </data>
   <data name="ServiceConnect_BtnRetryAuthId" xml:space="preserve">
-    <value>&amp;Apply</value>
+    <value>应用(&A)</value>
   </data>
   <data name="ServiceConnect_LblRetryAuthId" xml:space="preserve">
-    <value>Auth &amp;ID</value>
+    <value>身份验证 ID(&I)</value>
   </data>
   <data name="ServiceConnect_LblAuthenticate" xml:space="preserve">
-    <value>Authenticate</value>
+    <value>身份验证</value>
   </data>
   <data name="ServiceConnect_LblConnect" xml:space="preserve">
-    <value>Connect with service</value>
+    <value>与服务连接</value>
   </data>
   <data name="ServiceConnect_LblLoading" xml:space="preserve">
-    <value>Connecting satellite service, please wait..</value>
+    <value>正在连接卫星服务，请稍候..</value>
   </data>
   <data name="ServiceConnect_LblFetchConfig" xml:space="preserve">
-    <value>Fetch Configuration</value>
+    <value>获取配置</value>
   </data>
   <data name="ServiceGeneral_LblInfo1" xml:space="preserve">
-    <value>This page contains general configuration settings, for MQTT settings, commands, and sensors, browse the different tabs above.</value>
+    <value>此页面包含常规配置设置，如需 MQTT 设置、命令和传感器，请浏览上方不同的选项卡。</value>
   </data>
   <data name="ServiceGeneral_LblAuthId" xml:space="preserve">
-    <value>Auth &amp;ID</value>
+    <value>身份验证 ID(&I)</value>
   </data>
   <data name="ServiceGeneral_LblDeviceName" xml:space="preserve">
-    <value>Device &amp;Name</value>
+    <value>设备名称(&N)</value>
   </data>
   <data name="ServiceGeneral_LblTip1" xml:space="preserve">
-    <value>Tip: Double-click these fields to browse</value>
+    <value>提示：双击这些字段以浏览</value>
   </data>
   <data name="ServiceGeneral_LblCustomExecBinary" xml:space="preserve">
-    <value>Custom Executor &amp;Binary</value>
+    <value>自定义执行器可执行文件(&B)</value>
   </data>
   <data name="ServiceGeneral_LblCustomExecName" xml:space="preserve">
-    <value>Custom &amp;Executor Name</value>
+    <value>自定义执行器名称(&E)</value>
   </data>
   <data name="ServiceGeneral_LblSeconds" xml:space="preserve">
-    <value>seconds</value>
+    <value>秒</value>
   </data>
   <data name="ServiceGeneral_LblDisconGrace" xml:space="preserve">
-    <value>Disconnected Grace &amp;Period</value>
+    <value>断开连接宽限期(&P)</value>
   </data>
   <data name="ServiceGeneral_Apply" xml:space="preserve">
-    <value>Apply</value>
+    <value>应用</value>
   </data>
   <data name="ServiceGeneral_LblVersionInfo" xml:space="preserve">
-    <value>Version</value>
+    <value>版本</value>
   </data>
   <data name="ServiceGeneral_LblTip2" xml:space="preserve">
-    <value>Tip: Double-click to generate random</value>
+    <value>提示：双击以生成随机值</value>
   </data>
   <data name="ServiceGeneral_Stored" xml:space="preserve">
-    <value>Stored!</value>
+    <value>已存储！</value>
   </data>
   <data name="ServiceMqtt_LblTip2" xml:space="preserve">
-    <value>(leave empty to auto generate)</value>
+    <value>（留空以自动生成）</value>
   </data>
   <data name="ServiceMqtt_LblClientId" xml:space="preserve">
-    <value>Client ID</value>
+    <value>客户端 ID</value>
   </data>
   <data name="ServiceMqtt_LblTip3" xml:space="preserve">
-    <value>Tip: Double-click these fields to browse</value>
+    <value>提示：双击这些字段以浏览</value>
   </data>
   <data name="ServiceMqtt_LblClientCert" xml:space="preserve">
-    <value>Client Certificate</value>
+    <value>客户端证书</value>
   </data>
   <data name="ServiceMqtt_LblRootCert" xml:space="preserve">
-    <value>Root Certificate</value>
+    <value>根证书</value>
   </data>
   <data name="ServiceMqtt_CbUseRetainFlag" xml:space="preserve">
-    <value>Use &amp;Retain Flag</value>
+    <value>使用保留标志(&R)</value>
   </data>
   <data name="ServiceMqtt_CbAllowUntrustedCertificates" xml:space="preserve">
-    <value>&amp;Allow Untrusted Certificates</value>
+    <value>允许不受信任的证书(&A)</value>
   </data>
   <data name="ServiceMqtt_BtnMqttClearConfig" xml:space="preserve">
-    <value>&amp;Clear Configuration</value>
+    <value>清除配置(&C)</value>
   </data>
   <data name="ServiceMqtt_LblTip1" xml:space="preserve">
-    <value>(leave default if not sure)</value>
+    <value>（如果不确定，保持默认）</value>
   </data>
   <data name="ServiceMqtt_LblInfo1" xml:space="preserve">
-	  <value>Commands and sensors are sent through MQTT. Please provide credentials for your server. If you're using the HA addon,
-you can probably use the preset address.</value>
+    <value>命令和传感器通过 MQTT 发送。请为您的服务器提供凭据。如果您使用 HA 插件，
+您可能可以使用预设地址。</value>
   </data>
   <data name="ServiceMqtt_LblDiscoPrefix" xml:space="preserve">
-    <value>Discovery Prefix</value>
+    <value>发现前缀</value>
   </data>
   <data name="ServiceMqtt_LblBrokerPassword" xml:space="preserve">
-    <value>Password</value>
+    <value>密码</value>
   </data>
   <data name="ServiceMqtt_LblBrokerUsername" xml:space="preserve">
-    <value>Username</value>
+    <value>用户名</value>
   </data>
   <data name="ServiceMqtt_LblBrokerPort" xml:space="preserve">
-    <value>Port</value>
+    <value>端口</value>
   </data>
   <data name="ServiceMqtt_LblBrokerIp" xml:space="preserve">
-    <value>Broker IP Address or Hostname</value>
+    <value>代理 IP 地址或主机名</value>
   </data>
   <data name="ServiceMqtt_BtnStore" xml:space="preserve">
-    <value>&amp;Send &amp;&amp; Activate Configuration</value>
+    <value>发送并激活配置(&S)</value>
   </data>
   <data name="ServiceMqtt_BtnCopy" xml:space="preserve">
-    <value>Copy from &amp;HASS.Agent</value>
+    <value>从 HASS.Agent 复制(&H)</value>
   </data>
   <data name="ServiceMqtt_LblStored" xml:space="preserve">
-    <value>Configuration stored!</value>
+    <value>配置已存储！</value>
   </data>
   <data name="ServiceMqtt_LblStatusInfo" xml:space="preserve">
-    <value>Status</value>
+    <value>状态</value>
   </data>
   <data name="ServiceMqtt_LblStatus" xml:space="preserve">
-    <value>Querying..</value>
+    <value>正在查询..</value>
   </data>
   <data name="ServiceSensors_ClmName" xml:space="preserve">
-    <value>Name</value>
+    <value>名称</value>
   </data>
   <data name="ServiceSensors_ClmType" xml:space="preserve">
-    <value>Type</value>
+    <value>类型</value>
   </data>
   <data name="ServiceSensors_LblRefresh" xml:space="preserve">
-    <value>Refresh</value>
+    <value>刷新</value>
   </data>
   <data name="ServiceSensors_BtnRemove" xml:space="preserve">
-    <value>&amp;Remove</value>
+    <value>移除(&R)</value>
   </data>
   <data name="ServiceSensors_BtnAdd" xml:space="preserve">
-    <value>&amp;Add New</value>
+    <value>添加新项(&A)</value>
   </data>
   <data name="ServiceSensors_BtnModify" xml:space="preserve">
-    <value>&amp;Modify</value>
+    <value>修改(&M)</value>
   </data>
   <data name="ServiceSensors_BtnStore" xml:space="preserve">
-    <value>&amp;Send &amp;&amp; Activate Sensors</value>
+    <value>发送并激活传感器(&S)</value>
   </data>
   <data name="ServiceSensors_LblStored" xml:space="preserve">
-    <value>Sensors stored!</value>
+    <value>传感器已存储！</value>
   </data>
   <data name="PortReservation_LblInfo1" xml:space="preserve">
-    <value>Please wait a bit while the task is performed ..</value>
+    <value>请稍候，正在执行任务..</value>
   </data>
   <data name="PortReservation_LblTask1" xml:space="preserve">
-    <value>Create API Port Binding</value>
+    <value>创建 API 端口绑定</value>
   </data>
   <data name="PortReservation_LblTask2" xml:space="preserve">
-    <value>Set Firewall Rule</value>
+    <value>设置防火墙规则</value>
   </data>
   <data name="PortReservation_Title" xml:space="preserve">
-    <value>HASS.Agent Port Reservation</value>
+    <value>HASS.Agent 端口预留</value>
   </data>
   <data name="PostUpdate_LblInfo1" xml:space="preserve">
-    <value>Please wait a bit while some post-update tasks are performed ..</value>
+    <value>请稍候，正在执行一些更新后任务..</value>
   </data>
   <data name="PostUpdate_LblTask1" xml:space="preserve">
-    <value>Configuring Satellite Service</value>
+    <value>正在配置卫星服务</value>
   </data>
   <data name="PostUpdate_LblTask2" xml:space="preserve">
-    <value>Create API Port Binding</value>
+    <value>创建 API 端口绑定</value>
   </data>
   <data name="PostUpdate_Title" xml:space="preserve">
-    <value>HASS.Agent Post Update</value>
+    <value>HASS.Agent 更新后处理</value>
   </data>
   <data name="Restart_LblInfo1" xml:space="preserve">
-    <value>Please wait while HASS.Agent restarts..</value>
+    <value>请稍候，HASS.Agent 正在重启..</value>
   </data>
   <data name="Restart_LblTask1" xml:space="preserve">
-    <value>Waiting for previous instance to close..</value>
+    <value>正在等待上一个实例关闭..</value>
   </data>
   <data name="Restart_LblTask2" xml:space="preserve">
-    <value>Relaunch HASS.Agent</value>
+    <value>重新启动 HASS.Agent</value>
   </data>
   <data name="Restart_Title" xml:space="preserve">
-    <value>HASS.Agent Restarter</value>
+    <value>HASS.Agent 重启器</value>
   </data>
   <data name="ServiceReinstall_LblInfo1" xml:space="preserve">
-    <value>Please wait while the satellite service is re-installed..</value>
+    <value>请稍候，正在重新安装卫星服务..</value>
   </data>
   <data name="ServiceReinstall_LblTask1" xml:space="preserve">
-    <value>Remove Satellite Service</value>
+    <value>移除卫星服务</value>
   </data>
   <data name="ServiceReinstall_LblTask2" xml:space="preserve">
-    <value>Install Satellite Service</value>
+    <value>安装卫星服务</value>
   </data>
   <data name="ServiceReinstall_Title" xml:space="preserve">
-    <value>HASS.Agent Reinstall Satellite Service</value>
+    <value>HASS.Agent 重新安装卫星服务</value>
   </data>
   <data name="ServiceSetState_LblInfo1" xml:space="preserve">
-    <value>Please wait while the satellite service is configured..</value>
+    <value>请稍候，正在配置卫星服务..</value>
   </data>
   <data name="ServiceSetState_LblTask1" xml:space="preserve">
-    <value>Enable Satellite Service</value>
+    <value>启用卫星服务</value>
   </data>
   <data name="ServiceSetState_Title" xml:space="preserve">
-    <value>HASS.Agent Configure Satellite Service</value>
+    <value>HASS.Agent 配置卫星服务</value>
   </data>
   <data name="CommandMqttTopic_BtnClose" xml:space="preserve">
-    <value>&amp;Close</value>
+    <value>关闭(&C)</value>
   </data>
   <data name="CommandMqttTopic_LblInfo1" xml:space="preserve">
-    <value>This is the MQTT topic on which you can publish action commands:</value>
+    <value>这是您可以发布操作命令的 MQTT 主题：</value>
   </data>
   <data name="CommandMqttTopic_BtnCopyClipboard" xml:space="preserve">
-    <value>Copy &amp;to Clipboard</value>
+    <value>复制到剪贴板(&T)</value>
   </data>
   <data name="CommandMqttTopic_LblHelp" xml:space="preserve">
-    <value>help and examples</value>
+    <value>帮助和示例</value>
   </data>
   <data name="CommandMqttTopic_Title" xml:space="preserve">
-    <value>MQTT Action Topic</value>
+    <value>MQTT 操作主题</value>
   </data>
   <data name="CommandsConfig_BtnRemove" xml:space="preserve">
-    <value>&amp;Remove</value>
+    <value>移除(&R)</value>
   </data>
   <data name="CommandsConfig_BtnModify" xml:space="preserve">
-    <value>&amp;Modify</value>
+    <value>修改(&M)</value>
   </data>
   <data name="CommandsConfig_BtnAdd" xml:space="preserve">
-    <value>&amp;Add New</value>
+    <value>添加新项(&A)</value>
   </data>
   <data name="CommandsConfig_BtnStore" xml:space="preserve">
-    <value>&amp;Store and Activate Commands</value>
+    <value>存储并激活命令(&S)</value>
   </data>
   <data name="CommandsConfig_ClmName" xml:space="preserve">
-    <value>Name</value>
+    <value>名称</value>
   </data>
   <data name="CommandsConfig_ClmType" xml:space="preserve">
-    <value>Type</value>
+    <value>类型</value>
   </data>
   <data name="CommandsConfig_LblLowIntegrity" xml:space="preserve">
-    <value>Low Integrity</value>
+    <value>低完整性</value>
   </data>
   <data name="CommandsConfig_LblActionInfo" xml:space="preserve">
-    <value>Action</value>
+    <value>操作</value>
   </data>
   <data name="CommandsConfig_Title" xml:space="preserve">
-    <value>Commands Config</value>
+    <value>命令配置</value>
   </data>
   <data name="CommandsMod_BtnStore" xml:space="preserve">
-    <value>&amp;Store Command</value>
+    <value>存储命令(&S)</value>
   </data>
   <data name="CommandsMod_LblSetting" xml:space="preserve">
-    <value>&amp;Configuration</value>
+    <value>配置(&C)</value>
   </data>
   <data name="CommandsMod_LblName" xml:space="preserve">
-    <value>&amp;Name</value>
+    <value>名称(&N)</value>
   </data>
   <data name="CommandsMod_LblDescription" xml:space="preserve">
-    <value>Description</value>
+    <value>描述</value>
   </data>
   <data name="CommandsMod_CbRunAsLowIntegrity" xml:space="preserve">
-    <value>&amp;Run as 'Low Integrity'</value>
+    <value>以"低完整性"运行(&R)</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo" xml:space="preserve">
-    <value>What's this?</value>
+    <value>这是什么？</value>
   </data>
   <data name="CommandsMod_ClmSensorName" xml:space="preserve">
-    <value>  Type</value>
+    <value>  类型</value>
   </data>
   <data name="CommandsMod_LblSelectedType" xml:space="preserve">
-    <value>Selected Type</value>
+    <value>已选类型</value>
   </data>
   <data name="CommandsMod_LblService" xml:space="preserve">
-    <value>Service</value>
+    <value>服务</value>
   </data>
   <data name="CommandsMod_LblAgent" xml:space="preserve">
-    <value>agent</value>
+    <value>代理</value>
   </data>
   <data name="CommandsMod_LblSpecificClient" xml:space="preserve">
-    <value>HASS.Agent only!</value>
+    <value>仅 HASS.Agent！</value>
   </data>
   <data name="CommandsMod_LblEntityType" xml:space="preserve">
-    <value>&amp;Entity Type</value>
+    <value>实体类型(&E)</value>
   </data>
   <data name="CommandsMod_LblMqttTopic" xml:space="preserve">
-    <value>Show MQTT Action Topic</value>
+    <value>显示 MQTT 操作主题</value>
   </data>
   <data name="CommandsMod_LblActionInfo" xml:space="preserve">
-    <value>Action</value>
+    <value>操作</value>
   </data>
   <data name="CommandsMod_Title" xml:space="preserve">
-    <value>Command</value>
+    <value>命令</value>
   </data>
   <data name="QuickActions_LblLoading" xml:space="preserve">
-    <value>Retrieving entities, please wait..</value>
+    <value>正在检索实体，请稍候..</value>
   </data>
   <data name="QuickActions_Title" xml:space="preserve">
-    <value>Quick Actions</value>
+    <value>快捷操作</value>
   </data>
   <data name="QuickActionsConfig_BtnStore" xml:space="preserve">
-    <value>&amp;Store Quick Actions</value>
+    <value>存储快捷操作(&S)</value>
   </data>
   <data name="QuickActionsConfig_BtnAdd" xml:space="preserve">
-    <value>&amp;Add New</value>
+    <value>添加新项(&A)</value>
   </data>
   <data name="QuickActionsConfig_BtnModify" xml:space="preserve">
-    <value>&amp;Modify</value>
+    <value>修改(&M)</value>
   </data>
   <data name="QuickActionsConfig_BtnRemove" xml:space="preserve">
-    <value>&amp;Remove</value>
+    <value>移除(&R)</value>
   </data>
   <data name="QuickActionsConfig_BtnPreview" xml:space="preserve">
-    <value>&amp;Preview</value>
+    <value>预览(&P)</value>
   </data>
   <data name="QuickActionsConfig_ClmDomain" xml:space="preserve">
-    <value>Domain</value>
+    <value>域</value>
   </data>
   <data name="QuickActionsConfig_ClmEntity" xml:space="preserve">
-    <value>Entity</value>
+    <value>实体</value>
   </data>
   <data name="QuickActionsConfig_ClmAction" xml:space="preserve">
-    <value>Action</value>
+    <value>操作</value>
   </data>
   <data name="QuickActionsConfig_ClmHotKey" xml:space="preserve">
-    <value>Hotkey</value>
+    <value>热键</value>
   </data>
   <data name="QuickActionsConfig_ClmDescription" xml:space="preserve">
-    <value>Description</value>
+    <value>描述</value>
   </data>
   <data name="QuickActionsConfig_LblHotkey" xml:space="preserve">
-	  <value>Hotkey Enabled</value>
+    <value>热键已启用</value>
   </data>
   <data name="QuickActionsConfig_Title" xml:space="preserve">
-    <value>Quick Actions Configuration</value>
+    <value>快捷操作配置</value>
   </data>
   <data name="QuickActionsMod_BtnStore" xml:space="preserve">
-    <value>&amp;Store Quick Action</value>
+    <value>存储快捷操作(&S)</value>
   </data>
   <data name="QuickActionsMod_LblDomain" xml:space="preserve">
-    <value>Domain</value>
+    <value>域</value>
   </data>
   <data name="QuickActionsMod_LblEntityInfo" xml:space="preserve">
-    <value>&amp;Entity</value>
+    <value>实体(&E)</value>
   </data>
   <data name="QuickActionsMod_LblAction" xml:space="preserve">
-    <value>Desired &amp;Action</value>
+    <value>所需操作(&A)</value>
   </data>
   <data name="QuickActionsMod_LblDescription" xml:space="preserve">
-    <value>&amp;Description</value>
+    <value>描述(&D)</value>
   </data>
   <data name="QuickActionsMod_LblLoading" xml:space="preserve">
-    <value>Retrieving entities, please wait..</value>
+    <value>正在检索实体，请稍候..</value>
   </data>
   <data name="QuickActionsMod_CbEnableHotkey" xml:space="preserve">
-    <value>enable hotkey</value>
+    <value>启用热键</value>
   </data>
   <data name="QuickActionsMod_LblHotkey" xml:space="preserve">
-    <value>&amp;hotkey combination</value>
+    <value>热键组合(&H)</value>
   </data>
   <data name="QuickActionsMod_LblTip1" xml:space="preserve">
-    <value>(optional, will be used instead of entity name)</value>
+    <value>（可选，将替代实体名称使用）</value>
   </data>
   <data name="QuickActionsMod_Title" xml:space="preserve">
-    <value>Quick Action</value>
+    <value>快捷操作</value>
   </data>
   <data name="SensorsConfig_BtnRemove" xml:space="preserve">
-    <value>&amp;Remove</value>
+    <value>移除(&R)</value>
   </data>
   <data name="SensorsConfig_BtnModify" xml:space="preserve">
-    <value>&amp;Modify</value>
+    <value>修改(&amp;M)</value>
   </data>
   <data name="SensorsConfig_BtnAdd" xml:space="preserve">
-    <value>&amp;Add New</value>
+    <value>新增(&amp;A)</value>
   </data>
   <data name="SensorsConfig_BtnStore" xml:space="preserve">
-    <value>&amp;Store &amp;&amp; Activate Sensors</value>
+    <value>存储 &amp;&amp; 激活传感器(&amp;S)</value>
   </data>
   <data name="SensorsConfig_ClmName" xml:space="preserve">
-    <value>Name</value>
+    <value>名称</value>
   </data>
   <data name="SensorsConfig_ClmType" xml:space="preserve">
-    <value>Type</value>
+    <value>类型</value>
   </data>
   <data name="SensorsConfig_LblRefresh" xml:space="preserve">
-    <value>Refresh</value>
+    <value>刷新</value>
   </data>
   <data name="SensorsConfig_Title" xml:space="preserve">
-    <value>Sensors Configuration</value>
+    <value>传感器配置</value>
   </data>
   <data name="SensorsMod_BtnStore" xml:space="preserve">
-    <value>&amp;Store Sensor</value>
+    <value>存储传感器(&amp;S)</value>
   </data>
   <data name="SensorsMod_LblSetting1" xml:space="preserve">
-    <value>setting 1</value>
+    <value>设置 1</value>
   </data>
   <data name="SensorsMod_LblType" xml:space="preserve">
-    <value>Selected Type</value>
+    <value>所选类型</value>
   </data>
   <data name="SensorsMod_LblName" xml:space="preserve">
-    <value>&amp;Name</value>
+    <value>名称(&amp;N)</value>
   </data>
   <data name="SensorsMod_LblUpdate" xml:space="preserve">
-    <value>&amp;Update every</value>
+    <value>更新间隔(&amp;U)</value>
   </data>
   <data name="SensorsMod_LblSeconds" xml:space="preserve">
-    <value>seconds</value>
+    <value>秒</value>
   </data>
   <data name="SensorsMod_LblDescription" xml:space="preserve">
-    <value>Description</value>
+    <value>描述</value>
   </data>
   <data name="SensorsMod_LblSetting2" xml:space="preserve">
-    <value>Setting 2</value>
+    <value>设置 2</value>
   </data>
   <data name="SensorsMod_LblSetting3" xml:space="preserve">
-    <value>Setting 3</value>
+    <value>设置 3</value>
   </data>
   <data name="SensorsMod_ClmSensorName" xml:space="preserve">
-    <value>  Type</value>
+    <value>  类型</value>
   </data>
   <data name="SensorsMod_LblMultiValue" xml:space="preserve">
-	  <value>Multivalue</value>
+    <value>多值</value>
   </data>
   <data name="SensorsMod_LblAgent" xml:space="preserve">
-    <value>Agent</value>
+    <value>代理</value>
   </data>
   <data name="SensorsMod_LblService" xml:space="preserve">
-    <value>Service</value>
+    <value>服务</value>
   </data>
   <data name="SensorsMod_LblSpecificClient" xml:space="preserve">
-    <value>HASS.Agent only!</value>
+    <value>仅限 HASS.Agent！</value>
   </data>
   <data name="SensorsMod_Title" xml:space="preserve">
-    <value>Sensor</value>
+    <value>传感器</value>
   </data>
   <data name="ServiceConfig_TabGeneral" xml:space="preserve">
-    <value>     General     </value>
+    <value>     常规     </value>
   </data>
   <data name="ServiceConfig_TabMqtt" xml:space="preserve">
     <value>     MQTT     </value>
   </data>
   <data name="ServiceConfig_TabCommands" xml:space="preserve">
-    <value>     Commands     </value>
+    <value>     命令     </value>
   </data>
   <data name="ServiceConfig_TabSensors" xml:space="preserve">
-    <value>     Sensors     </value>
+    <value>     传感器     </value>
   </data>
   <data name="ServiceConfig_Title" xml:space="preserve">
-    <value>Satellite Service Configuration</value>
+    <value>卫星服务配置</value>
   </data>
   <data name="About_BtnClose" xml:space="preserve">
-    <value>&amp;Close</value>
+    <value>关闭(&amp;C)</value>
   </data>
   <data name="About_LblInfo1" xml:space="preserve">
-    <value>A Windows-based client for the Home Assistant platform.</value>
+    <value>Home Assistant 平台的 Windows 客户端。</value>
   </data>
   <data name="About_LblInfo3" xml:space="preserve">
-	  <value>This application is open source and completely free, please check the project pages of 
-the used components for their individual licenses:</value>
+    <value>本应用程序是开源且完全免费的，请查看
+所用组件的项目页面以了解其各自的许可证：</value>
   </data>
   <data name="About_LblInfo4" xml:space="preserve">
-	  <value>A big 'thank you' to the developers of these projects, who were kind enough to share
-their hard work with the rest of us mere mortals. </value>
+    <value>衷心感谢这些项目的开发者，他们慷慨地
+将其辛勤成果与我们这些普通凡人分享。</value>
   </data>
   <data name="About_LblInfo5" xml:space="preserve">
-	  <value>And of course; thanks to Paulus Shoutsen and the entire team of developers that 
-created and maintain Home Assistant :-)</value>
+    <value>当然，还要感谢 Paulus Shoutsen 以及
+创建和维护 Home Assistant 的整个开发团队 :-)</value>
   </data>
   <data name="About_LblInfo2" xml:space="preserve">
-    <value>Original created with even more love by</value>
+    <value>最初由以下作者倾注更多心血创建：</value>
   </data>
   <data name="About_LblInfo6" xml:space="preserve">
-    <value>HASS.Agent Team does not currently accept donations.
-If you like this tool however, support original (LAB02 Research) developers by buying them a cup of coffee:</value>
+    <value>HASS.Agent 团队目前不接受捐赠。
+但如果你喜欢这个工具，可以通过请原始（LAB02 Research）开发者喝杯咖啡来支持他们：</value>
   </data>
   <data name="About_Title" xml:space="preserve">
-    <value>About</value>
+    <value>关于</value>
   </data>
   <data name="Configuration_TabGeneral" xml:space="preserve">
-    <value>General</value>
+    <value>常规</value>
   </data>
   <data name="Configuration_TabExternalTools" xml:space="preserve">
-    <value>External Tools</value>
+    <value>外部工具</value>
   </data>
   <data name="Configuration_TabHassApi" xml:space="preserve">
     <value>Home Assistant API</value>
   </data>
   <data name="Configuration_TabHotKey" xml:space="preserve">
-    <value>Hotkey</value>
+    <value>热键</value>
   </data>
   <data name="Configuration_TabLocalStorage" xml:space="preserve">
-    <value>Local Storage</value>
+    <value>本地存储</value>
   </data>
   <data name="Configuration_TabLogging" xml:space="preserve">
-    <value>Logging</value>
+    <value>日志</value>
   </data>
   <data name="Configuration_TabMQTT" xml:space="preserve">
     <value>MQTT</value>
   </data>
   <data name="Configuration_TabNotifications" xml:space="preserve">
-    <value>Notifications</value>
+    <value>通知</value>
   </data>
   <data name="Configuration_TabService" xml:space="preserve">
-    <value>Satellite Service</value>
+    <value>卫星服务</value>
   </data>
   <data name="Configuration_TabStartup" xml:space="preserve">
-    <value>Startup</value>
+    <value>启动</value>
   </data>
   <data name="Configuration_TabUpdates" xml:space="preserve">
-    <value>Updates</value>
+    <value>更新</value>
   </data>
   <data name="Configuration_BtnAbout" xml:space="preserve">
-    <value>&amp;About</value>
+    <value>关于(&amp;A)</value>
   </data>
   <data name="Configuration_BtnHelp" xml:space="preserve">
-    <value>&amp;Help &amp;&amp; Contact</value>
+    <value>帮助 &amp;&amp; 联系(&amp;H)</value>
   </data>
   <data name="Configuration_BtnStore" xml:space="preserve">
-    <value>&amp;Save Configuration</value>
+    <value>保存配置(&amp;S)</value>
   </data>
   <data name="Configuration_BtnClose" xml:space="preserve">
-    <value>Close &amp;Without Saving</value>
+    <value>不保存关闭(&amp;W)</value>
   </data>
   <data name="Configuration_Title" xml:space="preserve">
-    <value>Configuration</value>
+    <value>配置</value>
   </data>
   <data name="ExitDialog_LblInfo1" xml:space="preserve">
-    <value>What would you like to do?</value>
+    <value>您想做什么？</value>
   </data>
   <data name="ExitDialog_BtnRestart" xml:space="preserve">
-    <value>&amp;Restart</value>
+    <value>重启(&amp;R)</value>
   </data>
   <data name="ExitDialog_BtnHide" xml:space="preserve">
-    <value>&amp;Hide</value>
+    <value>隐藏(&amp;H)</value>
   </data>
   <data name="ExitDialog_BtnExit" xml:space="preserve">
-    <value>&amp;Exit</value>
+    <value>退出(&amp;E)</value>
   </data>
   <data name="ExitDialog_Title" xml:space="preserve">
-    <value>Exit Dialog</value>
+    <value>退出对话框</value>
   </data>
   <data name="Help_BtnClose" xml:space="preserve">
-    <value>&amp;Close</value>
+    <value>关闭(&amp;C)</value>
   </data>
   <data name="Help_LblInfo1" xml:space="preserve">
-	  <value>If you are having trouble with HASS.Agent and require support
-with any sensors, commands, or for general support and feedback,
-there are few ways you can reach us:</value>
+    <value>如果您在使用 HASS.Agent 时遇到问题并需要支持，
+无论是关于传感器、命令，还是一般性的支持和反馈，
+都可以通过以下方式联系我们：</value>
   </data>
   <data name="Help_LblAbout" xml:space="preserve">
-    <value>About</value>
+    <value>关于</value>
   </data>
   <data name="Help_LblHAForum" xml:space="preserve">
-    <value>Home Assistant Forum</value>
+    <value>Home Assistant 论坛</value>
   </data>
   <data name="Help_LblGitHub" xml:space="preserve">
     <value>GitHub Issues</value>
   </data>
   <data name="Help_LblHAInfo" xml:space="preserve">
-	  <value>Bit of everything, with the addition that other
-HA users can help you out too!</value>
+    <value>内容丰富，此外其他
+HA 用户也能帮助您！</value>
   </data>
   <data name="Help_LblGitHubInfo" xml:space="preserve">
-    <value>Report bugs, post feature requests, see latest changes, etc.</value>
+    <value>报告错误、提交功能请求、查看最新变更等。</value>
   </data>
   <data name="Help_LblDiscordInfo" xml:space="preserve">
-	  <value>Get help with setting up and using HASS.Agent, 
-report bugs or get involved in general chit-chat!</value>
+    <value>获取 HASS.Agent 设置和使用方面的帮助，
+报告错误或参与日常闲聊！</value>
   </data>
   <data name="Help_LblWikiInfo" xml:space="preserve">
-    <value>Browse HASS.Agent documentation and usage examples.</value>
+    <value>浏览 HASS.Agent 文档和使用示例。</value>
   </data>
   <data name="Help_Title" xml:space="preserve">
-    <value>Help</value>
+    <value>帮助</value>
   </data>
   <data name="Main_TsShow" xml:space="preserve">
-    <value>Show HASS.Agent</value>
+    <value>显示 HASS.Agent</value>
   </data>
   <data name="Main_TsShowQuickActions" xml:space="preserve">
-    <value>Show Quick Actions</value>
+    <value>显示快捷操作</value>
   </data>
   <data name="Main_TsConfig" xml:space="preserve">
-    <value>Configuration</value>
+    <value>配置</value>
   </data>
   <data name="Main_TsQuickItemsConfig" xml:space="preserve">
-    <value>Manage Quick Actions</value>
+    <value>管理快捷操作</value>
   </data>
   <data name="Main_TsLocalSensors" xml:space="preserve">
-    <value>Manage Local Sensors</value>
+    <value>管理本地传感器</value>
   </data>
   <data name="Main_TsCommands" xml:space="preserve">
-    <value>Manage Commands</value>
+    <value>管理命令</value>
   </data>
   <data name="Main_CheckForUpdates" xml:space="preserve">
-    <value>Check for Updates</value>
+    <value>检查更新</value>
   </data>
   <data name="Main_TsDonate" xml:space="preserve">
-    <value>Donate</value>
+    <value>捐赠</value>
   </data>
   <data name="Main_TsHelp" xml:space="preserve">
-    <value>Help &amp;&amp; Contact</value>
+    <value>帮助 &amp;&amp; 联系</value>
   </data>
   <data name="Main_TsAbout" xml:space="preserve">
-    <value>About</value>
+    <value>关于</value>
   </data>
   <data name="Main_TsExit" xml:space="preserve">
-    <value>Exit HASS.Agent</value>
+    <value>退出 HASS.Agent</value>
   </data>
   <data name="Main_BtnHide" xml:space="preserve">
-    <value>&amp;Hide</value>
+    <value>隐藏(&amp;H)</value>
   </data>
   <data name="Main_GpControls" xml:space="preserve">
-    <value>Controls</value>
+    <value>控制</value>
   </data>
   <data name="Main_BtnServiceManager" xml:space="preserve">
-    <value>S&amp;atellite Service</value>
+    <value>卫星服务(&amp;A)</value>
   </data>
   <data name="Main_BtnAppSettings" xml:space="preserve">
-    <value>C&amp;onfiguration</value>
+    <value>配置(&amp;O)</value>
   </data>
   <data name="Main_BtnActionsManager" xml:space="preserve">
-    <value>&amp;Quick Actions</value>
+    <value>快捷操作(&amp;Q)</value>
   </data>
   <data name="Main_BtnCommandsManager" xml:space="preserve">
-    <value>Loading..</value>
+    <value>加载中..</value>
   </data>
   <data name="Main_BtnSensorsManager" xml:space="preserve">
-    <value>Loading..</value>
+    <value>加载中..</value>
   </data>
   <data name="Main_GpStatus" xml:space="preserve">
-    <value>System Status</value>
+    <value>系统状态</value>
   </data>
   <data name="Main_LblService" xml:space="preserve">
-    <value>Satellite Service:</value>
+    <value>卫星服务：</value>
   </data>
   <data name="Main_LblCommands" xml:space="preserve">
-    <value>Commands:</value>
+    <value>命令：</value>
   </data>
   <data name="Main_LblSensors" xml:space="preserve">
-    <value>Sensors:</value>
+    <value>传感器：</value>
   </data>
   <data name="Main_LblQuickActions" xml:space="preserve">
-    <value>Quick Actions:</value>
+    <value>快捷操作：</value>
   </data>
   <data name="Main_LblHomeAssistantApi" xml:space="preserve">
-    <value>Home Assistant API:</value>
+    <value>Home Assistant API：</value>
   </data>
   <data name="Main_LblNotificationApi" xml:space="preserve">
-    <value>notification api:</value>
+    <value>通知 API：</value>
   </data>
   <data name="Onboarding_BtnNext" xml:space="preserve">
-    <value>&amp;Next</value>
+    <value>下一步(&amp;N)</value>
   </data>
   <data name="Onboarding_BtnClose" xml:space="preserve">
-    <value>&amp;Close</value>
+    <value>关闭(&amp;C)</value>
   </data>
   <data name="Onboarding_BtnPrevious" xml:space="preserve">
-    <value>&amp;Previous</value>
+    <value>上一步(&amp;P)</value>
   </data>
   <data name="Onboarding_Onboarding" xml:space="preserve">
-    <value>HASS.Agent Onboarding</value>
+    <value>HASS.Agent 引导</value>
   </data>
   <data name="UpdatePending_BtnDownload" xml:space="preserve">
-    <value>Fetching info, please wait..</value>
+    <value>正在获取信息，请稍候..</value>
   </data>
   <data name="UpdatePending_LblNewReleaseInfo" xml:space="preserve">
-    <value>There's a new release available:</value>
+    <value>有新版本可用：</value>
   </data>
   <data name="UpdatePending_LblInfo1" xml:space="preserve">
-    <value>Release notes</value>
+    <value>发行说明</value>
   </data>
   <data name="UpdatePending_BtnIgnore" xml:space="preserve">
-    <value>&amp;Ignore Update</value>
+    <value>忽略更新(&amp;I)</value>
   </data>
   <data name="UpdatePending_LblRelease" xml:space="preserve">
-    <value>Release Page</value>
+    <value>发布页面</value>
   </data>
   <data name="UpdatePending_Title" xml:space="preserve">
-    <value>HASS.Agent Update</value>
+    <value>HASS.Agent 更新</value>
   </data>
   <data name="CommandsManager_CustomCommandDescription" xml:space="preserve">
-	  <value>Execute a custom command.
+    <value>执行自定义命令。
 
-These commands run without special elevation. To run elevated, create a Scheduled Task, and use 'schtasks /Run /TN "TaskName"' as the command to execute your task.
+这些命令运行时没有特殊提权。如需以提权方式运行，请创建计划任务，并使用 'schtasks /Run /TN "TaskName"' 作为执行任务的命令。
 
-Or enable 'run as low integrity' for even stricter execution.</value>
+或者启用"以低完整性级别运行"以获得更严格的执行环境。</value>
   </data>
   <data name="CommandsManager_CustomExecutorCommandDescription" xml:space="preserve">
-	  <value>Executes the command through the configured custom executor (in Configuration -&gt; External Tools).
+    <value>通过配置的自定义执行器（在 配置 -&gt; 外部工具 中）执行命令。
 
-Your command is provided as an argument 'as is', so you have to supply your own quotes etc. if necessary.</value>
+您的命令将"按原样"作为参数提供，因此如有必要，您需要自行添加引号等。</value>
   </data>
   <data name="CommandsManager_HibernateCommandDescription" xml:space="preserve">
-    <value>Sets the machine in hibernation.</value>
+    <value>使机器进入休眠状态。</value>
   </data>
   <data name="CommandsManager_KeyCommandDescription" xml:space="preserve">
-	  <value>Simulates a single keypress.
-Making this command a "switch" type will make the button pressed as long as the switch is turned on.
+    <value>模拟单次按键。
+将此命令设为"开关"类型后，只要开关处于开启状态，按钮就会一直保持按下。
 
-Click on the 'keycode' textbox and press the key you want simulated. The corresponding keycode will be entered for you.
-For TAB key please use LCTRL+TAB.
+点击"键码"文本框，然后按下您想要模拟的键，系统将自动填入对应的键码。
+TAB 键请使用 LCTRL+TAB。
 
-If you need more keys and/or modifiers like CTRL, use the MultipleKeys command.</value>
+如果您需要更多按键和/或 CTRL 等修饰键，请使用 MultipleKeys 命令。</value>
   </data>
   <data name="CommandsManager_LaunchUrlCommandDescription" xml:space="preserve">
-	  <value>Launches the provided URL, by default in your default browser.
+    <value>启动提供的 URL，默认在您的默认浏览器中打开。
 
-To use 'incognito', provide a specific browser in Configuration -&gt; External Tools.
+要使用"无痕模式"，请在 配置 -&gt; 外部工具 中指定特定浏览器。
 
-If you just want a window with a specific URL (not an entire browser), use a 'WebView' command.</value>
+如果您只需要一个显示特定 URL 的窗口（而非整个浏览器），请使用 'WebView' 命令。</value>
   </data>
   <data name="CommandsManager_LockCommandDescription" xml:space="preserve">
-    <value>Locks the current session.</value>
+    <value>锁定当前会话。</value>
   </data>
   <data name="CommandsManager_LogOffCommandDescription" xml:space="preserve">
-    <value>Logs off the current session.</value>
+    <value>注销当前会话。</value>
   </data>
   <data name="CommandsManager_MediaMuteCommandDescription" xml:space="preserve">
-    <value>Simulates 'Mute' key.</value>
+    <value>模拟"静音"键。</value>
   </data>
   <data name="CommandsManager_MediaNextCommandDescription" xml:space="preserve">
-    <value>Simulates 'Media Next' key.</value>
+    <value>模拟"媒体下一首"键。</value>
   </data>
   <data name="CommandsManager_MediaPlayPauseCommandDescription" xml:space="preserve">
-    <value>Simulates 'Media Pause/Play' key.</value>
+    <value>模拟"媒体暂停/播放"键。</value>
   </data>
   <data name="CommandsManager_MediaPreviousCommandDescription" xml:space="preserve">
-    <value>Simulates 'Media Previous' key.</value>
+    <value>模拟"媒体上一首"键。</value>
   </data>
   <data name="CommandsManager_MediaVolumeDownCommandDescription" xml:space="preserve">
-    <value>Simulates 'Volume Down' key.</value>
+    <value>模拟"音量减小"键。</value>
   </data>
   <data name="CommandsManager_MediaVolumeUpCommandDescription" xml:space="preserve">
-    <value>Simulates 'Volume Up' key.</value>
+    <value>模拟"音量增大"键。</value>
   </data>
   <data name="CommandsManager_MultipleKeysCommandDescription" xml:space="preserve">
-	  <value>Simulates pressing mulitple keys.
+    <value>模拟按下多个按键。
 
-You need to put [ ] between every key, otherwise HASS.Agent can't tell them apart. So say you want to press X TAB Y SHIFT-Z, it'd be [X] [{TAB}] [Y] [+Z].
+您需要在每个按键之间用 [ ] 分隔，否则 HASS.Agent 无法区分它们。例如，您想按下 X TAB Y SHIFT-Z，则应写为 [X] [{TAB}] [Y] [+Z]。
 
-There are a few tricks you can use:
+您可以使用以下技巧：
 
-- If you want a bracket pressed, escape it, so [ is [\[] and ] is [\]] 
+- 如需按下括号键，请对其进行转义，即 [ 写为 [\[]，] 写为 [\]]
 
-- Special keys go between { }, like {TAB} or {UP}
+- 特殊键放在 { } 中，例如 {TAB} 或 {UP}
 
-- Put a + in front of a key to add SHIFT, ^ for CTRL and % for ALT. So, +C is SHIFT-C. Or, +(CD) is SHIFT-C and SHIFT-D, while +CD is SHIFT-C and D
+- 在按键前加 + 表示 SHIFT，加 ^ 表示 CTRL，加 % 表示 ALT。因此，+C 表示 SHIFT-C。而 +(CD) 表示 SHIFT-C 和 SHIFT-D，+CD 则表示 SHIFT-C 和 D
 
-- For multiple presses, use {z 15}, which means Z will get pressed 15 times.
+- 如需多次按键，使用 {z 15}，表示 Z 将被按下 15 次。
 
-More info: https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.sendkeys</value>
+更多信息：https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.sendkeys</value>
   </data>
   <data name="CommandsManager_PowershellCommandDescription" xml:space="preserve">
-	  <value>Execute a Powershell command or script.
+    <value>执行 PowerShell 命令或脚本。
 
-You can either provide the location of a script (*.ps1), or a single-line command.
+您可以提供脚本（*.ps1）的位置，或单行命令。
 
-This will run without special elevation.</value>
+此命令运行时没有特殊提权。</value>
   </data>
   <data name="CommandsManager_PublishAllSensorsCommandDescription" xml:space="preserve">
-	  <value>Resets all sensor checks, forcing all sensors to process and send their value.
+    <value>重置所有传感器检查，强制所有传感器处理并发送其值。
 
-Useful for example if you want to force HASS.Agent to update all your sensors after a HA reboot.</value>
+例如，当您想在 HA 重启后强制 HASS.Agent 更新所有传感器时非常有用。</value>
   </data>
   <data name="CommandsManager_RestartCommandDescription" xml:space="preserve">
-	  <value>Restarts the machine after one minute.
+    <value>一分钟后重启机器。
 
-Tip: Accidentally triggered? Run 'shutdown /a' to abort shutdown.</value>
+提示：误触发了？运行 'shutdown /a' 中止关机。</value>
   </data>
   <data name="CommandsManager_ShutdownCommandDescription" xml:space="preserve">
-	  <value>Shuts down the machine after one minute.
+    <value>一分钟后关闭机器。
 
-Tip: Accidentally triggered? Run 'shutdown /a' to abort shutdown.</value>
+提示：误触发了？运行 'shutdown /a' 中止关机。</value>
   </data>
   <data name="CommandsManager_SleepCommandDescription" xml:space="preserve">
-	  <value>Puts the machine to sleep.
+    <value>使机器进入睡眠状态。
 
-Note: due to a limitation in Windows, this only works if hibernation is disabled, otherwise it will just hibernate.
+注意：由于 Windows 的限制，此功能仅在禁用休眠时有效，否则机器将进入休眠。
 
-You can use something like NirCmd (http://www.nirsoft.net/utils/nircmd.html) to circumvent this.</value>
+您可以使用 NirCmd（http://www.nirsoft.net/utils/nircmd.html）等工具绕过此限制。</value>
   </data>
   <data name="ConfigExternalTools_BtnExternalBrowserIncognitoTest_MessageBox1" xml:space="preserve">
-    <value>Please enter the location of your browser's binary! (.exe file)</value>
+    <value>请输入浏览器可执行文件的位置！（.exe 文件）</value>
   </data>
   <data name="ConfigExternalTools_ConfigExternalTools_BtnExternalBrowserIncognitoTest_MessageBox2" xml:space="preserve">
-    <value>The browser binary provided could not be found, please ensure the path is correct and try again.</value>
+    <value>找不到提供的浏览器可执行文件，请确保路径正确后重试。</value>
   </data>
   <data name="ConfigExternalTools_BtnExternalBrowserIncognitoTest_MessageBox3" xml:space="preserve">
-	  <value>No incognito arguments were provided so the browser will likely launch normally.
+    <value>未提供无痕模式参数，浏览器可能会正常启动。
 
-Do you want to continue?</value>
+您要继续吗？</value>
   </data>
   <data name="ConfigExternalTools_BtnExternalBrowserIncognitoTest_MessageBox4" xml:space="preserve">
-	  <value>Something went wrong while launching your browser in incognito mode!
+    <value>以无痕模式启动浏览器时出错！
 
-Please check the logs for more information.</value>
+请查看日志以获取更多信息。</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox1" xml:space="preserve">
-    <value>Please enter a valid API key!</value>
+    <value>请输入有效的 API 密钥！</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox2" xml:space="preserve">
-    <value>Please enter a value for your Home Assistant's URI.</value>
+    <value>请输入您的 Home Assistant URI 值。</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox3" xml:space="preserve">
-	  <value>Unable to connect, the following error was returned:
+    <value>无法连接，返回以下错误：
 
 {0}</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox4" xml:space="preserve">
-	  <value>Connection OK!
+    <value>连接成功！
 
-Home Assistant version: {0}</value>
+Home Assistant 版本：{0}</value>
   </data>
   <data name="ConfigLocalStorage_BtnClearImageCache_MessageBox1" xml:space="preserve">
-    <value>Image cache has been cleared!</value>
+    <value>图片缓存已清除！</value>
   </data>
   <data name="ConfigLocalStorage_BtnClearImageCache_InfoText1" xml:space="preserve">
-    <value>Cleaning..</value>
+    <value>清理中..</value>
   </data>
   <data name="ConfigNotifications_BtnSendTestNotification_MessageBox1" xml:space="preserve">
-    <value>Notifications are currently disabled, please enable them and restart the HASS.Agent, then try again.</value>
+    <value>通知当前已禁用，请启用通知并重启 HASS.Agent 后重试。</value>
   </data>
   <data name="ConfigNotifications_BtnSendTestNotification_MessageBox2" xml:space="preserve">
-	  <value>The test notification should have appeared, if you did not receive it please check the logs or consult the documentation for troubleshooting tips.
+    <value>测试通知应该已经显示，如果您没有收到，请查看日志或查阅文档以获取故障排查提示。
 
-Note: This only tests locally whether notifications can be shown!</value>
+注意：这仅在本地测试通知是否能显示！</value>
   </data>
   <data name="ConfigNotifications_TestNotification" xml:space="preserve">
-    <value>This is a test notification!</value>
+    <value>这是一条测试通知！</value>
   </data>
   <data name="ConfigNotifications_BtnExecutePortReservation_Busy" xml:space="preserve">
-    <value>Executing, please wait..</value>
+    <value>执行中，请稍候..</value>
   </data>
   <data name="ConfigNotifications_BtnExecutePortReservation_MessageBox1" xml:space="preserve">
-	  <value>Something went wrong whilst reserving the port!
+    <value>预留端口时出错！
 
-Manual execution is required and a command has been copied to your clipboard, please open an elevated terminal and paste the command.
+需要手动执行，命令已复制到剪贴板，请打开提权终端并粘贴命令。
 
-Additionally, remember to change your Firewall Rules port!</value>
+此外，请记得更改防火墙规则的端口！</value>
   </data>
   <data name="ConfigService_NotInstalled" xml:space="preserve">
-    <value>Not Installed</value>
+    <value>未安装</value>
   </data>
   <data name="ConfigService_Disabled" xml:space="preserve">
-    <value>Disabled</value>
+    <value>已禁用</value>
   </data>
   <data name="ConfigService_Running" xml:space="preserve">
-    <value>Running</value>
+    <value>运行中</value>
   </data>
   <data name="ConfigService_Stopped" xml:space="preserve">
-    <value>Stopped</value>
+    <value>已停止</value>
   </data>
   <data name="ConfigService_Failed" xml:space="preserve">
-    <value>Failed</value>
+    <value>失败</value>
   </data>
   <data name="ConfigService_BtnStopService_MessageBox1" xml:space="preserve">
-	  <value>Something went wrong whilst stopping the service, did you allow the UAC prompt?
+    <value>停止服务时出错，您是否允许了 UAC 提示？
 
-Check the HASS.Agent (not the service) logs for more information.</value>
+请查看 HASS.Agent（非服务）的日志以获取更多信息。</value>
   </data>
   <data name="ConfigService_BtnStartService_MessageBox1" xml:space="preserve">
-	  <value>The service is set to 'disabled', so it cannot be started.
+    <value>服务已设为"禁用"，无法启动。
 
-Please enable the service first and try again.</value>
+请先启用服务后再重试。</value>
   </data>
   <data name="ConfigService_BtnStartService_MessageBox2" xml:space="preserve">
-	  <value>Something went wrong whilst starting the service, did you allow the UAC prompt?
+    <value>启动服务时出错，您是否允许了 UAC 提示？
 
-Check the HASS.Agent (not the service) logs for more information.</value>
+请查看 HASS.Agent（非服务）的日志以获取更多信息。</value>
   </data>
   <data name="ConfigService_BtnDisableService_MessageBox1" xml:space="preserve">
-	  <value>Something went wrong whilst disabling the service, did you allow the UAC prompt?
+    <value>禁用服务时出错，您是否允许了 UAC 提示？
 
-Check the HASS.Agent (not the service) logs for more information.</value>
+请查看 HASS.Agent（非服务）的日志以获取更多信息。</value>
   </data>
   <data name="ConfigService_BtnEnableService_MessageBox1" xml:space="preserve">
-	  <value>Something went wrong whilst enabling the service, did you allow the UAC prompt?
+    <value>启用服务时出错，您是否允许了 UAC 提示？
 
-Check the HASS.Agent (not the service) logs for more information.</value>
+请查看 HASS.Agent（非服务）的日志以获取更多信息。</value>
   </data>
   <data name="ConfigService_BtnShowLogs_MessageBox1" xml:space="preserve">
-	  <value>Something went wrong whilst reinstalling the service, did you allow the UAC prompt?
+    <value>重新安装服务时出错，您是否允许了 UAC 提示？
 
-Check the HASS.Agent (not the service) logs for more information.</value>
+请查看 HASS.Agent（非服务）的日志以获取更多信息。</value>
   </data>
   <data name="ConfigStartup_BtnSetStartOnLogin_MessageBox1" xml:space="preserve">
-    <value>Something went wrong whilst disabling Start-on-Login, please check the logs for more information.</value>
+    <value>禁用开机启动时出错，请查看日志以获取更多信息。</value>
   </data>
   <data name="ConfigStartup_BtnSetStartOnLogin_MessageBox2" xml:space="preserve">
-    <value>Something went wrong whilst disabling Start-on-Login, please check the logs for more information.</value>
+    <value>禁用开机启动时出错，请查看日志以获取更多信息。</value>
   </data>
   <data name="ConfigStartup_Enabled" xml:space="preserve">
-    <value>Enabled</value>
+    <value>已启用</value>
   </data>
   <data name="ConfigStartup_Disable" xml:space="preserve">
-    <value>Disable Start-on-Login</value>
+    <value>禁用开机启动</value>
   </data>
   <data name="ConfigStartup_Disabled" xml:space="preserve">
-    <value>Disabled</value>
+    <value>已禁用</value>
   </data>
   <data name="ConfigStartup_Enable" xml:space="preserve">
-    <value>Enable Start-on-Login</value>
+    <value>启用开机启动</value>
   </data>
   <data name="OnboardingStartup_Activated" xml:space="preserve">
-    <value>Start-on-Login has been activated!</value>
+    <value>开机启动已激活！</value>
   </data>
   <data name="OnboardingStartup_EnableNow" xml:space="preserve">
-    <value>Do you want to enable Start-on-Login now?</value>
+    <value>您想现在启用开机启动吗？</value>
   </data>
   <data name="OnboardingStartup_AlreadyActivated" xml:space="preserve">
-    <value>Start-on-Login is already activated, all set!</value>
+    <value>开机启动已激活，一切就绪！</value>
   </data>
   <data name="OnboardingStartup_Activating" xml:space="preserve">
-    <value>Activating Start-on-Login..</value>
+    <value>正在激活开机启动..</value>
   </data>
   <data name="OnboardingStartup_Failed" xml:space="preserve">
-    <value>Something went wrong. You can try again, or skip to the next page and retry after HASS.Agent's restart.</value>
+    <value>出错了。您可以重试，或跳到下一页并在 HASS.Agent 重启后重试。</value>
   </data>
   <data name="OnboardingStartup_BtnSetLaunchOnLogin_2" xml:space="preserve">
-    <value>Enable Start-on-Login</value>
+    <value>启用开机启动</value>
   </data>
   <data name="OnboardingApi_BtnTest_MessageBox1" xml:space="preserve">
-    <value>Please provide a valid API key.</value>
+    <value>请提供有效的 API 密钥。</value>
   </data>
   <data name="OnboardingApi_BtnTest_MessageBox2" xml:space="preserve">
-    <value>Please enter your Home Assistant's URI.</value>
+    <value>请输入您的 Home Assistant URI。</value>
   </data>
   <data name="OnboardingApi_BtnTest_MessageBox3" xml:space="preserve">
-	  <value>Unable to connect, the following error was returned:
+    <value>无法连接，返回以下错误：
 
 {0}</value>
   </data>
   <data name="OnboardingApi_BtnTest_MessageBox4" xml:space="preserve">
-	  <value>Connection OK!
+    <value>连接成功！
 
-Home Assistant version: {0}</value>
+Home Assistant 版本：{0}</value>
   </data>
   <data name="OnboardingApi_BtnTest_Testing" xml:space="preserve">
-    <value>Testing..</value>
+    <value>测试中..</value>
   </data>
   <data name="ServiceCommands_BtnStore_MessageBox1" xml:space="preserve">
-    <value>An error occurred whilst saving your commands, please check the logs for more information.</value>
+    <value>保存命令时出错，请查看日志以获取更多信息。</value>
   </data>
   <data name="ServiceCommands_BtnStore_Storing" xml:space="preserve">
-    <value>Storing and registering, please wait..</value>
+    <value>存储并注册中，请稍候..</value>
   </data>
   <data name="ServiceConnect_Connecting" xml:space="preserve">
-    <value>Connecting with satellite service, please wait..</value>
+    <value>正在连接卫星服务，请稍候..</value>
   </data>
   <data name="ServiceConnect_Failed" xml:space="preserve">
-    <value>Connecting to the service has failed!</value>
+    <value>连接服务失败！</value>
   </data>
   <data name="ServiceConnect_FailedMessage" xml:space="preserve">
-	  <value>The service hasn't been found! You can install and manage it from the configuration panel.
+    <value>未找到服务！您可以在配置面板中安装和管理它。
 
-When it's up and running, come back here to configure the commands and sensors.</value>
+当服务启动并运行后，请返回此处配置命令和传感器。</value>
   </data>
   <data name="ServiceConnect_CommunicationFailed" xml:space="preserve">
-    <value>Communicating with the service has failed!</value>
+    <value>与服务通信失败！</value>
   </data>
   <data name="ServiceConnect_CommunicationFailedMessage" xml:space="preserve">
-	  <value>Unable to communicate with the service. Check the logs for more info.
+    <value>无法与服务通信。请查看日志以获取更多信息。
 
-You can open the logs and manage the service from the configuration panel.</value>
+您可以在配置面板中打开日志并管理服务。</value>
   </data>
   <data name="ServiceConnect_Unauthorized" xml:space="preserve">
-    <value>Unauthorized</value>
+    <value>未授权</value>
   </data>
   <data name="ServiceConnect_UnauthorizedMessage" xml:space="preserve">
-	  <value>You are not authorized to contact the service.
+    <value>您无权访问该服务。
 
-If you have the correct auth ID, you can set it now and try again.</value>
+如果您有正确的身份验证 ID，可以现在设置并重试。</value>
   </data>
   <data name="ServiceConnect_SettingsFailed" xml:space="preserve">
-    <value>Fetching settings failed!</value>
+    <value>获取设置失败！</value>
   </data>
   <data name="ServiceConnect_SettingsFailedMessage" xml:space="preserve">
-	  <value>The service returned an error while requesting its settings. Check the logs for more info.
+    <value>请求设置时服务返回了错误。请查看日志以获取更多信息。
 
-You can open the logs and manage the service from the configuration panel.</value>
+您可以在配置面板中打开日志并管理服务。</value>
   </data>
   <data name="ServiceConnect_MqttFailed" xml:space="preserve">
-    <value>Fetching MQTT settings failed!</value>
+    <value>获取 MQTT 设置失败！</value>
   </data>
   <data name="ServiceConnect_MqttFailedMessage" xml:space="preserve">
-	  <value>The service returned an error while requesting its MQTT settings. Check the logs for more info.
+    <value>请求 MQTT 设置时服务返回了错误。请查看日志以获取更多信息。
 
-You can open the logs and manage the service from the configuration panel.</value>
+您可以在配置面板中打开日志并管理服务。</value>
   </data>
   <data name="ServiceConnect_CommandsFailed" xml:space="preserve">
-    <value>Fetching configured commands failed!</value>
+    <value>获取已配置的命令失败！</value>
   </data>
   <data name="ServiceConnect_CommandsFailedMessage" xml:space="preserve">
-	  <value>The service returned an error while requesting its configured commands. Check the logs for more info.
+    <value>请求已配置的命令时服务返回了错误。请查看日志以获取更多信息。
 
-You can open the logs and manage the service from the configuration panel.</value>
+您可以在配置面板中打开日志并管理服务。</value>
   </data>
   <data name="ServiceConnect_SensorsFailed" xml:space="preserve">
-    <value>Fetching configured sensors failed!</value>
+    <value>获取已配置的传感器失败！</value>
   </data>
   <data name="ServiceConnect_SensorsFailedMessage" xml:space="preserve">
-	  <value>The service returned an error while requesting its configured sensors. Check the logs for more info.
+    <value>请求已配置的传感器时服务返回了错误。请查看日志以获取更多信息。
 
-You can open the logs and manage the service from the configuration panel.</value>
+您可以在配置面板中打开日志并管理服务。</value>
   </data>
   <data name="ServiceGeneral_TbAuthId_MessageBox1" xml:space="preserve">
-	  <value>Storing an empty auth ID will allow all HASS.Agent to access the service.
+    <value>存储空的身份验证 ID 将允许所有 HASS.Agent 访问该服务。
 
-Are you sure you want this?</value>
+您确定要这样做吗？</value>
   </data>
   <data name="ServiceGeneral_SavingFailedMessageBox" xml:space="preserve">
-    <value>An error occurred whilst saving, check the logs for more information.</value>
+    <value>保存时出错，请查看日志以获取更多信息。</value>
   </data>
   <data name="ServiceGeneral_BtnStoreDeviceName_MessageBox1" xml:space="preserve">
-    <value>Please provide a device name!</value>
+    <value>请提供设备名称！</value>
   </data>
   <data name="ServiceGeneral_BtnStoreCustomExecutor_MessageBox1" xml:space="preserve">
-    <value>Please select an executor first. (Tip: Double click to Browse)</value>
+    <value>请先选择一个执行器。（提示：双击进行浏览）</value>
   </data>
   <data name="ServiceGeneral_BtnStoreCustomExecutor_MessageBox2" xml:space="preserve">
-    <value>The selected executor could not be found, please ensure the path provided is correct and try again.</value>
+    <value>找不到所选的执行器，请确保提供的路径正确后重试。</value>
   </data>
   <data name="ServiceGeneral_LblAuthIdInfo_MessageBox1" xml:space="preserve">
-	  <value>Set an auth ID if you don't want every instance of HASS.Agent on this PC to connect with the satellite service.
+    <value>如果您不希望此 PC 上的每个 HASS.Agent 实例都连接到卫星服务，请设置身份验证 ID。
 
-Only the instances that have the correct ID, can connect.
+只有拥有正确 ID 的实例才能连接。
 
-Leave empty to allow all to connect.</value>
+留空则允许所有实例连接。</value>
   </data>
   <data name="ServiceGeneral_LblDeviceNameInfo_MessageBox1" xml:space="preserve">
-	  <value>This is the name with which the satellite service registers itself on Home Assistant.
+    <value>这是卫星服务在 Home Assistant 上注册时使用的名称。
 
-By default, it's your PC's name plus '-satellite'.</value>
+默认情况下，它是您的 PC 名称加上 '-satellite'。</value>
   </data>
   <data name="ServiceGeneral_LblDisconGraceInfo_MessageBox1" xml:space="preserve">
-    <value>The amount of time the satellite service will wait before reporting a lost connection to the MQTT broker.</value>
+    <value>卫星服务在报告与 MQTT 代理失去连接前等待的时间。</value>
   </data>
   <data name="ServiceMqtt_StatusError" xml:space="preserve">
-    <value>Error fetching status, please check logs for information.</value>
+    <value>获取状态时出错，请查看日志以获取信息。</value>
   </data>
   <data name="ServiceMqtt_BtnStore_MessageBox1" xml:space="preserve">
-    <value>An error occurred whilst saving the configuration, please check the logs for more information.</value>
+    <value>保存配置时出错，请查看日志以获取更多信息。</value>
   </data>
   <data name="ServiceMqtt_BtnStore_Storing" xml:space="preserve">
-    <value>Storing and registering, please wait..</value>
+    <value>存储并注册中，请稍候..</value>
   </data>
   <data name="ServiceSensors_BtnStore_MessageBox1" xml:space="preserve">
-    <value>An error occurred whilst saving the sensors, please check the logs for more information.</value>
+    <value>保存传感器时出错，请查看日志以获取更多信息。</value>
   </data>
   <data name="ServiceSensors_BtnStore_Storing" xml:space="preserve">
-    <value>Storing and registering, please wait..</value>
+    <value>存储并注册中，请稍候..</value>
   </data>
   <data name="PortReservation_ProcessPostUpdate_MessageBox1" xml:space="preserve">
-    <value>Not all steps completed succesfully. Please consult the logs for more information.</value>
+    <value>并非所有步骤都成功完成。请查看日志以获取更多信息。</value>
   </data>
   <data name="PostUpdate_ProcessPostUpdate_MessageBox1" xml:space="preserve">
-    <value>Not all steps completed succesfully. Please consult the logs for more information.</value>
+    <value>并非所有步骤都成功完成。请查看日志以获取更多信息。</value>
   </data>
   <data name="Restart_ProcessRestart_MessageBox1" xml:space="preserve">
-	  <value>HASS.Agent is still active after {0} seconds. Please close all instances and restart manually.
+    <value>{0} 秒后 HASS.Agent 仍然处于活动状态。请关闭所有实例并手动重启。
 
-Check the logs for more info, and optionally inform the developers.</value>
+请查看日志以获取更多信息，并可选择通知开发者。</value>
   </data>
   <data name="ServiceReinstall_ProcessReinstall_MessageBox1" xml:space="preserve">
-    <value>Not all steps completed successfully, please check the logs for more information.</value>
+    <value>并非所有步骤都成功完成，请查看日志以获取更多信息。</value>
   </data>
   <data name="ServiceSetState_Enabled" xml:space="preserve">
-    <value>Enable Satellite Service</value>
+    <value>启用卫星服务</value>
   </data>
   <data name="ServiceSetState_Disabled" xml:space="preserve">
-    <value>Disable Satellite Service</value>
+    <value>禁用卫星服务</value>
   </data>
   <data name="ServiceSetState_Started" xml:space="preserve">
-    <value>Start Satellite Service</value>
+    <value>启动卫星服务</value>
   </data>
   <data name="ServiceSetState_Stopped" xml:space="preserve">
-    <value>Stop Satellite Service</value>
+    <value>停止卫星服务</value>
   </data>
   <data name="ServiceSetState_ProcessState_MessageBox1" xml:space="preserve">
-	  <value>Something went wrong while processing the desired service state.
+    <value>处理所需的服务状态时出错。
 
-Please consult the logs for more information.</value>
+请查看日志以获取更多信息。</value>
   </data>
   <data name="CommandMqttTopic_BtnCopyClipboard_Copied" xml:space="preserve">
-    <value>Topic copied to clipboard!</value>
+    <value>主题已复制到剪贴板！</value>
   </data>
   <data name="CommandsConfig_BtnStore_Storing" xml:space="preserve">
-    <value>Storing and registering, please wait..</value>
+    <value>存储并注册中，请稍候..</value>
   </data>
   <data name="CommandsConfig_BtnStore_MessageBox1" xml:space="preserve">
-    <value>An error occurred whilst saving commands, please check the logs for more information.</value>
+    <value>保存命令时出错，请查看日志以获取更多信息。</value>
   </data>
   <data name="CommandsMod_Title_NewCommand" xml:space="preserve">
-    <value>New Command</value>
+    <value>新建命令</value>
   </data>
   <data name="CommandsMod_Title_ModCommand" xml:space="preserve">
-    <value>Mod Command</value>
+    <value>修改命令</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox1" xml:space="preserve">
-    <value>Please select a command type!</value>
+    <value>请选择命令类型！</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox2" xml:space="preserve">
-    <value>Please select a valid command type!</value>
+    <value>请选择有效的命令类型！</value>
   </data>
   <data name="CommandsMod_MessageBox_EntityType" xml:space="preserve">
-    <value>Select a valid entity type first.</value>
+    <value>请先选择有效的实体类型。</value>
   </data>
   <data name="CommandsMod_MessageBox_Name" xml:space="preserve">
-    <value>Please provide a name!</value>
+    <value>请提供名称！</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox3" xml:space="preserve">
-    <value>A command with that name already exists, are you sure you want to continue?</value>
+    <value>同名命令已存在，您确定要继续吗？</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox4" xml:space="preserve">
-	  <value>If a command is not provided, you may only use this entity with an 'action' value via Home Assistant, running it as-is will have no action.
+    <value>如果未提供命令，则只能通过 Home Assistant 使用 'action' 值来使用此实体，直接运行不会产生任何动作。
 
-Are you sure you want to proceed?</value>
+您确定要继续吗？</value>
   </data>
   <data name="CommandsMod_MessageBox_Action" xml:space="preserve">
-	  <value>If you don't enter a command or script, you can only use this entity with an 'action' value through Home Assistant. Running it as-is won't do anything.
+    <value>如果您不输入命令或脚本，则只能通过 Home Assistant 使用 'action' 值来使用此实体。直接运行不会产生任何效果。
 
-Are you sure you want this?</value>
+您确定要这样吗？</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox5" xml:space="preserve">
-    <value>Please enter a key code!</value>
+    <value>请输入键码！</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox6" xml:space="preserve">
-    <value>Checking keys failed: {0}</value>
+    <value>检查按键失败：{0}</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox7" xml:space="preserve">
-	  <value>If a URL is not provided, you may only use this entity with an 'action' value via Home Assistant, running it as-is will have no action.
+    <value>如果未提供 URL，则只能通过 Home Assistant 使用 'action' 值来使用此实体，直接运行不会产生任何动作。
 
-Are you sure you want to proceed?</value>
+您确定要继续吗？</value>
   </data>
   <data name="CommandsMod_LblSetting_Command" xml:space="preserve">
-    <value>Command</value>
+    <value>命令</value>
   </data>
   <data name="CommandsMod_LblSetting_CommandScript" xml:space="preserve">
-    <value>Command or Script</value>
+    <value>命令或脚本</value>
   </data>
   <data name="CommandsMod_LblSetting_KeyCode" xml:space="preserve">
-    <value>Keycode</value>
+    <value>键码</value>
   </data>
   <data name="CommandsMod_LblSetting_KeyCodes" xml:space="preserve">
-    <value>Keycodes</value>
+    <value>键码</value>
   </data>
   <data name="CommandsMod_CbCommandSpecific_Incognito" xml:space="preserve">
-    <value>Launch in Incognito Mode</value>
+    <value>以无痕模式启动</value>
   </data>
   <data name="CommandsMod_LblInfo_Browser" xml:space="preserve">
-	  <value>Browser: Default
+    <value>浏览器：默认
 
-Please configure a custom browser to enable incognito mode.</value>
+请配置自定义浏览器以启用无痕模式。</value>
   </data>
   <data name="CommandsMod_LblSetting_Url" xml:space="preserve">
     <value>URL</value>
   </data>
   <data name="CommandsMod_LblInfo_BrowserSpecific" xml:space="preserve">
-    <value>Browser: {0}</value>
+    <value>浏览器：{0}</value>
   </data>
   <data name="CommandsMod_LblInfo_Executor" xml:space="preserve">
-	  <value>Executor: None
+    <value>执行器：无
 
-Please configure an executor or your command will not run.</value>
+请配置执行器，否则您的命令将无法运行。</value>
   </data>
   <data name="CommandsMod_LblInfo_ExecutorSpecific" xml:space="preserve">
-    <value>Executor: {0}</value>
+    <value>执行器：{0}</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo_InfoMsg1" xml:space="preserve">
-    <value>Low integrity means your command will be executed with restricted privileges.</value>
+    <value>低完整性意味着您的命令将以受限权限执行。</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo_InfoMsg2" xml:space="preserve">
-    <value>This means it will only be able to save and modify files in certain locations,</value>
+    <value>这意味着它只能在某些位置保存和修改文件，</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo_InfoMsg3" xml:space="preserve">
-    <value>such as the '%USERPROFILE%\AppData\LocalLow' folder or</value>
+    <value>例如 '%USERPROFILE%\AppData\LocalLow' 文件夹，或</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo_InfoMsg4" xml:space="preserve">
-    <value>the 'HKEY_CURRENT_USER\Software\AppDataLow' registry key.</value>
+    <value>'HKEY_CURRENT_USER\Software\AppDataLow' 注册表项。</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo_InfoMsg5" xml:space="preserve">
-    <value>You should test your command to make sure it's not influenced by this!</value>
+    <value>您应该测试您的命令以确保不受此影响！</value>
   </data>
   <data name="CommandsMod_SpecificClient" xml:space="preserve">
-    <value>{0} only!</value>
+    <value>仅限 {0}！</value>
   </data>
   <data name="CommandsMod_LblMqttTopic_MessageBox1" xml:space="preserve">
-    <value>The MQTT manager hasn't been configured properly, or hasn't yet completed its startup.</value>
+    <value>MQTT 管理器尚未正确配置，或尚未完成启动。</value>
   </data>
   <data name="QuickActions_CheckHassManager_MessageBox1" xml:space="preserve">
-    <value>Unable to fetch your entities because of missing config, please enter the required values in the config screen.</value>
+    <value>由于缺少配置无法获取您的实体，请在配置界面中输入所需值。</value>
   </data>
   <data name="QuickActions_MessageBox_EntityFailed" xml:space="preserve">
-    <value>There was an error trying to fetch your entities!</value>
+    <value>尝试获取您的实体时出错！</value>
   </data>
   <data name="QuickActionsMod_Title_New" xml:space="preserve">
-    <value>New Quick Action</value>
+    <value>新建快捷操作</value>
   </data>
   <data name="QuickActionsMod_Title_Mod" xml:space="preserve">
-    <value>Mod Quick Action</value>
+    <value>修改快捷操作</value>
   </data>
   <data name="QuickActionsMod_CheckHassManager_MessageBox1" xml:space="preserve">
-    <value>Unable to fetch your entities because of missing config, please enter the required values in the config screen.</value>
+    <value>由于缺少配置无法获取您的实体，请在配置界面中输入所需值。</value>
   </data>
   <data name="QuickActionsMod_MessageBox_Entities" xml:space="preserve">
-    <value>There was an error trying to fetch your entities.</value>
+    <value>尝试获取您的实体时出错。</value>
   </data>
   <data name="QuickActionsMod_BtnStore_MessageBox1" xml:space="preserve">
-    <value>Please select an entity!</value>
+    <value>请选择一个实体！</value>
   </data>
   <data name="QuickActionsMod_BtnStore_MessageBox2" xml:space="preserve">
-    <value>Please select an domain!</value>
+    <value>请选择一个域！</value>
   </data>
   <data name="QuickActionsMod_BtnStore_MessageBox3" xml:space="preserve">
-    <value>Unknown action, please select a valid one.</value>
+    <value>未知操作，请选择一个有效的操作。</value>
   </data>
   <data name="SensorsConfig_BtnStore_Storing" xml:space="preserve">
-    <value>Storing and registering, please wait..</value>
+    <value>正在保存和注册，请稍候..</value>
   </data>
   <data name="SensorsConfig_BtnStore_MessageBox1" xml:space="preserve">
-    <value>An error occurred whilst saving the sensors, please check the logs for more information.</value>
+    <value>保存传感器时发生错误，请查看日志以获取更多信息。</value>
   </data>
   <data name="SensorsMod_Title_New" xml:space="preserve">
-    <value>New Sensor</value>
+    <value>新建传感器</value>
   </data>
   <data name="SensorsMod_Title_Mod" xml:space="preserve">
-    <value>Mod Sensor</value>
+    <value>修改传感器</value>
   </data>
   <data name="SensorsMod_LblSetting1_WindowName" xml:space="preserve">
-    <value>Window Name</value>
+    <value>窗口名称</value>
   </data>
   <data name="SensorsMod_LblSetting1_Wmi" xml:space="preserve">
-    <value>WMI Query</value>
+    <value>WMI 查询</value>
   </data>
   <data name="SensorsMod_LblSetting2_Wmi" xml:space="preserve">
-    <value>WMI Scope (optional)</value>
+    <value>WMI 范围（可选）</value>
   </data>
   <data name="SensorsMod_LblSetting1_Category" xml:space="preserve">
-    <value>Category</value>
+    <value>类别</value>
   </data>
   <data name="SensorsMod_LblSetting2_Counter" xml:space="preserve">
-    <value>Counter</value>
+    <value>计数器</value>
   </data>
   <data name="SensorsMod_LblSetting3_Instance" xml:space="preserve">
-    <value>Instance (optional)</value>
+    <value>实例（可选）</value>
   </data>
   <data name="SensorsMod_LblSetting1_Process" xml:space="preserve">
-    <value>Process</value>
+    <value>进程</value>
   </data>
   <data name="SensorsMod_LblSetting1_Service" xml:space="preserve">
-    <value>Service</value>
+    <value>服务</value>
   </data>
   <data name="SensorsMod_BtnStore_MessageBox1" xml:space="preserve">
-    <value>Please select a sensor type!</value>
+    <value>请选择一个传感器类型！</value>
   </data>
   <data name="SensorsMod_BtnStore_MessageBox2" xml:space="preserve">
-    <value>Please select a valid sensor type!</value>
+    <value>请选择一个有效的传感器类型！</value>
   </data>
   <data name="SensorsMod_BtnStore_MessageBox3" xml:space="preserve">
-    <value>Please provide a name!</value>
+    <value>请提供一个名称！</value>
   </data>
   <data name="SensorsMod_BtnStore_MessageBox4" xml:space="preserve">
-    <value>A single-value sensor already exists with that name, are you sure you want to proceed?</value>
+    <value>已存在使用该名称的单值传感器，您确定要继续吗？</value>
   </data>
   <data name="SensorsMod_BtnStore_MessageBox5" xml:space="preserve">
-    <value>A multi-value sensor already exists with that name, are you sure you want to proceed?</value>
+    <value>已存在使用该名称的多值传感器，您确定要继续吗？</value>
   </data>
   <data name="SensorsMod_BtnStore_MessageBox6" xml:space="preserve">
-    <value>Please provide an interval between 1 and 43200 (12 hours)!</value>
+    <value>请提供一个介于 1 和 43200（12 小时）之间的间隔！</value>
   </data>
   <data name="SensorsMod_BtnStore_MessageBox7" xml:space="preserve">
-    <value>Please enter a window name!</value>
+    <value>请输入窗口名称！</value>
   </data>
   <data name="SensorsMod_BtnStore_MessageBox8" xml:space="preserve">
-    <value>Please enter a query!</value>
+    <value>请输入查询！</value>
   </data>
   <data name="SensorsMod_BtnStore_MessageBox9" xml:space="preserve">
-    <value>Please enter a category and instance!</value>
+    <value>请输入类别和实例！</value>
   </data>
   <data name="SensorsMod_BtnStore_MessageBox10" xml:space="preserve">
-    <value>Please enter the name of a process!</value>
+    <value>请输入进程名称！</value>
   </data>
   <data name="SensorsMod_BtnStore_MessageBox11" xml:space="preserve">
-    <value>Please enter the name of a service!</value>
+    <value>请输入服务名称！</value>
   </data>
   <data name="SensorsMod_SpecificClient" xml:space="preserve">
-    <value>{0} only!</value>
+    <value>仅 {0}！</value>
   </data>
   <data name="Configuration_ProcessChanges_MessageBox1" xml:space="preserve">
-	  <value>You've changed your device's name.
+    <value>您已更改了设备的名称。
 
-All your sensors and commands will now be unpublished, and HASS.Agent will restart afterwards to republish them.
+您的所有传感器和命令将被取消发布，HASS.Agent 将在之后重启以重新发布它们。
 
-Don't worry, they'll keep their current names, so your automations or scripts will keep working.
+别担心，它们会保留当前的名称，因此您的自动化或脚本将继续正常工作。
 
-Note: the name will get 'sanitized', which means everything except letters, digits and whitespace get replaced by an underscore. This is required by HA.</value>
+注意：名称将被"清理"，即除字母、数字和空格外的所有字符都将被替换为下划线。这是 Home Assistant 的要求。</value>
   </data>
   <data name="Configuration_ProcessChanges_MessageBox2" xml:space="preserve">
-	  <value>You've changed the local API's port. This new port needs to be reserved.
+    <value>您已更改了本地 API 的端口。此新端口需要被保留。
 
-You'll get an UAC request to do so, please approve.</value>
+您将收到一个 UAC 请求来执行此操作，请批准。</value>
   </data>
   <data name="Configuration_ProcessChanges_MessageBox3" xml:space="preserve">
-	  <value>Something went wrong!
+    <value>出现错误！
 
-Please manually execute the required command. It has been copied onto your clipboard, you just need to paste it into an elevated command prompt.
+请手动执行所需的命令。该命令已复制到您的剪贴板，您只需将其粘贴到提升的命令提示符中即可。
 
-Remember to change your firewall rule's port as well.</value>
+请记住同时更改防火墙规则的端口。</value>
   </data>
   <data name="Configuration_ProcessChanges_MessageBox4" xml:space="preserve">
-	  <value>The port has succesfully been reserved!
+    <value>端口已成功保留！
 
-HASS.Agent will now restart to activate the new configuration.</value>
+HASS.Agent 现在将重启以激活新配置。</value>
   </data>
   <data name="Configuration_MessageBox_RestartManually" xml:space="preserve">
-	  <value>Something went wrong while preparing to restart.
-Please restart manually.</value>
+    <value>准备重启时出现错误。
+请手动重启。</value>
   </data>
   <data name="Configuration_ProcessChanges_MessageBox5" xml:space="preserve">
-	  <value>Your configuration has been saved. Most changes require HASS.Agent to restart before they take effect.
+    <value>您的配置已保存。大部分更改需要 HASS.Agent 重启后才能生效。
 
-Do you want to restart now?</value>
+您想现在重启吗？</value>
   </data>
   <data name="Main_Load_MessageBox1" xml:space="preserve">
-	  <value>Something went wrong while loading your settings.
+    <value>加载设置时出现错误。
 
-Check appsettings.json in the 'config' subfolder, or just delete it to start fresh.</value>
+请检查 'config' 子文件夹中的 appsettings.json，或者直接删除它以重新开始。</value>
   </data>
   <data name="Main_Load_MessageBox2" xml:space="preserve">
-	  <value>There was an error launching HASS.Agent.
-Please check the logs and make a bug report on GitHub.</value>
+    <value>启动 HASS.Agent 时出现错误。
+请检查日志并在 GitHub 上提交错误报告。</value>
   </data>
   <data name="Main_BtnSensorsManage_Ready" xml:space="preserve">
-	  <value>&amp;Sensors</value>
+    <value>传感器(&amp;S)</value>
   </data>
   <data name="Main_BtnCommandsManager_Ready" xml:space="preserve">
-    <value>&amp;Commands</value>
+    <value>命令(&amp;C)</value>
   </data>
   <data name="Main_Checking" xml:space="preserve">
-    <value>Checking..</value>
+    <value>检查中..</value>
   </data>
   <data name="Main_CheckForUpdate_MessageBox1" xml:space="preserve">
-    <value>You're running the latest version: {0}{1}</value>
+    <value>您正在运行最新版本：{0}{1}</value>
   </data>
   <data name="UpdatePending_NewBetaRelease" xml:space="preserve">
-    <value>There's a new BETA release available:</value>
+    <value>有新的 BETA 版本可用：</value>
   </data>
   <data name="UpdatePending_Title_Beta" xml:space="preserve">
-    <value>HASS.Agent BETA Update</value>
+    <value>HASS.Agent BETA 更新</value>
   </data>
   <data name="UpdatePending_LblUpdateQuestion_Download" xml:space="preserve">
-    <value>Do you want to &amp;download and launch the installer?</value>
+    <value>您想下载并启动安装程序吗(&amp;D)？</value>
   </data>
   <data name="UpdatePending_LblUpdateQuestion_Navigate" xml:space="preserve">
-    <value>Do you want to &amp;navigate to the release page?</value>
+    <value>您想导航到发布页面吗(&amp;N)？</value>
   </data>
   <data name="UpdatePending_InstallUpdate" xml:space="preserve">
-    <value>Install Update</value>
+    <value>安装更新</value>
   </data>
   <data name="UpdatePending_InstallBetaRelease" xml:space="preserve">
-    <value>Install Beta Release</value>
+    <value>安装 Beta 版本</value>
   </data>
   <data name="UpdatePending_OpenReleasePage" xml:space="preserve">
-    <value>Open Release Page</value>
+    <value>打开发布页面</value>
   </data>
   <data name="UpdatePending_OpenBetaReleasePage" xml:space="preserve">
-    <value>Open Beta Release Page</value>
+    <value>打开 Beta 发布页面</value>
   </data>
   <data name="UpdatePending_LblUpdateQuestion_Processing" xml:space="preserve">
-    <value>Processing request, please wait..</value>
+    <value>正在处理请求，请稍候..</value>
   </data>
   <data name="UpdatePending_BtnDownload_Processing" xml:space="preserve">
-    <value>Processing..</value>
+    <value>处理中..</value>
   </data>
   <data name="OnboardingManager_OnboardingTitle_Start" xml:space="preserve">
-    <value>HASS.Agent Onboarding: Start [{0}/{1}]</value>
+    <value>HASS.Agent 引导：开始 [{0}/{1}]</value>
   </data>
   <data name="OnboardingManager_OnboardingTitle_Startup" xml:space="preserve">
-    <value>HASS.Agent Onboarding: Startup [{0}/{1}]</value>
+    <value>HASS.Agent 引导：启动 [{0}/{1}]</value>
   </data>
   <data name="OnboardingManager_OnboardingTitle_Notifications" xml:space="preserve">
-    <value>HASS.Agent Onboarding: Notifications [{0}/{1}]</value>
+    <value>HASS.Agent 引导：通知 [{0}/{1}]</value>
   </data>
   <data name="OnboardingManager_OnboardingTitle_Integration" xml:space="preserve">
-    <value>HASS.Agent Onboarding: Integration [{0}/{1}]</value>
+    <value>HASS.Agent 引导：集成 [{0}/{1}]</value>
   </data>
   <data name="OnboardingManager_OnboardingTitle_Api" xml:space="preserve">
-    <value>HASS.Agent Onboarding: API [{0}/{1}]</value>
+    <value>HASS.Agent 引导：API [{0}/{1}]</value>
   </data>
   <data name="OnboardingManager_OnboardingTitle_Mqtt" xml:space="preserve">
-    <value>HASS.Agent Onboarding: MQTT [{0}/{1}]</value>
+    <value>HASS.Agent 引导：MQTT [{0}/{1}]</value>
   </data>
   <data name="OnboardingManager_OnboardingTitle_HotKey" xml:space="preserve">
-    <value>HASS.Agent Onboarding: HotKey [{0}/{1}]</value>
+    <value>HASS.Agent 引导：热键 [{0}/{1}]</value>
   </data>
   <data name="OnboardingManager_OnboardingTitle_Updates" xml:space="preserve">
-    <value>HASS.Agent Onboarding: Updates [{0}/{1}]</value>
+    <value>HASS.Agent 引导：更新 [{0}/{1}]</value>
   </data>
   <data name="OnboardingManager_OnboardingTitle_Completed" xml:space="preserve">
-    <value>HASS.Agent Onboarding: Completed [{0}/{1}]</value>
+    <value>HASS.Agent 引导：已完成 [{0}/{1}]</value>
   </data>
   <data name="OnboardingManager_ConfirmBeforeClose_MessageBox1" xml:space="preserve">
-	  <value>Are you sure you want to abort the onboarding process?
+    <value>您确定要中止引导过程吗？
 
-Your progress will not be saved, and it will not be shown again on next launch.</value>
+您的进度将不会被保存，并且在下次启动时不会再显示。</value>
   </data>
   <data name="UpdateManager_GetLatestVersionInfo_Error" xml:space="preserve">
-    <value>Error fetching info, please check logs for more information.</value>
+    <value>获取信息时出错，请查看日志以获取更多信息。</value>
   </data>
   <data name="UpdateManager_DownloadAndExecuteUpdate_MessageBox1" xml:space="preserve">
-	  <value>Unable to prepare downloading the update, check the logs for more info.
+    <value>无法准备下载更新，请查看日志以获取更多信息。
 
-The release page will now open instead.</value>
+将改为打开发布页面。</value>
   </data>
   <data name="UpdateManager_DownloadAndExecuteUpdate_MessageBox2" xml:space="preserve">
-	  <value>Unable to download the update, check the logs for more info.
+    <value>无法下载更新，请查看日志以获取更多信息。
 
-The release page will now open instead.</value>
+将改为打开发布页面。</value>
   </data>
   <data name="UpdateManager_DownloadAndExecuteUpdate_MessageBox3" xml:space="preserve">
-	  <value>The downloaded file FAILED the certificate check.
+    <value>下载的文件未通过证书检查。
 
-This could be a technical error, but also a tampered file!
+这可能是技术错误，但也可能是文件被篡改！
 
-Please check the logs, and post a ticket with the findings.</value>
+请检查日志，并提交一个包含发现结果的工单。</value>
   </data>
   <data name="UpdateManager_DownloadAndExecuteUpdate_MessageBox4" xml:space="preserve">
-	  <value>Unable to launch the installer (did you approve the UAC prompt?), check the logs for more info.
+    <value>无法启动安装程序（您是否批准了 UAC 提示？），请查看日志以获取更多信息。
 
-The release page will now open instead.</value>
+将改为打开发布页面。</value>
   </data>
   <data name="HassApiManager_ToolTip_ConnectionSetupFailed" xml:space="preserve">
-    <value>HASS API: Connection setup failed.</value>
+    <value>HASS API：连接设置失败。</value>
   </data>
   <data name="HassApiManager_ToolTip_InitialConnectionFailed" xml:space="preserve">
-    <value>HASS API: Initial connection failed.</value>
+    <value>HASS API：初始连接失败。</value>
   </data>
   <data name="HassApiManager_ToolTip_ConnectionFailed" xml:space="preserve">
-    <value>HASS API: Connection failed.</value>
+    <value>HASS API：连接失败。</value>
   </data>
   <data name="HassApiManager_CheckHassConfig_CertNotFound" xml:space="preserve">
-    <value>Client certificate file not found.</value>
+    <value>未找到客户端证书文件。</value>
   </data>
   <data name="HassApiManager_CheckHassConfig_UnableToConnect" xml:space="preserve">
-    <value>Unable to connect, check URI.</value>
+    <value>无法连接，请检查 URI。</value>
   </data>
   <data name="HassApiManager_CheckHassConfig_ConfigFailed" xml:space="preserve">
-    <value>Unable to fetch configuration, please check API key.</value>
+    <value>无法获取配置，请检查 API 密钥。</value>
   </data>
   <data name="HassApiManager_ConnectionFailed" xml:space="preserve">
-    <value>Unable to connect, please check URI and configuration.</value>
+    <value>无法连接，请检查 URI 和配置。</value>
   </data>
   <data name="HassApiManager_ToolTip_QuickActionFailed" xml:space="preserve">
-    <value>quick action: action failed, check the logs for info</value>
+    <value>快捷操作：操作失败，请查看日志以获取信息</value>
   </data>
   <data name="HassApiManager_ToolTip_QuickActionFailedOnEntity" xml:space="preserve">
-    <value>quick action: action failed, entity not found</value>
+    <value>快捷操作：操作失败，未找到实体</value>
   </data>
   <data name="MqttManager_ToolTip_ConnectionError" xml:space="preserve">
-    <value>MQTT: Error while connecting</value>
+    <value>MQTT：连接时出错</value>
   </data>
   <data name="MqttManager_ToolTip_ConnectionFailed" xml:space="preserve">
-    <value>MQTT: Failed to connect</value>
+    <value>MQTT：连接失败</value>
   </data>
   <data name="MqttManager_ToolTip_Disconnected" xml:space="preserve">
-    <value>MQTT: Disconnected</value>
+    <value>MQTT：已断开</value>
   </data>
   <data name="NotifierManager_Initialize_MessageBox1" xml:space="preserve">
-	  <value>Error trying to bind the API to port {0}.
+    <value>尝试将 API 绑定到端口 {0} 时出错。
 
-Make sure no other instance of HASS.Agent is running and the port is available and registered.</value>
+请确保没有其他 HASS.Agent 实例正在运行，且该端口可用并已注册。</value>
   </data>
   <data name="SensorsManager_ActiveWindowSensorDescription" xml:space="preserve">
-    <value>Provides the title of the current active window.</value>
+    <value>提供当前活动窗口的标题。</value>
   </data>
   <data name="SensorsManager_AudioSensorsDescription" xml:space="preserve">
-	  <value>Provides information various aspects of your device's audio:
+    <value>提供有关设备音频各个方面的信息：
 
-Current peak volume level (can be used as a simple 'is something playing' value).
+当前峰值音量级别（可用作简单的"是否有内容正在播放"的值）。
 
-Default audio device: name, state and volume.
+默认音频设备：名称、状态和音量。
 
-Summary of your audio sessions: application name, muted state, volume and current peak volume.</value>
+音频会话摘要：应用程序名称、静音状态、音量和当前峰值音量。</value>
   </data>
   <data name="SensorsManager_BatterySensorsDescription" xml:space="preserve">
-    <value>Provides a sensor with the current charging status, estimated amount of minutes on a full charge, remaining charge as a percentage, remaining charge in minutes and the powerline status.</value>
+    <value>提供一个包含当前充电状态、充满电预计分钟数、剩余电量百分比、剩余电量分钟数和电源线状态的传感器。</value>
   </data>
   <data name="SensorsManager_CpuLoadSensorDescription" xml:space="preserve">
-    <value>Provides the current load of the first CPU as a percentage.</value>
+    <value>以百分比形式提供第一个 CPU 的当前负载。</value>
   </data>
   <data name="SensorsManager_CurrentClockSpeedSensorDescription" xml:space="preserve">
-    <value>Provides the current clockspeed of the first CPU.</value>
+    <value>提供第一个 CPU 的当前时钟频率。</value>
   </data>
   <data name="SensorsManager_CurrentVolumeSensorDescription" xml:space="preserve">
-	  <value>Provides the current volume level as a percentage.
+    <value>以百分比形式提供当前音量级别。
 
-Currently takes the volume of your default device.</value>
+目前取您默认设备的音量。</value>
   </data>
   <data name="SensorsManager_DisplaySensorsDescription" xml:space="preserve">
-    <value>Provides a sensor with the amount of displays, name of the primary display, and per display its name, resolution and bits per pixel.</value>
+    <value>提供一个包含显示器数量、主显示器名称，以及每个显示器的名称、分辨率和每像素位数的传感器。</value>
   </data>
   <data name="SensorsManager_DummySensorDescription" xml:space="preserve">
-    <value>Dummy sensor for testing purposes, sends a random integer value between 0 and 100.</value>
+    <value>用于测试的虚拟传感器，发送一个 0 到 100 之间的随机整数值。</value>
   </data>
   <data name="SensorsManager_GpuLoadSensorDescription" xml:space="preserve">
-    <value>Provides the current load of the first GPU as a percentage.</value>
+    <value>以百分比形式提供第一个 GPU 的当前负载。</value>
   </data>
   <data name="SensorsManager_GpuTemperatureSensorDescription" xml:space="preserve">
-    <value>NOTE: This is a non-functioning sensor.
+    <value>注意：这是一个不工作的传感器。
 
-Due to the security concerns regarding Libre Hardware Monitor (library allowing HASS.Agent to access GPU temperature data) this sensor is left for backward compatibility reasons and will always return 0.
-Please see documentation for alternative options.</value>
+由于关于 Libre Hardware Monitor（允许 HASS.Agent 访问 GPU 温度数据的库）的安全顾虑，此传感器保留用于向后兼容，将始终返回 0。
+请查看文档以获取替代方案。</value>
   </data>
   <data name="SensorsManager_LastActiveSensorDescription" xml:space="preserve">
-    <value>Provides a datetime value containing the last moment the user provided input.
+    <value>提供一个包含用户最后提供输入时间的日期时间值。
 
-Optionally updates the sensor with current date, when system has been woken from sleep/hibernation in configuerd time window and no user activity was performed.</value>
+当系统在配置的时间窗口内从睡眠/休眠中唤醒且未执行任何用户活动时，可选择使用当前日期更新传感器。</value>
   </data>
   <data name="SensorsManager_LastBootSensorDescription" xml:space="preserve">
-	  <value>Provides a datetime value containing the last moment the system (re)booted.
+    <value>提供一个包含系统上次（重）启动时间的日期时间值。
 
-Important: Windows' FastBoot option can throw this value off, because that's a form of hibernation. You can disable it through Power Options -&gt; 'Choose what the power buttons do' -&gt; uncheck 'Turn on fast start-up'. It doesn't make much difference for modern machines with SSDs, but disabling makes sure you get a clean state after rebooting.</value>
+重要提示：Windows 的 FastBoot 选项可能会影响此值，因为这实际上是一种休眠形式。您可以通过以下路径禁用它：电源选项 -&gt; '选择电源按钮的功能' -&gt; 取消勾选'启用快速启动'。对于使用 SSD 的现代计算机影响不大，但禁用后可以确保重启后获得干净的状态。</value>
   </data>
   <data name="SensorsManager_LastSystemStateChangeSensorDescription" xml:space="preserve">
-	  <value>Provides the last system state change:
+    <value>提供上次系统状态变更：
 
-ApplicationStarted, Logoff, SystemShutdown, Resume, Suspend, ConsoleConnect, ConsoleDisconnect, RemoteConnect, RemoteDisconnect, SessionLock, SessionLogoff, SessionLogon, SessionRemoteControl and SessionUnlock.</value>
+ApplicationStarted、Logoff、SystemShutdown、Resume、Suspend、ConsoleConnect、ConsoleDisconnect、RemoteConnect、RemoteDisconnect、SessionLock、SessionLogoff、SessionLogon、SessionRemoteControl 和 SessionUnlock。</value>
   </data>
   <data name="SensorsManager_LoggedUserSensorDescription" xml:space="preserve">
-	  <value>Returns the name of the currently logged user.
+    <value>返回当前登录用户的名称。
 
-This will only show active users, and falls back to 'Empty' if there are none. If there are multiple, the first will be used.</value>
+这只会显示活跃用户，如果没有则返回 'Empty'。如果有多个，将使用第一个。</value>
   </data>
   <data name="SensorsManager_LoggedUsersSensorDescription" xml:space="preserve">
-	  <value>Returns a json-formatted list of currently logged users.
+    <value>返回当前登录用户的 JSON 格式列表。
 
-This will also contain users that aren't active. If you only want the current active user, use the LoggedUser sensor instead.</value>
+这也会包含不活跃的用户。如果您只想获取当前活跃用户，请改用 LoggedUser 传感器。</value>
   </data>
   <data name="SensorsManager_MemoryUsageSensorDescription" xml:space="preserve">
-    <value>Provides the amount of used memory as a percentage.</value>
+    <value>以百分比形式提供已用内存量。</value>
   </data>
   <data name="SensorsManager_MicrophoneActiveSensorDescription" xml:space="preserve">
-	  <value>Provides a bool value based on whether the microphone is currently being used.
+    <value>提供一个基于麦克风当前是否正在使用的布尔值。
 
-Note: if used in the satellite service, it won't detect userspace applications.</value>
+注意：如果在卫星服务中使用，将无法检测用户空间应用程序。</value>
   </data>
   <data name="SensorsManager_NamedWindowSensorDescription" xml:space="preserve">
-    <value>Provides an ON/OFF value based on whether the window is currently open (doesn't have to be active).</value>
+    <value>基于窗口当前是否打开（不一定是活动的）提供一个 ON/OFF 值。</value>
   </data>
   <data name="SensorsManager_NetworkSensorsDescription" xml:space="preserve">
-	  <value>Provides card info, configuration, transfer- &amp; package statistics and addresses (ip, mac, dhcp, dns) of the selected network card(s).
+    <value>提供所选网卡的卡信息、配置、传输 &amp; 包统计信息以及地址（ip、mac、dhcp、dns）。
 
-This is a multi-value sensor.</value>
+这是一个多值传感器。</value>
   </data>
   <data name="SensorsManager_PerformanceCounterSensorDescription" xml:space="preserve">
-	  <value>Provides the values of a performance counter.
+    <value>提供性能计数器的值。
 
-For example, the built-in CPU load sensor uses these values:
+例如，内置的 CPU 负载传感器使用以下值：
 
-Category: Processor
-Counter: % Processor Time
-Instance: _Total
+类别：Processor
+计数器：% Processor Time
+实例：_Total
 
-You can explore the counters through Windows' 'perfmon.exe' tool.</value>
+您可以通过 Windows 的 'perfmon.exe' 工具来浏览计数器。</value>
   </data>
   <data name="SensorsManager_ProcessActiveSensorDescription" xml:space="preserve">
-	  <value>Provides the number of active instances of the process.
+    <value>提供该进程的活动实例数量。
 
-Note: don't add the extension (eg. notepad.exe becomes notepad).</value>
+注意：不要添加扩展名（例如 notepad.exe 变成 notepad）。</value>
   </data>
   <data name="SensorsManager_ServiceStateSensorDescription" xml:space="preserve">
-	  <value>Returns the state of the provided service: NotFound, Stopped, StartPending, StopPending, Running, ContinuePending, PausePending or Paused.
+    <value>返回所提供服务的状态：NotFound、Stopped、StartPending、StopPending、Running、ContinuePending、PausePending 或 Paused。
 
-Make sure to provide the 'Service name', not the 'Display name'.</value>
+请确保提供"服务名称"，而不是"显示名称"。</value>
   </data>
   <data name="SensorsManager_SessionStateSensorDescription" xml:space="preserve">
-	  <value>Provides the current session state:
+    <value>提供当前会话状态：
 
-Locked, Unlocked or Unknown.
+Locked、Unlocked 或 Unknown。
 
-Use a LastSystemStateChangeSensor to monitor session state changes.</value>
+使用 LastSystemStateChangeSensor 来监控会话状态变更。</value>
   </data>
   <data name="SensorsManager_StorageSensorsDescription" xml:space="preserve">
-    <value>Provides the labels, total size (MB), available space (MB), used space (MB) and file system of all present non-removable disks.</value>
+    <value>提供所有存在的非可移动磁盘的标签、总大小（MB）、可用空间（MB）、已用空间（MB）和文件系统。</value>
   </data>
   <data name="SensorsManager_UserNotificationStateSensorDescription" xml:space="preserve">
-	  <value>Provides the current user state:
+    <value>提供当前用户状态：
 
-NotPresent, Busy, RunningDirect3dFullScreen, PresentationMode, AcceptsNotifications, QuietTime or RunningWindowsStoreApp.
+NotPresent、Busy、RunningDirect3dFullScreen、PresentationMode、AcceptsNotifications、QuietTime 或 RunningWindowsStoreApp。
 
-Can for instance be used to determine whether to send notifications or TTS messages.</value>
+例如，可用于确定是否发送通知或 TTS 消息。</value>
   </data>
   <data name="SensorsManager_WebcamActiveSensorDescription" xml:space="preserve">
-	  <value>Provides a bool value based on whether the webcam is currently being used.
+    <value>提供一个基于摄像头当前是否正在使用的布尔值。
 
-Note: if used in the satellite service, it won't detect userspace applications.</value>
+注意：如果在卫星服务中使用，将无法检测用户空间应用程序。</value>
   </data>
   <data name="SensorsManager_WindowsUpdatesSensorsDescription" xml:space="preserve">
-	  <value>Provides a sensor with the amount of pending driver updates, a sensor with the amount of pending software updates, a sensor containing all pending driver updates information (title, kb article id's, hidden, type and categories) and a sensor containing the same for pending software updates.
+    <value>提供一个包含待处理驱动程序更新数量的传感器、一个包含待处理软件更新数量的传感器、一个包含所有待处理驱动程序更新信息（标题、kb 文章 ID、是否隐藏、类型和类别）的传感器，以及一个包含待处理软件更新相同信息的传感器。
 
-This is a costly request, so the recommended interval is 15 minutes (900 seconds). But it's capped at 10 minutes, if you provide a lower value, you'll get the last known list.</value>
+这是一个开销较大的请求，因此建议间隔为 15 分钟（900 秒）。但最低限制为 10 分钟，如果您提供更低的值，将获取上次已知的列表。</value>
   </data>
   <data name="SensorsManager_WmiQuerySensorDescription" xml:space="preserve">
-    <value>Provides the result of the WMI query.</value>
+    <value>提供 WMI 查询的结果。</value>
   </data>
   <data name="SettingsManager_LoadAppSettings_MessageBox1" xml:space="preserve">
-	  <value>Error loading settings:
+    <value>加载设置时出错：
 
 {0}</value>
   </data>
   <data name="SettingsManager_StoreInitialSettings_MessageBox1" xml:space="preserve">
-	  <value>Error storing initial settings:
+    <value>存储初始设置时出错：
 
 {0}</value>
   </data>
   <data name="SettingsManager_StoreAppSettings_MessageBox1" xml:space="preserve">
-	  <value>Error storing settings:
+    <value>存储设置时出错：
 
 {0}</value>
   </data>
   <data name="StoredCommands_Load_MessageBox1" xml:space="preserve">
-	  <value>Error loading commands:
+    <value>加载命令时出错：
 
 {0}</value>
   </data>
   <data name="StoredCommands_Store_MessageBox1" xml:space="preserve">
-	  <value>Error storing commands:
+    <value>存储命令时出错：
 
 {0}</value>
   </data>
   <data name="StoredQuickActions_Load_MessageBox1" xml:space="preserve">
-	  <value>Error loading quick actions:
+    <value>加载快捷操作时出错：
 
 {0}</value>
   </data>
   <data name="StoredQuickActions_Store_MessageBox1" xml:space="preserve">
-	  <value>Error storing quick actions:
+    <value>存储快捷操作时出错：
 
 {0}</value>
   </data>
   <data name="StoredSensors_Load_MessageBox1" xml:space="preserve">
-	  <value>Error loading sensors:
+    <value>加载传感器时出错：
 
 {0}</value>
   </data>
   <data name="StoredSensors_Store_MessageBox1" xml:space="preserve">
-	  <value>Error storing sensors:
+    <value>存储传感器时出错：
 
 {0}</value>
   </data>
@@ -2208,1106 +2206,1104 @@ This is a costly request, so the recommended interval is 15 minutes (900 seconds
     <value>Wiki</value>
   </data>
   <data name="Configuration_BtnStore_Busy" xml:space="preserve">
-    <value>Busy, please wait..</value>
+    <value>正忙，请稍候..</value>
   </data>
   <data name="ConfigGeneral_LblInterfaceLangauge" xml:space="preserve">
-    <value>Interface &amp;Language</value>
+    <value>界面语言(&amp;L)</value>
   </data>
   <data name="About_LblOr" xml:space="preserve">
-    <value>or</value>
+    <value>或</value>
   </data>
   <data name="OnboardingManager_BtnNext_Finish" xml:space="preserve">
-    <value>Finish</value>
+    <value>完成</value>
   </data>
   <data name="OnboardingWelcome_LblInterfaceLangauge" xml:space="preserve">
-    <value>Interface &amp;Language</value>
+    <value>界面语言(&amp;L)</value>
   </data>
   <data name="ServiceMqtt_SetMqttStatus_ConfigError" xml:space="preserve">
-    <value>Configuration missing</value>
+    <value>配置缺失</value>
   </data>
   <data name="ServiceMqtt_SetMqttStatus_Connected" xml:space="preserve">
-    <value>Connected</value>
+    <value>已连接</value>
   </data>
   <data name="ServiceMqtt_SetMqttStatus_Connecting" xml:space="preserve">
-    <value>Connecting..</value>
+    <value>连接中..</value>
   </data>
   <data name="ServiceMqtt_SetMqttStatus_Disconnected" xml:space="preserve">
-    <value>Disconnected</value>
+    <value>已断开</value>
   </data>
   <data name="ServiceMqtt_SetMqttStatus_Error" xml:space="preserve">
-    <value>Error</value>
+    <value>错误</value>
   </data>
   <data name="CommandType_CustomCommand" xml:space="preserve">
-    <value>Custom</value>
+    <value>自定义</value>
   </data>
   <data name="CommandType_CustomExecutorCommand" xml:space="preserve">
-    <value>CustomExecutor</value>
+    <value>自定义执行器</value>
   </data>
   <data name="CommandType_HibernateCommand" xml:space="preserve">
-    <value>Hibernate</value>
+    <value>休眠</value>
   </data>
   <data name="CommandType_KeyCommand" xml:space="preserve">
-    <value>Key</value>
+    <value>按键</value>
   </data>
   <data name="CommandType_LaunchUrlCommand" xml:space="preserve">
-    <value>LaunchUrl</value>
+    <value>启动 URL</value>
   </data>
   <data name="CommandType_LockCommand" xml:space="preserve">
-    <value>Lock</value>
+    <value>锁定</value>
   </data>
   <data name="CommandType_LogOffCommand" xml:space="preserve">
-    <value>LogOff</value>
+    <value>注销</value>
   </data>
   <data name="CommandType_MediaMuteCommand" xml:space="preserve">
-    <value>MediaMute</value>
+    <value>静音</value>
   </data>
   <data name="CommandType_MediaNextCommand" xml:space="preserve">
-    <value>MediaNext</value>
+    <value>下一曲</value>
   </data>
   <data name="CommandType_MediaPlayPauseCommand" xml:space="preserve">
-    <value>MediaPlayPause</value>
+    <value>播放/暂停</value>
   </data>
   <data name="CommandType_MediaPreviousCommand" xml:space="preserve">
-    <value>MediaPrevious</value>
+    <value>上一曲</value>
   </data>
   <data name="CommandType_MediaVolumeDownCommand" xml:space="preserve">
-    <value>MediaVolumeDown</value>
+    <value>音量减</value>
   </data>
   <data name="CommandType_MediaVolumeUpCommand" xml:space="preserve">
-    <value>MediaVolumeUp</value>
+    <value>音量加</value>
   </data>
   <data name="CommandType_MultipleKeysCommand" xml:space="preserve">
-    <value>MultipleKeys</value>
+    <value>多按键</value>
   </data>
   <data name="CommandType_PowershellCommand" xml:space="preserve">
-    <value>Powershell</value>
+    <value>PowerShell</value>
   </data>
   <data name="CommandType_PublishAllSensorsCommand" xml:space="preserve">
-    <value>PublishAllSensors</value>
+    <value>发布所有传感器</value>
   </data>
   <data name="CommandType_RestartCommand" xml:space="preserve">
-    <value>Restart</value>
+    <value>重启</value>
   </data>
   <data name="CommandType_ShutdownCommand" xml:space="preserve">
-    <value>Shutdown</value>
+    <value>关机</value>
   </data>
   <data name="CommandType_SleepCommand" xml:space="preserve">
-    <value>Sleep</value>
+    <value>睡眠</value>
   </data>
   <data name="UserNotificationState_AcceptsNotifications" xml:space="preserve">
-    <value>AcceptsNotifications</value>
+    <value>接受通知</value>
   </data>
   <data name="UserNotificationState_Busy" xml:space="preserve">
-    <value>Busy</value>
+    <value>忙碌</value>
   </data>
   <data name="UserNotificationState_NotPresent" xml:space="preserve">
-    <value>NotPresent</value>
+    <value>不在场</value>
   </data>
   <data name="UserNotificationState_PresentationMode" xml:space="preserve">
-    <value>PresentationMode</value>
+    <value>演示模式</value>
   </data>
   <data name="UserNotificationState_QuietTime" xml:space="preserve">
-    <value>QuietTime</value>
+    <value>安静时间</value>
   </data>
   <data name="UserNotificationState_RunningDirect3dFullScreen" xml:space="preserve">
-    <value>RunningDirect3dFullScreen</value>
+    <value>正在运行 Direct3D 全屏</value>
   </data>
   <data name="UserNotificationState_RunningWindowsStoreApp" xml:space="preserve">
-    <value>RunningWindowsStoreApp</value>
+    <value>正在运行 Windows 应用商店应用</value>
   </data>
   <data name="SystemStateEvent_ConsoleConnect" xml:space="preserve">
-    <value>ConsoleConnect</value>
+    <value>控制台连接</value>
   </data>
   <data name="SystemStateEvent_ConsoleDisconnect" xml:space="preserve">
-    <value>ConsoleDisconnect</value>
+    <value>控制台断开</value>
   </data>
   <data name="SystemStateEvent_HassAgentSatelliteServiceStarted" xml:space="preserve">
-    <value>HassAgentSatelliteServiceStarted</value>
+    <value>HASS.Agent 卫星服务已启动</value>
   </data>
   <data name="SystemStateEvent_HassAgentStarted" xml:space="preserve">
-    <value>HassAgentStarted</value>
+    <value>HASS.Agent 已启动</value>
   </data>
   <data name="SystemStateEvent_Logoff" xml:space="preserve">
-    <value>Logoff</value>
+    <value>注销</value>
   </data>
   <data name="SystemStateEvent_RemoteConnect" xml:space="preserve">
-    <value>RemoteConnect</value>
+    <value>远程连接</value>
   </data>
   <data name="SystemStateEvent_RemoteDisconnect" xml:space="preserve">
-    <value>RemoteDisconnect</value>
+    <value>远程断开</value>
   </data>
   <data name="SystemStateEvent_Resume" xml:space="preserve">
-    <value>Resume</value>
+    <value>恢复</value>
   </data>
   <data name="SystemStateEvent_SessionLock" xml:space="preserve">
-    <value>SessionLock</value>
+    <value>会话锁定</value>
   </data>
   <data name="SystemStateEvent_SessionLogoff" xml:space="preserve">
-    <value>SessionLogoff</value>
+    <value>会话注销</value>
   </data>
   <data name="SystemStateEvent_SessionLogon" xml:space="preserve">
-    <value>SessionLogon</value>
+    <value>会话登录</value>
   </data>
   <data name="SystemStateEvent_SessionRemoteControl" xml:space="preserve">
-    <value>SessionRemoteControl</value>
+    <value>会话远程控制</value>
   </data>
   <data name="SystemStateEvent_SessionUnlock" xml:space="preserve">
-    <value>SessionUnlock</value>
+    <value>会话解锁</value>
   </data>
   <data name="SystemStateEvent_Suspend" xml:space="preserve">
-    <value>Suspend</value>
+    <value>挂起</value>
   </data>
   <data name="SystemStateEvent_SystemShutdown" xml:space="preserve">
-    <value>SystemShutdown</value>
+    <value>系统关机</value>
   </data>
   <data name="SensorType_ActiveWindowSensor" xml:space="preserve">
-    <value>ActiveWindow</value>
+    <value>活动窗口</value>
   </data>
   <data name="SensorType_AudioSensors" xml:space="preserve">
-    <value>Audio</value>
+    <value>音频</value>
   </data>
   <data name="SensorType_BatterySensors" xml:space="preserve">
-    <value>Battery</value>
+    <value>电池</value>
   </data>
   <data name="SensorType_CpuLoadSensor" xml:space="preserve">
-    <value>CpuLoad</value>
+    <value>CPU 负载</value>
   </data>
   <data name="SensorType_CurrentClockSpeedSensor" xml:space="preserve">
-    <value>CurrentClockSpeed</value>
+    <value>当前时钟频率</value>
   </data>
   <data name="SensorType_CurrentVolumeSensor" xml:space="preserve">
-    <value>CurrentVolume</value>
+    <value>当前音量</value>
   </data>
   <data name="SensorType_DisplaySensors" xml:space="preserve">
-    <value>Display</value>
+    <value>显示器</value>
   </data>
   <data name="SensorType_DummySensor" xml:space="preserve">
-    <value>Dummy</value>
+    <value>虚拟</value>
   </data>
   <data name="SensorType_GpuLoadSensor" xml:space="preserve">
-    <value>GpuLoad</value>
+    <value>GPU 负载</value>
   </data>
   <data name="SensorType_GpuTemperatureSensor" xml:space="preserve">
-    <value>GpuTemperature</value>
+    <value>GPU 温度</value>
   </data>
   <data name="SensorType_LastActiveSensor" xml:space="preserve">
-    <value>LastActive</value>
+    <value>最后活动</value>
   </data>
   <data name="SensorType_LastBootSensor" xml:space="preserve">
-    <value>LastBoot</value>
+    <value>最后启动</value>
   </data>
   <data name="SensorType_LastSystemStateChangeSensor" xml:space="preserve">
-    <value>LastSystemStateChange</value>
+    <value>最后系统状态变更</value>
   </data>
   <data name="SensorType_LoggedUserSensor" xml:space="preserve">
-    <value>LoggedUser</value>
+    <value>已登录用户</value>
   </data>
   <data name="SensorType_LoggedUsersSensor" xml:space="preserve">
-    <value>LoggedUsers</value>
+    <value>已登录用户列表</value>
   </data>
   <data name="SensorType_MemoryUsageSensor" xml:space="preserve">
-    <value>MemoryUsage</value>
+    <value>内存使用</value>
   </data>
   <data name="SensorType_MicrophoneActiveSensor" xml:space="preserve">
-    <value>MicrophoneActive</value>
+    <value>麦克风活动</value>
   </data>
   <data name="SensorType_NamedWindowSensor" xml:space="preserve">
-    <value>NamedWindow</value>
+    <value>命名窗口</value>
   </data>
   <data name="SensorType_NetworkSensors" xml:space="preserve">
-    <value>Network</value>
+    <value>网络</value>
   </data>
   <data name="SensorType_PerformanceCounterSensor" xml:space="preserve">
-    <value>PerformanceCounter</value>
+    <value>性能计数器</value>
   </data>
   <data name="SensorType_ProcessActiveSensor" xml:space="preserve">
-    <value>ProcessActive</value>
+    <value>进程活动</value>
   </data>
   <data name="SensorType_ServiceStateSensor" xml:space="preserve">
-    <value>ServiceState</value>
+    <value>服务状态</value>
   </data>
   <data name="SensorType_SessionStateSensor" xml:space="preserve">
-    <value>SessionState</value>
+    <value>会话状态</value>
   </data>
   <data name="SensorType_StorageSensors" xml:space="preserve">
-    <value>Storage</value>
+    <value>存储</value>
   </data>
   <data name="SensorType_UserNotificationStateSensor" xml:space="preserve">
-    <value>UserNotification</value>
+    <value>用户通知</value>
   </data>
   <data name="SensorType_WebcamActiveSensor" xml:space="preserve">
-    <value>WebcamActive</value>
+    <value>摄像头活动</value>
   </data>
   <data name="SensorType_WindowsUpdatesSensors" xml:space="preserve">
-    <value>WindowsUpdates</value>
+    <value>Windows 更新</value>
   </data>
   <data name="SensorType_WmiQuerySensor" xml:space="preserve">
-    <value>WmiQuery</value>
+    <value>WMI 查询</value>
   </data>
   <data name="HassDomain_Automation" xml:space="preserve">
-    <value>Automation</value>
+    <value>自动化</value>
   </data>
   <data name="HassDomain_Climate" xml:space="preserve">
-    <value>Climate</value>
+    <value>气候</value>
   </data>
   <data name="HassDomain_Cover" xml:space="preserve">
-    <value>Cover</value>
+    <value>窗帘</value>
   </data>
   <data name="HassDomain_InputBoolean" xml:space="preserve">
-    <value>InputBoolean</value>
+    <value>输入布尔</value>
   </data>
   <data name="HassDomain_Light" xml:space="preserve">
-    <value>Light</value>
+    <value>灯</value>
   </data>
   <data name="HassDomain_MediaPlayer" xml:space="preserve">
-    <value>MediaPlayer</value>
+    <value>媒体播放器</value>
   </data>
   <data name="HassDomain_Scene" xml:space="preserve">
-    <value>Scene</value>
+    <value>场景</value>
   </data>
   <data name="HassDomain_Script" xml:space="preserve">
-    <value>Script</value>
+    <value>脚本</value>
   </data>
   <data name="HassDomain_Switch" xml:space="preserve">
-    <value>Switch</value>
+    <value>开关</value>
   </data>
   <data name="HassAction_Close" xml:space="preserve">
-    <value>Close</value>
+    <value>关闭</value>
   </data>
   <data name="HassAction_Off" xml:space="preserve">
-    <value>Off</value>
+    <value>关</value>
   </data>
   <data name="HassAction_On" xml:space="preserve">
-    <value>On</value>
+    <value>开</value>
   </data>
   <data name="HassAction_Open" xml:space="preserve">
-    <value>Open</value>
+    <value>打开</value>
   </data>
   <data name="HassAction_Pause" xml:space="preserve">
-    <value>Pause</value>
+    <value>暂停</value>
   </data>
   <data name="HassAction_Play" xml:space="preserve">
-    <value>Play</value>
+    <value>播放</value>
   </data>
   <data name="HassAction_Stop" xml:space="preserve">
-    <value>Stop</value>
+    <value>停止</value>
   </data>
   <data name="HassAction_Toggle" xml:space="preserve">
-    <value>Toggle</value>
+    <value>切换</value>
   </data>
   <data name="CommandEntityType_Button" xml:space="preserve">
-    <value>Button</value>
+    <value>按钮</value>
   </data>
   <data name="CommandEntityType_Light" xml:space="preserve">
-    <value>Light</value>
+    <value>灯</value>
   </data>
   <data name="CommandEntityType_Lock" xml:space="preserve">
-    <value>Lock</value>
+    <value>锁</value>
   </data>
   <data name="CommandEntityType_Siren" xml:space="preserve">
-    <value>Siren</value>
+    <value>警报器</value>
   </data>
   <data name="CommandEntityType_Switch" xml:space="preserve">
-    <value>Switch</value>
+    <value>开关</value>
   </data>
   <data name="ComponentStatus_Connecting" xml:space="preserve">
-    <value>Connecting..</value>
+    <value>连接中..</value>
   </data>
   <data name="ComponentStatus_Disabled" xml:space="preserve">
-    <value>Disabled</value>
+    <value>已禁用</value>
   </data>
   <data name="ComponentStatus_Failed" xml:space="preserve">
-    <value>Failed</value>
+    <value>失败</value>
   </data>
   <data name="ComponentStatus_Loading" xml:space="preserve">
-    <value>Loading..</value>
+    <value>加载中..</value>
   </data>
   <data name="ComponentStatus_Ok" xml:space="preserve">
-	  <value>Running</value>
+    <value>运行中</value>
   </data>
   <data name="ComponentStatus_Stopped" xml:space="preserve">
-    <value>Stopped</value>
+    <value>已停止</value>
   </data>
   <data name="LockState_Locked" xml:space="preserve">
-    <value>Locked</value>
+    <value>已锁定</value>
   </data>
   <data name="LockState_Unknown" xml:space="preserve">
-    <value>Unknown</value>
+    <value>未知</value>
   </data>
   <data name="LockState_Unlocked" xml:space="preserve">
-    <value>Unlocked</value>
+    <value>已解锁</value>
   </data>
   <data name="SensorType_GeoLocationSensor" xml:space="preserve">
-    <value>GeoLocation</value>
+    <value>地理位置</value>
   </data>
   <data name="SensorsMod_All" xml:space="preserve">
-    <value>All</value>
+    <value>全部</value>
   </data>
   <data name="SensorsMod_BtnTest" xml:space="preserve">
-    <value>&amp;Test</value>
+    <value>测试(&amp;T)</value>
   </data>
   <data name="SensorsMod_BtnTest_PerformanceCounter" xml:space="preserve">
-    <value>Test Performance Counter</value>
+    <value>测试性能计数器</value>
   </data>
   <data name="SensorsMod_BtnTest_Wmi" xml:space="preserve">
-    <value>Test WMI Query</value>
+    <value>测试 WMI 查询</value>
   </data>
   <data name="SensorsMod_LblSetting1_Network" xml:space="preserve">
-    <value>Network Card</value>
+    <value>网卡</value>
   </data>
   <data name="SensorsMod_TestPerformanceCounter_MessageBox1" xml:space="preserve">
-    <value>Enter a category and counter first.</value>
+    <value>请先输入类别和计数器。</value>
   </data>
   <data name="SensorsMod_TestPerformanceCounter_MessageBox2" xml:space="preserve">
-	  <value>Test succesfully executed, result value:
+    <value>测试成功执行，结果值：
 
 {0}</value>
   </data>
   <data name="SensorsMod_TestPerformanceCounter_MessageBox3" xml:space="preserve">
-	  <value>The test failed to execute:
+    <value>测试执行失败：
 
 {0}
 
-Do you want to open the logs folder?</value>
+您想打开日志文件夹吗？</value>
   </data>
   <data name="SensorsMod_TestWmi_MessageBox1" xml:space="preserve">
-    <value>Enter a WMI query first.</value>
+    <value>请先输入 WMI 查询。</value>
   </data>
   <data name="SensorsMod_TestWmi_MessageBox2" xml:space="preserve">
-	  <value>Query succesfully executed, result value:
+    <value>查询成功执行，结果值：
 
 {0}</value>
   </data>
   <data name="SensorsMod_TestWmi_MessageBox3" xml:space="preserve">
-	  <value>The query failed to execute:
+    <value>查询执行失败：
 
 {0}
 
-Do you want to open the logs folder?</value>
+您想打开日志文件夹吗？</value>
   </data>
   <data name="SensorsMod_WmiTestFailed" xml:space="preserve">
-	  <value>It looks like your scope is malformed, it should probably start like this:
+    <value>看起来您的范围格式不正确，它可能应该以如下方式开头：
 
 \\.\ROOT\
 
-The scope you entered:
+您输入的范围：
 
 {0}
 
-Tip: make sure you haven't switched the scope and query fields around.
+提示：请确保您没有混淆范围和查询字段。
 
-Do you still want to use the current values?</value>
+您仍要使用当前值吗？</value>
   </data>
   <data name="SystemStateEvent_ApplicationStarted" xml:space="preserve">
-    <value>ApplicationStarted</value>
+    <value>应用程序已启动</value>
   </data>
   <data name="ServiceGeneral_LblInfo2" xml:space="preserve">
-    <value>You can use the satellite service to run sensors and commands without having to be logged in. Not all types are available, for instance the 'LaunchUrl' command can only be added as a regular command.</value>
+    <value>您可以使用卫星服务来运行传感器和命令，而无需登录。并非所有类型都可用，例如 'LaunchUrl' 命令只能作为常规命令添加。</value>
   </data>
   <data name="SensorsConfig_ClmValue" xml:space="preserve">
-    <value>Last Known Value</value>
+    <value>上次已知值</value>
   </data>
   <data name="LocalApiManager_Initialize_MessageBox1" xml:space="preserve">
-	  <value>Error trying to bind the API to port {0}.
+    <value>尝试将 API 绑定到端口 {0} 时出错。
 
-Make sure no other instance of HASS.Agent is running and the port is available and registered.</value>
+请确保没有其他 HASS.Agent 实例正在运行，并且该端口可用且已注册。</value>
   </data>
   <data name="CommandType_SendWindowToFrontCommand" xml:space="preserve">
-    <value>SendWindowToFront</value>
+    <value>发送窗口到前台</value>
   </data>
   <data name="CommandType_WebViewCommand" xml:space="preserve">
     <value>WebView</value>
   </data>
   <data name="CommandsManager_WebViewCommandDescription" xml:space="preserve">
-	  <value>Shows a window with the provided URL.
+    <value>显示一个包含指定 URL 的窗口。
 
-This differs from the 'LaunchUrl' command in that it doesn't load a full-fledged browser, just the provided URL in its own window.
+这与 'LaunchUrl' 命令的不同之处在于，它不会加载完整的浏览器，只是在独立窗口中显示提供的 URL。
 
-You can use this to for instance quickly show Home Assistant's dashboard.
+例如，你可以使用它来快速显示 Home Assistant 的仪表板。
 
-By default, it stores cookies indefinitely so you only have to log in once.</value>
+默认情况下，它会永久存储 cookies，因此你只需登录一次。</value>
   </data>
   <data name="HassDomain_HASSAgentCommands" xml:space="preserve">
-    <value>HASS.Agent Commands</value>
+    <value>HASS.Agent 命令</value>
   </data>
   <data name="CommandsManager_CommandsManager_SendWindowToFrontCommandDescription" xml:space="preserve">
-	  <value>Looks for the specified process, and tries to send its main window to the front.
+    <value>查找指定的进程，并尝试将其主窗口发送到前台。
 
-If the application is minimized, it'll get restored.
+如果应用程序已最小化，它将被还原。
 
-Example: if you want to send VLC to the foreground, use 'vlc'.</value>
+例如：如果要将 VLC 发送到前台，请使用 'vlc'。</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox8" xml:space="preserve">
-	  <value>If you do not configure the command, you may only use this entity with an 'action' value via Home Assistant and it will appear using the default settings, running it as-is will have no action.
+    <value>如果不配置命令，你可能只能通过 Home Assistant 使用 'action' 值来操作此实体，它将以默认设置显示，按原样运行将不会有任何操作。
 
-Are you sure you want to do this?</value>
+你确定要这样做吗？</value>
   </data>
   <data name="ConfigLocalStorage_BtnClearAudioCache" xml:space="preserve">
-    <value>Clear Audio Cache</value>
+    <value>清除音频缓存</value>
   </data>
   <data name="ConfigLocalStorage_BtnClearAudioCache_InfoText1" xml:space="preserve">
-    <value>Cleaning..</value>
+    <value>清理中..</value>
   </data>
   <data name="ConfigLocalStorage_BtnClearAudioCache_MessageBox1" xml:space="preserve">
-    <value>The audio cache has been cleared!</value>
+    <value>音频缓存已清除！</value>
   </data>
   <data name="ConfigLocalStorage_BtnClearWebViewCache" xml:space="preserve">
-    <value>Clear WebView Cache</value>
+    <value>清除 WebView 缓存</value>
   </data>
   <data name="ConfigLocalStorage_BtnClearWebViewCache_InfoText1" xml:space="preserve">
-    <value>Cleaning..</value>
+    <value>清理中..</value>
   </data>
   <data name="ConfigLocalStorage_BtnClearWebViewCache_MessageBox1" xml:space="preserve">
-    <value>The WebView cache has been cleared!</value>
+    <value>WebView 缓存已清除！</value>
   </data>
   <data name="Main_CheckDpiScalingFactor_MessageBox1" xml:space="preserve">
-	  <value>It looks like you're using an alternative scaling. This may result in some parts of HASS.Agent not looking as intended.
+    <value>看起来你正在使用替代缩放比例。这可能导致 HASS.Agent 的某些部分显示不正常。
 
-Please report any unusable aspects on GitHub. Thanks!
+请在 GitHub 上报告任何无法使用的部分。谢谢！
 
-Note: this message only shows once.</value>
+注意：此消息只会显示一次。</value>
   </data>
   <data name="WebViewCommandConfig_SetStoredVariables_MessageBox1" xml:space="preserve">
-    <value>Unable to load the stored command settings, resetting to default.</value>
+    <value>无法加载存储的命令设置，将重置为默认值。</value>
   </data>
   <data name="CommandsMod_BtnConfigureCommand" xml:space="preserve">
-    <value>Configure Command &amp;Parameters</value>
+    <value>配置命令参数(&P)</value>
   </data>
   <data name="ConfigLocalApi_BtnExecutePortReservation" xml:space="preserve">
-    <value>Execute Port &amp;Reservation</value>
+    <value>执行端口保留(&R)</value>
   </data>
   <data name="ConfigLocalApi_CbLocalApiActive" xml:space="preserve">
-    <value>&amp;Enable Local API</value>
+    <value>启用本地 API(&E)</value>
   </data>
   <data name="ConfigLocalApi_LblInfo1" xml:space="preserve">
-	  <value>HASS.Agent has its own local API, so Home Assistant can send requests (for instance to send a notification). You can configure it globally here, and afterwards you can configure the dependent sections (currently notifications and mediaplayer).
+    <value>HASS.Agent 有自己的本地 API，因此 Home Assistant 可以发送请求（例如发送通知）。你可以在此处全局配置它，然后配置相关部分（目前是通知和媒体播放器）。
 
-Note: this is not required for the new integration to function. Only enable and use it if you don't use MQTT.</value>
+注意：新集成无需此功能即可运行。仅在不使用 MQTT 时才启用并使用它。</value>
   </data>
   <data name="ConfigLocalApi_LblInfo2" xml:space="preserve">
-    <value>To be able to listen to the requests, HASS.Agent needs to have its port reserved and opened in your firewall. You can use this button to have it done for you.</value>
+    <value>为了能够监听请求，HASS.Agent 需要在你的防火墙中保留并打开其端口。你可以使用此按钮自动完成此操作。</value>
   </data>
   <data name="ConfigLocalApi_LblPort" xml:space="preserve">
-    <value>&amp;Port</value>
+    <value>端口(&P)</value>
   </data>
   <data name="ConfigLocalStorage_LblAudioCacheLocation" xml:space="preserve">
-    <value>Audio Cache Location</value>
+    <value>音频缓存位置</value>
   </data>
   <data name="ConfigLocalStorage_LblImageCacheDays" xml:space="preserve">
-    <value>days</value>
+    <value>天</value>
   </data>
   <data name="ConfigLocalStorage_LblImageCacheLocation" xml:space="preserve">
-    <value>Image Cache Location</value>
+    <value>图片缓存位置</value>
   </data>
   <data name="ConfigLocalStorage_LblKeepAudio" xml:space="preserve">
-    <value>Keep audio for</value>
+    <value>保留音频</value>
   </data>
   <data name="ConfigLocalStorage_LblKeepImages" xml:space="preserve">
-    <value>Keep images for</value>
+    <value>保留图片</value>
   </data>
   <data name="ConfigLocalStorage_LblKeepWebView" xml:space="preserve">
-    <value>Clear cache every</value>
+    <value>清除缓存频率</value>
   </data>
   <data name="ConfigLocalStorage_LblWebViewCacheLocation" xml:space="preserve">
-    <value>WebView Cache Location</value>
+    <value>WebView 缓存位置</value>
   </data>
   <data name="ConfigMediaPlayer_BtnMediaPlayerReadme" xml:space="preserve">
-    <value>Media Player &amp;Documentation</value>
+    <value>媒体播放器文档(&D)</value>
   </data>
   <data name="ConfigMediaPlayer_CbEnableMediaPlayer" xml:space="preserve">
-    <value>&amp;Enable Media Player Functionality</value>
+    <value>启用媒体播放器功能(&E)</value>
   </data>
   <data name="ConfigMediaPlayer_LblInfo1" xml:space="preserve">
-    <value>HASS.Agent can act as a media player for Home Assistant, so you'll be able to see and control any media that's playing, and send text-to-speech. If you have MQTT enabled, your device will automatically get added. Otherwise, manually configure the integration to use the local API.</value>
+    <value>HASS.Agent 可以作为 Home Assistant 的媒体播放器，因此你将能够查看和控制任何正在播放的媒体，并发送文本转语音。如果你启用了 MQTT，你的设备将被自动添加。否则，请手动配置集成以使用本地 API。</value>
   </data>
   <data name="ConfigMediaPlayer_LblInfo2" xml:space="preserve">
-	  <value>If something is not working, make sure you try the following steps:
+    <value>如果某些功能无法正常工作，请尝试以下步骤：
 
-- Install the HASS.Agent integration
-- Restart Home Assistant
-- Make sure HASS.Agent is active with MQTT enabled!
-- Your device should get detected and added as an entity automatically
-- Optionally: manually add it using the local API</value>
+- 安装 HASS.Agent 集成
+- 重启 Home Assistant
+- 确保 HASS.Agent 处于活动状态并启用了 MQTT！
+- 你的设备应该会被自动检测并添加为实体
+- 可选：使用本地 API 手动添加</value>
   </data>
   <data name="ConfigMediaPlayer_LblLocalApiDisabled" xml:space="preserve">
-    <value>The local API is disabled however the media player requires it in order to function.</value>
+    <value>本地 API 已禁用，但媒体播放器需要它才能运行。</value>
   </data>
   <data name="ConfigMqtt_CbMqttTls" xml:space="preserve">
-    <value>&amp;TLS</value>
+    <value>TLS(&T)</value>
   </data>
   <data name="ConfigNotifications_LblLocalApiDisabled" xml:space="preserve">
-    <value>The local API is disabled however the media player requires it in order to function.</value>
+    <value>本地 API 已禁用，但媒体播放器需要它才能运行。</value>
   </data>
   <data name="ConfigTrayIcon_BtnShowWebViewPreview" xml:space="preserve">
-    <value>Show &amp;Preview</value>
+    <value>显示预览(&P)</value>
   </data>
   <data name="ConfigTrayIcon_CbDefaultMenu" xml:space="preserve">
-    <value>Show &amp;Default Menu</value>
+    <value>显示默认菜单(&D)</value>
   </data>
   <data name="ConfigTrayIcon_CbShowWebView" xml:space="preserve">
-    <value>Show &amp;WebView</value>
+    <value>显示 WebView(&W)</value>
   </data>
   <data name="ConfigTrayIcon_CbWebViewKeepLoaded" xml:space="preserve">
-    <value>&amp;Keep page loaded in the background</value>
+    <value>在后台保持页面加载(&K)</value>
   </data>
   <data name="ConfigTrayIcon_LblInfo1" xml:space="preserve">
-    <value>Control the behaviour of the tray icon when it is right-clicked.</value>
+    <value>控制右键单击托盘图标时的行为。</value>
   </data>
   <data name="ConfigTrayIcon_LblInfo2" xml:space="preserve">
-    <value>(This uses extra resources, but reduces loading time.)</value>
+    <value>（这会使用额外资源，但会减少加载时间。）</value>
   </data>
   <data name="ConfigTrayIcon_LblWebViewSize" xml:space="preserve">
-    <value>Size (px)</value>
+    <value>大小 (px)</value>
   </data>
   <data name="ConfigTrayIcon_LblWebViewUrl" xml:space="preserve">
-    <value>&amp;WebView URL (For instance, your Home Assistant Dashboard URL)</value>
+    <value>WebView URL(&W)（例如，你的 Home Assistant 仪表板 URL）</value>
   </data>
   <data name="Configuration_TablLocalApi" xml:space="preserve">
-    <value>Local API</value>
+    <value>本地 API</value>
   </data>
   <data name="Configuration_TabMediaPlayer" xml:space="preserve">
-    <value>Media Player</value>
+    <value>媒体播放器</value>
   </data>
   <data name="Configuration_TabTrayIcon" xml:space="preserve">
-    <value>Tray Icon</value>
+    <value>托盘图标</value>
   </data>
   <data name="HelperFunctions_InputLanguageCheckDiffers_ErrorMsg1" xml:space="preserve">
-    <value>Your input language '{0}' is known to collide with the default CTRL-ALT-Q hotkey. Please set your own.</value>
+    <value>你的输入语言 '{0}' 已知会与默认的 CTRL-ALT-Q 热键冲突。请设置你自己的热键。</value>
   </data>
   <data name="HelperFunctions_InputLanguageCheckDiffers_ErrorMsg2" xml:space="preserve">
-    <value>Your input language '{0}' is unknown, and might collide with the default CTRL-ALT-Q hotkey. Please check to be sure. If it does, consider opening a ticket on GitHub so it can be added to the list.</value>
+    <value>你的输入语言 '{0}' 未知，可能与默认的 CTRL-ALT-Q 热键冲突。请检查确认。如果确实冲突，请考虑在 GitHub 上提交工单，以便将其添加到列表中。</value>
   </data>
   <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg1" xml:space="preserve">
-    <value>No keys found</value>
+    <value>未找到键</value>
   </data>
   <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg2" xml:space="preserve">
-    <value>brackets missing, start and close all keys with [ ]</value>
+    <value>缺少括号，请用 [ ] 开始和结束所有键</value>
   </data>
   <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg3" xml:space="preserve">
-    <value>Error while parsing keys, please check the logs for more information.</value>
+    <value>解析键时出错，请查看日志以获取更多信息。</value>
   </data>
   <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg4" xml:space="preserve">
-    <value>The number of open brackets ('[') does not correspond to the number of closed brackets. (']')! ({0} to {1})</value>
+    <value>左括号 ('[') 的数量与右括号 (']') 的数量不匹配！({0} 对 {1})</value>
   </data>
   <data name="Help_LblDocumentation" xml:space="preserve">
-    <value>Documentation</value>
+    <value>文档</value>
   </data>
   <data name="Help_LblDocumentationInfo" xml:space="preserve">
-    <value>Documentation and Usage Examples</value>
+    <value>文档和使用示例</value>
   </data>
   <data name="Main_BtnCheckForUpdate" xml:space="preserve">
-    <value>Check for &amp;Updates</value>
+    <value>检查更新(&U)</value>
   </data>
   <data name="Main_LblLocalApi" xml:space="preserve">
-    <value>Local API:</value>
+    <value>本地 API：</value>
   </data>
   <data name="Main_TsSatelliteService" xml:space="preserve">
-    <value>Manage Satellite Service</value>
+    <value>管理卫星服务</value>
   </data>
   <data name="OnboardingIntegrations_LblInfo1" xml:space="preserve">
-	  <value>To use notifications, you need to install and configure the HASS.Agent integration in
-Home Assistant.
+    <value>要使用通知，你需要在 Home Assistant 中安装并配置 HASS.Agent 集成。
 
-This is very easy using HACS, but you can also install manually. Visit the link below for more
-information.</value>
+使用 HACS 安装非常简单，你也可以手动安装。请访问下方链接获取更多信息。</value>
   </data>
   <data name="OnboardingIntegrations_LblInfo2" xml:space="preserve">
-	  <value>Make sure you follow these steps:
+    <value>请确保按照以下步骤操作：
 
-- Install the HASS.Agent-Notifier and / or HASS.Agent-MediaPlayer integration
-- Restart Home Assistant
--Configure a notifier and / or media_player entity
--Restart Home Assistant</value>
+- 安装 HASS.Agent-Notifier 和/或 HASS.Agent-MediaPlayer 集成
+- 重启 Home Assistant
+- 配置 notifier 和/或 media_player 实体
+- 重启 Home Assistant</value>
   </data>
   <data name="OnboardingIntegrations_LblInfo3" xml:space="preserve">
-    <value>The same goes for the media player, this integration allows you to control your device as a media_player entity, see what's playing and send text-to-speech.</value>
+    <value>媒体播放器也是如此，此集成允许你将设备作为 media_player 实体进行控制，查看正在播放的内容并发送文本转语音。</value>
   </data>
   <data name="OnboardingIntegrations_LblMediaPlayerIntegration" xml:space="preserve">
-    <value>HASS.Agent-MediaPlayer GitHub Page</value>
+    <value>HASS.Agent-MediaPlayer GitHub 页面</value>
   </data>
   <data name="OnboardingIntegrations_LblNotifierIntegration" xml:space="preserve">
-    <value>HASS.Agent-Integration GitHub Page</value>
+    <value>HASS.Agent-Integration GitHub 页面</value>
   </data>
   <data name="OnboardingLocalApi_CbEnableLocalApi" xml:space="preserve">
-    <value>Yes, &amp;enable the local API on port</value>
+    <value>是，启用本地 API 端口(&E)</value>
   </data>
   <data name="OnboardingLocalApi_CbEnableMediaPlayer" xml:space="preserve">
-    <value>Enable &amp;Media Player and text-to-speech (TTS)</value>
+    <value>启用媒体播放器和文本转语音(TTS)(&M)</value>
   </data>
   <data name="OnboardingLocalApi_CbEnableNotifications" xml:space="preserve">
-    <value>Enable &amp;Notifications</value>
+    <value>启用通知(&N)</value>
   </data>
   <data name="OnboardingLocalApi_LblInfo1" xml:space="preserve">
-	  <value>HASS.Agent has its own internal API, so Home Assistant can send requests (like notifications or text-to-speech).
+    <value>HASS.Agent 有自己的内部 API，因此 Home Assistant 可以发送请求（如通知或文本转语音）。
 
-Do you want to enable it?</value>
+你想要启用它吗？</value>
   </data>
   <data name="OnboardingLocalApi_LblInfo2" xml:space="preserve">
-    <value>You can choose what modules you want to enable. They require HA integrations, but don't worry, the next page will give you more info on how to set them up.</value>
+    <value>你可以选择要启用的模块。它们需要 HA 集成，但别担心，下一页将为你提供更多关于如何设置它们的信息。</value>
   </data>
   <data name="OnboardingLocalApi_LblTip1" xml:space="preserve">
-    <value>Note: 5115 is the default port, only change it if you changed it in Home Assistant.</value>
+    <value>注意：5115 是默认端口，只有在 Home Assistant 中更改过才需要修改。</value>
   </data>
   <data name="OnboardingMqtt_CbMqttTls" xml:space="preserve">
-    <value>&amp;TLS</value>
+    <value>TLS(&T)</value>
   </data>
   <data name="OnboardingWelcome_Store_MessageBox1" xml:space="preserve">
-	  <value>Your device name contained some characters that are not allowed by HA (only letters, digits and whitespace).
+    <value>你的设备名称包含一些 HA 不允许的字符（只允许字母、数字和空格）。
 
-The final name is: {0}
+最终名称为：{0}
 
-Do you want to use that version?</value>
+你想使用该版本吗？</value>
   </data>
   <data name="Onboarding_Title" xml:space="preserve">
-    <value>HASS.Agent Onboarding</value>
+    <value>HASS.Agent 引导</value>
   </data>
   <data name="ServiceGeneral_LblAuthStored" xml:space="preserve">
-    <value>stored!</value>
+    <value>已存储！</value>
   </data>
   <data name="ServiceMqtt_CbMqttTls" xml:space="preserve">
-    <value>&amp;TLS</value>
+    <value>TLS(&T)</value>
   </data>
   <data name="WebViewCommandConfig_BtnSave" xml:space="preserve">
-    <value>&amp;Save</value>
+    <value>保存(&S)</value>
   </data>
   <data name="WebViewCommandConfig_CbCenterScreen" xml:space="preserve">
-    <value>&amp;Always show centered in screen</value>
+    <value>始终在屏幕居中显示(&A)</value>
   </data>
   <data name="WebViewCommandConfig_CbShowTitleBar" xml:space="preserve">
-    <value>Show the window's &amp;title bar</value>
+    <value>显示窗口标题栏(&T)</value>
   </data>
   <data name="WebViewCommandConfig_CbTopMost" xml:space="preserve">
-    <value>Set window as 'Always on &amp;Top'</value>
+    <value>将窗口设置为'始终置顶'(&T)</value>
   </data>
   <data name="WebViewCommandConfig_LblInfo1" xml:space="preserve">
-    <value>Drag and resize this window to set the size and location of your webview command.</value>
+    <value>拖动并调整此窗口的大小，以设置你的 WebView 命令的大小和位置。</value>
   </data>
   <data name="WebViewCommandConfig_LblLocation" xml:space="preserve">
-    <value>Location</value>
+    <value>位置</value>
   </data>
   <data name="WebViewCommandConfig_LblSize" xml:space="preserve">
-    <value>Size</value>
+    <value>大小</value>
   </data>
   <data name="WebViewCommandConfig_LblTip1" xml:space="preserve">
-    <value>Tip: Press ESCAPE to close a WebView.</value>
+    <value>提示：按 ESCAPE 键关闭 WebView。</value>
   </data>
   <data name="WebViewCommandConfig_LblUrl" xml:space="preserve">
-    <value>&amp;URL</value>
+    <value>URL(&U)</value>
   </data>
   <data name="WebViewCommandConfig_Title" xml:space="preserve">
-    <value>WebView Configuration</value>
+    <value>WebView 配置</value>
   </data>
   <data name="WebView_Title" xml:space="preserve">
     <value>WebView</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox9" xml:space="preserve">
-	  <value>The keycode you have provided is not a valid number!
+    <value>你提供的键码不是有效的数字！
 
-Please ensure the keycode field is in focus and press the key you want simulated, the keycode should then be generated for you.</value>
+请确保键码字段处于焦点状态，然后按下你想要模拟的键，系统将为你生成键码。</value>
   </data>
   <data name="ConfigGeneral_CbEnableDeviceNameSanitation" xml:space="preserve">
-    <value>Enable Device Name &amp;Sanitation</value>
+    <value>启用设备名称清理(&S)</value>
   </data>
   <data name="ConfigGeneral_CbEnableStateNotifications" xml:space="preserve">
-    <value>Enable State Notifications</value>
+    <value>启用状态通知</value>
   </data>
   <data name="ConfigGeneral_LblInfo5" xml:space="preserve">
-    <value>HASS.Agent will sanitize your device name to make sure HA will accept it, you can overrule this rule below if you're sure that your name will be accepted as-is.</value>
+    <value>HASS.Agent 将清理你的设备名称以确保 HA 接受它，如果你确定你的名称原样会被接受，可以在下方覆盖此规则。</value>
   </data>
   <data name="ConfigGeneral_LblInfo6" xml:space="preserve">
-    <value>HASS.Agent sends notifications when the state of a module changes, you can adjust whether or not you want to receive these notifications below.</value>
+    <value>当模块状态发生变化时，HASS.Agent 会发送通知，你可以在下方调整是否要接收这些通知。</value>
   </data>
   <data name="Configuration_ProcessChanges_MessageBox6" xml:space="preserve">
-	  <value>You've changed your device's name.
+    <value>你已更改了设备名称。
 
-All your sensors and commands will now be unpublished and published again after the HASS.Agent restarts.
+所有传感器和命令将被取消发布，并在 HASS.Agent 重启后重新发布。
 
-Don't worry! they'll keep their current names so your automations and scripts will continue to work.
+别担心！它们将保留当前名称，因此你的自动化和脚本将继续工作。
 
-Note: You disabled sanitation, so make sure your device name is accepted by Home Assistant.</value>
+注意：你已禁用名称清理，请确保你的设备名称被 Home Assistant 接受。</value>
   </data>
   <data name="SensorType_PrintersSensors" xml:space="preserve">
-    <value>Printers</value>
+    <value>打印机</value>
   </data>
   <data name="CommandType_MonitorSleepCommand" xml:space="preserve">
-    <value>MonitorSleep</value>
+    <value>显示器休眠</value>
   </data>
   <data name="CommandType_MonitorWakeCommand" xml:space="preserve">
-    <value>MonitorWake</value>
+    <value>显示器唤醒</value>
   </data>
   <data name="MonitorPowerEvent_PowerOn" xml:space="preserve">
-    <value>PowerOn</value>
+    <value>开启</value>
   </data>
   <data name="MonitorPowerEvent_PowerOff" xml:space="preserve">
-    <value>PowerOff</value>
+    <value>关闭</value>
   </data>
   <data name="MonitorPowerEvent_Dimmed" xml:space="preserve">
-    <value>Dimmed</value>
+    <value>变暗</value>
   </data>
   <data name="MonitorPowerEvent_Unknown" xml:space="preserve">
-    <value>Unknown</value>
+    <value>未知</value>
   </data>
   <data name="SensorType_MonitorPowerStateSensor" xml:space="preserve">
-    <value>MonitorPowerState</value>
+    <value>显示器电源状态</value>
   </data>
   <data name="SensorType_PowershellSensor" xml:space="preserve">
-    <value>PowershellSensor</value>
+    <value>PowerShell 传感器</value>
   </data>
   <data name="CommandType_SetVolumeCommand" xml:space="preserve">
-    <value>SetVolume</value>
+    <value>设置音量</value>
   </data>
   <data name="WindowState_Maximized" xml:space="preserve">
-    <value>Maximized</value>
+    <value>最大化</value>
   </data>
   <data name="WindowState_Minimized" xml:space="preserve">
-    <value>Minimized</value>
+    <value>最小化</value>
   </data>
   <data name="WindowState_Normal" xml:space="preserve">
-    <value>Normal</value>
+    <value>正常</value>
   </data>
   <data name="WindowState_Unknown" xml:space="preserve">
-    <value>Unknown</value>
+    <value>未知</value>
   </data>
   <data name="WindowState_Hidden" xml:space="preserve">
-    <value>Hidden</value>
+    <value>隐藏</value>
   </data>
   <data name="SensorType_WindowStateSensor" xml:space="preserve">
-    <value>WindowState</value>
+    <value>窗口状态</value>
   </data>
   <data name="SensorType_WebcamProcessSensor" xml:space="preserve">
-    <value>WebcamProcess</value>
+    <value>摄像头进程</value>
   </data>
   <data name="SensorType_MicrophoneProcessSensor" xml:space="preserve">
-    <value>MicrophoneProcess</value>
+    <value>麦克风进程</value>
   </data>
   <data name="CommandsManager_MonitorSleepCommandDescription" xml:space="preserve">
-    <value>Puts all monitors in sleep (low power) mode.</value>
+    <value>将所有显示器置于休眠（低功耗）模式。</value>
   </data>
   <data name="CommandsManager_MonitorWakeCommandDescription" xml:space="preserve">
-    <value>Tries to wake up all monitors by simulating a 'arrow up' keypress.</value>
+    <value>尝试通过模拟'向上箭头'按键来唤醒所有显示器。</value>
   </data>
   <data name="CommandsManager_SetVolumeCommandDescription" xml:space="preserve">
-    <value>Sets the volume of the current default audiodevice to the specified level.</value>
+    <value>将当前默认音频设备的音量设置为指定级别。</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox10" xml:space="preserve">
-    <value>Please enter a value between 0-100 as the desired volume level!</value>
+    <value>请输入一个 0-100 之间的值作为所需的音量级别！</value>
   </data>
   <data name="CommandsMod_CommandsMod" xml:space="preserve">
-    <value>Command</value>
+    <value>命令</value>
   </data>
   <data name="CommandsMod_MessageBox_Action2" xml:space="preserve">
-	  <value>If you don't enter a volume value, you can only use this entity with an 'action' value through Home Assistant. Running it as-is won't do anything.
+    <value>如果不输入音量值，你只能通过 Home Assistant 使用 'action' 值来操作此实体。按原样运行不会有任何效果。
 
-Are you sure you want this?</value>
+你确定要这样做吗？</value>
   </data>
   <data name="CommandsMod_MessageBox_Sanitize" xml:space="preserve">
-	  <value>The name you provided contains unsupported characters and won't work. The suggested version is:
+    <value>你提供的名称包含不支持的字符，无法使用。建议的版本为：
 
 {0}
 
-Do you want to use this version?</value>
+你想使用此版本吗？</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox5" xml:space="preserve">
-	  <value>The API token you have provided doesn't appear to be valid, please ensure you selected the entire token (Don't use CTRL + A or double-click). A valid API key contains three sections, separated by two dots.
+    <value>你提供的 API 令牌似乎无效，请确保你选择了整个令牌（不要使用 CTRL + A 或双击）。有效的 API 密钥包含三部分，由两个点分隔。
 
-Are you sure you want to use this key anyway?</value>
+你确定仍要使用此密钥吗？</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox6" xml:space="preserve">
-	  <value>The URI you have provided does not appear to be valid, a valid URI may look like either of the following:
+    <value>你提供的 URI 似乎无效，有效的 URI 可能类似于以下格式：
 - http://homeassistant.local:8123
 - http://192.168.0.1:8123
 
-Are you sure you want to use this URI anyway?</value>
+你确定仍要使用此 URI 吗？</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi_Testing" xml:space="preserve">
-    <value>Testing..</value>
+    <value>测试中..</value>
   </data>
   <data name="ConfigMediaPlayer_LblConnectivityDisabled" xml:space="preserve">
-    <value>both the local API and MQTT are disabled, but the integration needs at least one for it to work</value>
+    <value>本地 API 和 MQTT 均已禁用，但集成需要至少启用一个才能工作</value>
   </data>
   <data name="ConfigMqtt_CbEnableMqtt" xml:space="preserve">
-    <value>Enable MQTT</value>
+    <value>启用 MQTT</value>
   </data>
   <data name="ConfigMqtt_LblMqttDisabledWarning" xml:space="preserve">
-    <value>If MQTT is not enabled, commands and sensors will not work!</value>
+    <value>如果未启用 MQTT，命令和传感器将无法工作！</value>
   </data>
   <data name="ConfigNotifications_LblConnectivityDisabled" xml:space="preserve">
-    <value>both the local API and MQTT are disabled, but the integration needs at least one for it to work</value>
+    <value>本地 API 和 MQTT 均已禁用，但集成需要至少启用一个才能工作</value>
   </data>
   <data name="ConfigService_BtnManageService" xml:space="preserve">
-    <value>&amp;Manage Service</value>
+    <value>管理服务(&M)</value>
   </data>
   <data name="ConfigService_BtnManageService_MessageBox1" xml:space="preserve">
-	  <value>The service is currently stopped and cannot be configured.
+    <value>服务当前已停止，无法配置。
 
-Please start the service first in order to configure it.</value>
+请先启动服务才能进行配置。</value>
   </data>
   <data name="ConfigService_LblInfo5" xml:space="preserve">
-    <value>If you want to manage the service (add commands and sensor, change settings) you can do so here, or by using the 'satellite service' button on the main window.</value>
+    <value>如果你想管理服务（添加命令和传感器、更改设置），可以在此处进行，或使用主窗口上的'卫星服务'按钮。</value>
   </data>
   <data name="ConfigTrayIcon_CbWebViewShowMenuOnLeftClick" xml:space="preserve">
-    <value>Show default menu on mouse left-click</value>
+    <value>鼠标左键单击时显示默认菜单</value>
   </data>
   <data name="Configuration_CheckValues_MessageBox1" xml:space="preserve">
-	  <value>Your Home Assistant API token doesn't look right. Make sure you selected the entire token (don't use CTRL+A or doubleclick).
-It should contain three sections (seperated by two dots).
+    <value>你的 Home Assistant API 令牌看起来不正确。请确保你选择了整个令牌（不要使用 CTRL+A 或双击）。
+它应该包含三部分（由两个点分隔）。
 
-Are you sure you want to use it like this?</value>
+你确定要这样使用它吗？</value>
   </data>
   <data name="Configuration_CheckValues_MessageBox2" xml:space="preserve">
-	  <value>Your Home Assistant URI doesn't look right. It should look something like 'http://homeassistant.local:8123' or 'https://192.168.0.1:8123'.
+    <value>你的 Home Assistant URI 看起来不正确。它应该类似于 'http://homeassistant.local:8123' 或 'https://192.168.0.1:8123'。
 
-Are you sure you want to use it like this?</value>
+你确定要这样使用它吗？</value>
   </data>
   <data name="Configuration_CheckValues_MessageBox3" xml:space="preserve">
-	  <value>Your MQTT broker URI doesn't look right. It should look something like 'homeassistant.local' or '192.168.0.1'.
+    <value>你的 MQTT 代理 URI 看起来不正确。它应该类似于 'homeassistant.local' 或 '192.168.0.1'。
 
-Are you sure you want to use it like this?</value>
+你确定要这样使用它吗？</value>
   </data>
   <data name="Donate_BtnClose" xml:space="preserve">
-    <value>&amp;Close</value>
+    <value>关闭(&C)</value>
   </data>
   <data name="Donate_CbHideDonateButton" xml:space="preserve">
-    <value>I already donated, hide the button on the main window.</value>
+    <value>我已经捐赠，在主窗口上隐藏按钮。</value>
   </data>
   <data name="Donate_LblInfo" xml:space="preserve">
-	  <value>HASS.Agent is completely free, and will always stay that way without restrictions!
+    <value>HASS.Agent 完全免费，并将始终保持免费，没有任何限制！
 
-However, developing and maintaining this tool (and everything that surrounds it, like support and the docs) takes up a lot of time. 
+然而，开发和维护此工具（以及围绕它的所有工作，如支持和文档）需要花费大量时间。
 
-Like most developers, I run on caffeïne - so if you can spare it, a cup of coffee is always very much appreciated!</value>
+像大多数开发者一样，我靠咖啡因维持——因此，如果你有余力，一杯咖啡将非常感谢！</value>
   </data>
   <data name="Donate_Title" xml:space="preserve">
-    <value>Donate</value>
+    <value>捐赠</value>
   </data>
   <data name="Main_NotifyIcon_MouseClick_MessageBox1" xml:space="preserve">
-    <value>No URL has been set! Please configure the webview through Configuration -&gt; Tray Icon.</value>
+    <value>未设置 URL！请通过 配置 -&gt; 托盘图标 配置 WebView。</value>
   </data>
   <data name="Main_TsCheckForUpdates" xml:space="preserve">
-    <value>Check for Updates</value>
+    <value>检查更新</value>
   </data>
   <data name="OnboardingApi_BtnTest_MessageBox5" xml:space="preserve">
-	  <value>The API token you have provided doesn't appear to be valid, please ensure you selected the entire token (Don't use CTRL + A or double-click). A valid API key contains three sections, separated by two dots.
+    <value>你提供的 API 令牌似乎无效，请确保你选择了整个令牌（不要使用 CTRL + A 或双击）。有效的 API 密钥包含三部分，由两个点分隔。
 
-Are you sure you want to use this key anyway?</value>
+你确定仍要使用此密钥吗？</value>
   </data>
   <data name="OnboardingApi_BtnTest_MessageBox6" xml:space="preserve">
-	  <value>The URI you have provided does not appear to be valid, a valid URI may look like either of the following:
+    <value>你提供的 URI 似乎无效，有效的 URI 可能类似于以下格式：
 - http://homeassistant.local:8123
 - http://192.168.0.1:8123
 
-Are you sure you want to use this URI anyway?</value>
+你确定仍要使用此 URI 吗？</value>
   </data>
   <data name="OnboardingDone_LblInfo6" xml:space="preserve">
-    <value>Currently, we (HASS.Agent Team maintaining the fork) do not accept donations in any form :)
-Please however feel free to donate to the original author of HASS.Agent - Sam! Wherever they currently are, cup of coffee might brighten their day.</value>
+    <value>目前，我们（维护此分支的 HASS.Agent 团队）不接受任何形式的捐赠 :)
+但请随意向 HASS.Agent 的原作者 - Sam 捐赠！无论他们现在在哪里，一杯咖啡可能会让他们开心一天。</value>
   </data>
   <data name="OnboardingDone_LblTip2" xml:space="preserve">
-    <value>Tip: Other donation methods are available on the About Window.</value>
+    <value>提示：其他捐赠方式可在"关于"窗口中找到。</value>
   </data>
   <data name="OnboardingIntegrations_CbEnableMediaPlayer" xml:space="preserve">
-    <value>Enable &amp;Media Player (including text-to-speech)</value>
+    <value>启用媒体播放器(&M)（包括文本转语音）</value>
   </data>
   <data name="OnboardingIntegrations_CbEnableNotifications" xml:space="preserve">
-    <value>Enable &amp;Notifications</value>
+    <value>启用通知(&N)</value>
   </data>
   <data name="OnboardingMqtt_CbEnableMqtt" xml:space="preserve">
-    <value>Enable MQTT</value>
+    <value>启用 MQTT</value>
   </data>
   <data name="PostUpdate_PostUpdate" xml:space="preserve">
-    <value>HASS.Agent Post Update</value>
+    <value>HASS.Agent 更新后处理</value>
   </data>
   <data name="SensorsManager_BluetoothDevicesSensorDescription" xml:space="preserve">
-	  <value>Provides a sensor with the amount of bluetooth devices found.
+    <value>提供一个传感器，显示找到的蓝牙设备数量。
 
-The devices and their connected state are added as attributes.</value>
+设备和它们的连接状态将作为属性添加。</value>
   </data>
   <data name="SensorsManager_BluetoothLeDevicesSensorDescription" xml:space="preserve">
-	  <value>Provides a sensors with the amount of bluetooth LE devices found.
+    <value>提供一个传感器，显示找到的蓝牙 LE 设备数量。
 
-The devices and their connected state are added as attributes.
+设备和它们的连接状态将作为属性添加。
 
-Only shows devices that were seen since the last report, ie. when the sensor publishes, the list clears.</value>
+仅显示自上次报告以来出现的设备，即当传感器发布时，列表会清空。</value>
   </data>
   <data name="SensorsManager_GeoLocationSensorDescription" xml:space="preserve">
-	  <value>Returns your current latitude, longitude and altitude as a comma-seperated value.
+    <value>返回你当前的纬度、经度和海拔，以逗号分隔的值形式。
 
-Make sure Windows' location services are enabled!
+请确保 Windows 的定位服务已启用！
 
-Depending on your Windows version, this can be found in the new control panel -&gt; 'privacy and security' -&gt; 'location'.</value>
+根据你的 Windows 版本，这可以在新的控制面板 -&gt; '隐私和安全' -&gt; '位置' 中找到。</value>
   </data>
   <data name="SensorsManager_MonitorPowerStateSensorDescription" xml:space="preserve">
-	  <value>Provides the last monitor power state change:
+    <value>提供上次显示器电源状态变化：
 
-Dimmed, PowerOff, PowerOn and Unkown.</value>
+变暗、关闭、开启和未知。</value>
   </data>
   <data name="SensorsManager_PowershellSensorDescription" xml:space="preserve">
-	  <value>Returns the result of the provided Powershell command or script.
-Note: please keep in mind that Home Assistant accepts payload up to 255 characters.
+    <value>返回提供的 PowerShell 命令或脚本的结果。
+注意：请记住 Home Assistant 接受的最大负载为 255 个字符。
 
-Converts the outcome to text.</value>
+将结果转换为文本。</value>
   </data>
   <data name="SensorsManager_PrintersSensorsDescription" xml:space="preserve">
-    <value>Provides information about all installed printers and their queues.</value>
+    <value>提供所有已安装打印机及其队列的信息。</value>
   </data>
   <data name="SensorsManager_WebcamProcessSensorDescription" xml:space="preserve">
-	  <value>Provides the name of the process that's currently using the webcam.
+    <value>提供当前正在使用摄像头的进程名称。
 
-Note: if used in the satellite service, it won't detect userspace applications.</value>
+注意：如果在卫星服务中使用，将无法检测用户空间应用程序。</value>
   </data>
   <data name="SensorsManager_WindowStateSensorDescription" xml:space="preserve">
-	  <value>Provides the current state of the process' window:
+    <value>提供进程窗口的当前状态：
 
-Hidden, Maximized, Minimized, Normal and Unknown.</value>
+隐藏、最大化、最小化、正常和未知。</value>
   </data>
   <data name="SensorsMod_LblSetting1_Powershell" xml:space="preserve">
-    <value>powershell command or script</value>
+    <value>powershell 命令或脚本</value>
   </data>
   <data name="SensorsMod_MessageBox_Sanitize" xml:space="preserve">
-	  <value>The name you provided contains unsupported characters and won't work. The suggested version is:
+    <value>你提供的名称包含不支持的字符，无法使用。建议的版本为：
 
 {0}
 
-Do you want to use this version?</value>
+你想使用此版本吗？</value>
   </data>
   <data name="SensorsMod_SensorsMod_BtnTest_Powershell" xml:space="preserve">
-    <value>Test Command/Script</value>
+    <value>测试命令/脚本</value>
   </data>
   <data name="SensorsMod_TestPowershell_MessageBox1" xml:space="preserve">
-    <value>Please enter a command or script!</value>
+    <value>请输入命令或脚本！</value>
   </data>
   <data name="SensorsMod_TestPowershell_MessageBox2" xml:space="preserve">
-	  <value>Test succesfully executed, result value:
+    <value>测试成功执行，结果值为：
 
 {0}</value>
   </data>
   <data name="SensorsMod_TestPowershell_MessageBox3" xml:space="preserve">
-	  <value>The test failed to execute:
+    <value>测试执行失败：
 
 {0}
 
-Do you want to open the logs folder?</value>
+你想打开日志文件夹吗？</value>
   </data>
   <data name="SensorType_BluetoothDevicesSensor" xml:space="preserve">
-    <value>BluetoothDevices</value>
+    <value>蓝牙设备</value>
   </data>
   <data name="SensorType_BluetoothLeDevicesSensor" xml:space="preserve">
-    <value>BluetoothLeDevices</value>
+    <value>蓝牙LE设备</value>
   </data>
   <data name="ServiceControllerManager_Error_Fatal" xml:space="preserve">
-    <value>Fatal error, please check logs for information!</value>
+    <value>致命错误，请查看日志获取信息！</value>
   </data>
   <data name="ServiceControllerManager_Error_Timeout" xml:space="preserve">
-    <value>Timeout expired</value>
+    <value>超时已过期</value>
   </data>
   <data name="ServiceControllerManager_Error_Unknown" xml:space="preserve">
-    <value>unknown reason</value>
+    <value>未知原因</value>
   </data>
   <data name="ServiceHelper_ChangeStartMode_Error1" xml:space="preserve">
-    <value>unable to open Service Manager</value>
+    <value>无法打开服务管理器</value>
   </data>
   <data name="ServiceHelper_ChangeStartMode_Error2" xml:space="preserve">
-    <value>unable to open service</value>
+    <value>无法打开服务</value>
   </data>
   <data name="ServiceHelper_ChangeStartMode_Error3" xml:space="preserve">
-    <value>Error configuring startup mode, please check the logs for more information.</value>
+    <value>配置启动模式时出错，请查看日志获取更多信息。</value>
   </data>
   <data name="ServiceHelper_ChangeStartMode_Error4" xml:space="preserve">
-    <value>Error setting startup mode, please check the logs for more information.</value>
+    <value>设置启动模式时出错，请查看日志获取更多信息。</value>
   </data>
   <data name="WebView_InitializeAsync_MessageBox1" xml:space="preserve">
-	  <value>Microsoft's WebView2 runtime isn't found on your machine. Usually this is handled by the installer, but you can install it manually.
+    <value>未在你的计算机上找到 Microsoft 的 WebView2 运行时。通常这由安装程序处理，但你也可以手动安装。
 
-Do you want to download the runtime installer?</value>
+你想下载运行时安装程序吗？</value>
   </data>
   <data name="WebView_InitializeAsync_MessageBox2" xml:space="preserve">
-    <value>Something went wrong while initializing the WebView! Please check your logs and open a GitHub issue for further assistance.</value>
+    <value>初始化 WebView 时出现问题！请检查你的日志并在 GitHub 上提交 issue 以获取进一步帮助。</value>
   </data>
   <data name="QuickActionsMod_ClmDomain" xml:space="preserve">
-	  <value>domain</value>
+    <value>域</value>
   </data>
   <data name="CommandsManager_SwitchDesktopCommandDescription" xml:space="preserve">
-    <value>Activates provided Virtual Desktop. Desktop ID can be retrieved from the "ActiveDesktop" sensor.</value>
+    <value>激活提供的虚拟桌面。桌面 ID 可从"ActiveDesktop"传感器获取。</value>
   </data>
   <data name="SensorsManager_ActiveDesktopSensorDescription" xml:space="preserve">
-    <value>Provides the ID of the currently active virtual desktop.</value>
+    <value>提供当前活动虚拟桌面的 ID。</value>
   </data>
   <data name="CommandsManager_RadioCommandDescription" xml:space="preserve">
-    <value>Switches selected radio device on/off. Availability of radio devices depends on the device HASS.Agent is installed on.</value>
+    <value>开启/关闭选定的无线电设备。无线电设备的可用性取决于安装 HASS.Agent 的设备。</value>
   </data>
   <data name="CommandType_RadioCommand" xml:space="preserve">
-    <value>RadioCommand</value>
+    <value>无线电命令</value>
   </data>
   <data name="CommandsMod_LblSetting_Radio" xml:space="preserve">
-    <value>Radio device</value>
+    <value>无线电设备</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox11" xml:space="preserve">
-    <value>Please select radio device!</value>
+    <value>请选择无线电设备！</value>
   </data>
   <data name="SensorsManager_InternalDeviceSensorDescription" xml:space="preserve">
-    <value>Provides data from the internal device sensor.
-Availability of the sensor depends on the device, in some cases no sensors will be available.</value>
+    <value>提供来自内部设备传感器的数据。
+传感器的可用性取决于设备，某些情况下可能没有可用的传感器。</value>
   </data>
   <data name="SensorType_InternalDeviceSensor" xml:space="preserve">
-    <value>InternalDeviceSensor</value>
+    <value>内部设备传感器</value>
   </data>
   <data name="SensorsMod_LblSetting1_InternalSensor" xml:space="preserve">
-    <value>Internal Sensor</value>
+    <value>内部传感器</value>
   </data>
   <data name="SensorsMod_None" xml:space="preserve">
-    <value>None</value>
+    <value>无</value>
   </data>
   <data name="SensorsMod_CbIgnoreAvailability" xml:space="preserve">
-    <value>&amp;Ignore availability</value>
+    <value>忽略可用性(&I)</value>
   </data>
   <data name="SensorsMod_IgnoreAvailability_Info" xml:space="preserve">
-    <value>Please note that ignoring availability will cause Home Assistant to always display last value for a given sensor, even when HASS.Agent is offline.</value>
+    <value>请注意，忽略可用性将导致 Home Assistant 始终显示给定传感器的最后一个值，即使 HASS.Agent 处于离线状态。</value>
   </data>
   <data name="ConfigNotifications_CbNotificationsOpenActionUri" xml:space="preserve">
-    <value>&amp;Treat URI Action elements like Android Companion App (open)</value>
+    <value>像 Android Companion App 一样处理 URI Action 元素（打开）(&T)</value>
   </data>
   <data name="ConfigNotifications_TestNotification_No" xml:space="preserve">
-    <value>No</value>
+    <value>否</value>
   </data>
   <data name="ConfigNotifications_TestNotification_Yes" xml:space="preserve">
-    <value>Yes</value>
+    <value>是</value>
   </data>
   <data name="ConfigNotifications_TestNotification_InputText" xml:space="preserve">
-    <value>Notification Input Text</value>
+    <value>通知输入文本</value>
   </data>
   <data name="ConfigNotifications_TestNotification_InputTitle" xml:space="preserve">
-    <value>Notification Input Title</value>
+    <value>通知输入标题</value>
   </data>
   <data name="SensorsMod_BtnStore_DeviceNameInSensorName" xml:space="preserve">
-    <value>Device name in the sensor name might cause issues with Home Assistant versions starting with 2023.8.</value>
+    <value>传感器名称中的设备名称可能会导致 2023.8 及以上版本的 Home Assistant 出现问题。</value>
   </data>
   <data name="CommandsMod_BtnStore_DeviceNameInSensorName" xml:space="preserve">
-    <value>Device name in the command name might cause issues with Home Assistant versions starting with 2023.8.</value>
+    <value>命令名称中的设备名称可能会导致 2023.8 及以上版本的 Home Assistant 出现问题。</value>
   </data>
   <data name="Compat_NameTask_Name" xml:space="preserve">
-    <value>Changing entity names
-to match Home Assistant 2023.8 requirements</value>
+    <value>正在更改实体名称
+以符合 Home Assistant 2023.8 的要求</value>
   </data>
   <data name="Compat_Error_CheckLogs" xml:space="preserve">
-    <value>Error, please check logs for more information.</value>
+    <value>出错，请查看日志获取更多信息。</value>
   </data>
   <data name="Compat_NameTask_Error_SingleValueSensors" xml:space="preserve">
-    <value>Error converting single value sensors!</value>
+    <value>转换单值传感器时出错！</value>
   </data>
   <data name="Compat_NameTask_Error_Commands" xml:space="preserve">
-    <value>Error converting commands!</value>
+    <value>转换命令时出错！</value>
   </data>
   <data name="Compat_NameTask_Error_MultiValueSensors" xml:space="preserve">
-    <value>Error converting multi value sensors!</value>
+    <value>转换多值传感器时出错！</value>
   </data>
   <data name="SensorsMod_CbApplyRounding_LastActive" xml:space="preserve">
-    <value>Force action
-when system
-wakes from sleep/hibernation</value>
+    <value>系统从休眠/冬眠
+唤醒时
+强制执行操作</value>
   </data>
   <data name="CommandsManager_SetApplicationVolumeCommandDescription" xml:space="preserve">
-    <value>Sets the volume and mute status of the provided application on provided audio device to the specified level.
-Command / payload needs to be in JSON format. Example of all possible options:
+    <value>将指定音频设备上指定应用的音量和静音状态设置为指定级别。
+命令/负载需要为 JSON 格式。所有可能选项的示例：
 {
   "playbackDevice": "Speakers (THX Spatial Audio)",
   "applicationName": "Discord",
@@ -3315,18 +3311,18 @@ Command / payload needs to be in JSON format. Example of all possible options:
   "mute": true
 }
 
-If no "playbackDevice" is provided, HASS.Agent will use the default one.
-If no "volume" is provided, HASS.Agent will set only mute status.
-If no "mute" is provided, HASS.Agent will unmute the provided application.
+如果未提供 "playbackDevice"，HASS.Agent 将使用默认设备。
+如果未提供 "volume"，HASS.Agent 将仅设置静音状态。
+如果未提供 "mute"，HASS.Agent 将取消指定应用的静音。
 
-Advanced option: additional "sessionId" can be provided to set volume only for specific session of the application, session id can be obtained from "Audio Sessions" sensor:
+高级选项：可提供额外的 "sessionId" 以仅设置应用程序特定会话的音量，会话 ID 可从"Audio Sessions"传感器获取：
 {
    "playbackDevice":"Speakers (THX SpatialAudio)",
    "applicationName":"Discord",
    "volume":50,
    "sessionid":"&lt;LONG SESSION ID FROM SENSOR&gt;"
-}Sets the volume and mute status of the provided application on provided audio device to the specified level.
-Command / payload needs to be in JSON format. Example of all possible options:
+}将指定音频设备上指定应用的音量和静音状态设置为指定级别。
+命令/负载需要为 JSON 格式。所有可能选项的示例：
 {
   "playbackDevice": "Speakers (THX Spatial Audio)",
   "applicationName": "Discord",
@@ -3334,11 +3330,11 @@ Command / payload needs to be in JSON format. Example of all possible options:
   "mute": true
 }
 
-If no "playbackDevice" is provided, HASS.Agent will use the default one.
-If no "volume" is provided, HASS.Agent will set only mute status.
-If no "mute" is provided, HASS.Agent will unmute the provided application.
+如果未提供 "playbackDevice"，HASS.Agent 将使用默认设备。
+如果未提供 "volume"，HASS.Agent 将仅设置静音状态。
+如果未提供 "mute"，HASS.Agent 将取消指定应用的静音。
 
-Advanced option: additional "sessionId" can be provided to set volume only for specific session of the application, session id can be obtained from "Audio Sessions" sensor:
+高级选项：可提供额外的 "sessionId" 以仅设置应用程序特定会话的音量，会话 ID 可从"Audio Sessions"传感器获取：
 {
    "playbackDevice":"Speakers (THX SpatialAudio)",
    "applicationName":"Discord",
@@ -3347,144 +3343,144 @@ Advanced option: additional "sessionId" can be provided to set volume only for s
 }</value>
   </data>
   <data name="CommandsMod_BtnStore_InvalidJson" xml:space="preserve">
-    <value>Please enter a valid JSON string!</value>
+    <value>请输入有效的 JSON 字符串！</value>
   </data>
   <data name="CommandsMod_BtnStore_VirtualDesktop_Unavailable" xml:space="preserve">
-    <value>Virtual Desktop management is unavailable on your machine.
-Usually this is due to the virtual desktop management library not being updated to support your version of Windows.</value>
+    <value>你的计算机上无法使用虚拟桌面管理。
+通常这是因为虚拟桌面管理库未更新以支持你的 Windows 版本。</value>
   </data>
   <data name="Compat_MigrateTask_Name" xml:space="preserve">
-    <value>Migrating HASS.Agent configuration
-from the original version</value>
+    <value>正在从原始版本迁移
+HASS.Agent 配置</value>
   </data>
   <data name="About_LblInfo2_1" xml:space="preserve">
-    <value>Updated and maintained with love by</value>
+    <value>由以下人员用心更新和维护</value>
   </data>
   <data name="About_LblInfo4_1" xml:space="preserve">
-    <value>Even bigger 'thank you' for LAB02 Research and Sam for developing the original version of HASS.Agent - this would wouldn't exist without it!</value>
+    <value>特别感谢 LAB02 Research 和 Sam 开发了 HASS.Agent 的原始版本——如果没有它，这将不会存在！</value>
   </data>
   <data name="Compat_NameTask_Error_ServiceStart" xml:space="preserve">
-    <value>Error starting satellite service!</value>
+    <value>启动卫星服务时出错！</value>
   </data>
   <data name="Compat_NameTask_Error_ServiceCommunication" xml:space="preserve">
-    <value>Error communicating with the satellite service!</value>
+    <value>与卫星服务通信时出错！</value>
   </data>
   <data name="CommandsManager_SetAudioOutputCommandDescription" xml:space="preserve">
-    <value>Sets the default audio output for the system.
-Requires audio device name as a payload.</value>
+    <value>设置系统的默认音频输出。
+需要音频设备名称作为负载。</value>
   </data>
   <data name="CommandsMod_LblSetting_AudioDeviceName" xml:space="preserve">
-    <value>Audio Device Name</value>
+    <value>音频设备名称</value>
   </data>
   <data name="CommandsMod_LblSetting_JsonPayload" xml:space="preserve">
-    <value>JSON Command Payload</value>
+    <value>JSON 命令负载</value>
   </data>
   <data name="CommandsMod_LblSetting_VolumeRange" xml:space="preserve">
-    <value>Volume (between 0 and 100)</value>
+    <value>音量（0 到 100 之间）</value>
   </data>
   <data name="SensorsMod_LblSetting1_ScreenNumber" xml:space="preserve">
-    <value>Screen number</value>
+    <value>屏幕编号</value>
   </data>
   <data name="SensorsManager_ScreenshotSensorDescription" xml:space="preserve">
-    <value>Provides a screenshot sensor in form of a camera entity.
-Screen number depends on system configuration - starts at 0.</value>
+    <value>提供一个相机实体形式的截图传感器。
+屏幕编号取决于系统配置 - 从 0 开始。</value>
   </data>
   <data name="CommandsManager_SetAudioInputCommandDescription" xml:space="preserve">
-    <value>Sets the default audio input for the system (including default communication device).
-Requires audio device name as a payload.</value>
+    <value>设置系统的默认音频输入（包括默认通信设备）。
+需要音频设备名称作为负载。</value>
   </data>
   <data name="ConfigMqtt_CbIgnoreGracePeriod" xml:space="preserve">
-    <value>Ignore grace period after waking up from hibernation</value>
+    <value>从冬眠唤醒后忽略宽限期</value>
   </data>
   <data name="ConfigTrayIcon_CbUseModernIcon" xml:space="preserve">
-    <value>Use modern tray icon</value>
+    <value>使用现代托盘图标</value>
   </data>
   <data name="SensorsManager_MicrophoneProcessSensorDescription" xml:space="preserve">
-    <value>Provides the number of the processes that currently use the microphone - additionally provides name of the processes in the sensor's attributes.
+    <value>提供当前使用麦克风的进程数量——另外在传感器的属性中提供进程名称。
 
-Note: if used in the satellite service, it won't detect userspace applications.</value>
+注意：如果在卫星服务中使用，将无法检测用户空间应用程序。</value>
   </data>
   <data name="Configuration_NFC" xml:space="preserve">
     <value>NFC</value>
   </data>
   <data name="SensorsMod_BtnAdvancedSettings" xml:space="preserve">
-    <value>Ad&amp;vanced Settings</value>
+    <value>高级设置(&V)</value>
   </data>
   <data name="AdvancedSensorConfig_Warning" xml:space="preserve">
-    <value>Warning, adding following settings (overrides) may break the sensor, use with caution!</value>
+    <value>警告，添加以下设置（覆盖）可能会破坏传感器，请谨慎使用！</value>
   </data>
   <data name="AdvancedSensorConfig_LblDeviceClass" xml:space="preserve">
-    <value>Device class</value>
+    <value>设备类别</value>
   </data>
   <data name="AdvancedSensorConfig_LblUnitOfMeasurement" xml:space="preserve">
-    <value>Unit of measurement</value>
+    <value>计量单位</value>
   </data>
   <data name="AdvancedSensorConfig_LblStateClass" xml:space="preserve">
-    <value>State class</value>
+    <value>状态类别</value>
   </data>
   <data name="AdvancedSensorConfig_Title" xml:space="preserve">
-    <value>Advanced Settings</value>
+    <value>高级设置</value>
   </data>
   <data name="CommandsManager_TrayWebViewCommandDescription" xml:space="preserve">
-    <value>Shows / hides the Tray Icon Web View.
-Requires it to be configured in "Configuration -&gt; Tray Icon"</value>
+    <value>显示/隐藏托盘图标 Web View。
+需要在"配置 -&gt; 托盘图标"中进行配置</value>
   </data>
   <data name="HassAction_Trigger" xml:space="preserve">
-    <value>Trigger</value>
+    <value>触发</value>
   </data>
   <data name="HassDomain_Button" xml:space="preserve">
-    <value>Button</value>
+    <value>按钮</value>
   </data>
   <data name="HassAction_Press" xml:space="preserve">
-    <value>Press</value>
+    <value>按下</value>
   </data>
   <data name="Notification_Dismiss" xml:space="preserve">
-    <value>Dismiss</value>
+    <value>忽略</value>
   </data>
   <data name="Main_CheckForUpdateFailed_MessageBox1" xml:space="preserve">
-    <value>Failed checking for update!</value>
+    <value>检查更新失败！</value>
   </data>
   <data name="SensorType_NamedActiveWindowSensor" xml:space="preserve">
-    <value>NamedActiveWindow</value>
+    <value>命名活动窗口</value>
   </data>
   <data name="SensorsManager_NamedActiveWindowSensorDescription" xml:space="preserve">
-    <value>Provides an ON/OFF value based on whether the focused window name contains configured string.</value>
+    <value>根据焦点窗口名称是否包含配置的字符串，提供一个 ON/OFF 值。</value>
   </data>
   <data name="SensorsManager_AccentColorSensorDescription" xml:space="preserve">
-    <value>Provides #RRGGBB color values for system accent colors.
-Main accent color is the sensor value, additional accent colors are available as attributes.</value>
+    <value>提供系统强调色的 #RRGGBB 颜色值。
+主强调色是传感器值，其他强调色作为属性提供。</value>
   </data>
   <data name="ConfigMqtt_CbUseWebSocket" xml:space="preserve">
-    <value>Use &amp;WebSocket</value>
+    <value>使用 WebSocket(&W)</value>
   </data>
   <data name="ServiceMqtt_CbUseWebSocket" xml:space="preserve">
-    <value>Use &amp;WebSocket</value>
+    <value>使用 WebSocket(&W)</value>
   </data>
   <data name="HassDomain_InputButton" xml:space="preserve">
-    <value>InputButton</value>
+    <value>输入按钮</value>
   </data>
   <data name="HassDomain_Fan" xml:space="preserve">
-    <value>Fan</value>
+    <value>风扇</value>
   </data>
   <data name="CommandsManager_WinformsSleepCommandDescription" xml:space="preserve">
-    <value>Puts the machine to sleep using WinForms API.
+    <value>使用 WinForms API 使机器进入休眠。
 
-Note: due to "Modern Sleep" the sleep commands might behave differently depending on the device OEM and OS configuration.</value>
+注意：由于"现代休眠"，休眠命令可能会根据设备 OEM 和操作系统配置的不同而表现不同。</value>
   </data>
   <data name="CommandType_WinformsSleepCommand" xml:space="preserve">
-    <value>WinformsSleep</value>
+    <value>Winforms休眠</value>
   </data>
   <data name="OnboardingMqtt_BtnTest_MessageOk" xml:space="preserve">
-    <value>Connection OK!</value>
+    <value>连接正常！</value>
   </data>
   <data name="OnboardingMqtt_BtnTest_MessageError" xml:space="preserve">
-    <value>Unable to connect.</value>
+    <value>无法连接。</value>
   </data>
   <data name="CommandType_MonitorSleepPowerPlanCommand" xml:space="preserve">
-    <value>MonitorSleepPowerPlan</value>
+    <value>显示器休眠电源计划</value>
   </data>
   <data name="CommandsManager_MonitorSleepPowerPlanCommandDescription" xml:space="preserve">
-    <value>Puts all monitors in sleep (low power) mode using alternative approach of power plan modification.
-Should provide better experience with new systems with "modern S0ix sleep" and not put the system to sleep.</value>
+    <value>使用修改电源计划的替代方法将所有显示器置于休眠（低功耗）模式。
+对于具有"现代 S0ix 休眠"的新系统，应提供更好的体验，并且不会使系统进入休眠。</value>
   </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.zh-CN.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.zh-CN.resx
@@ -12,7 +12,7 @@
     
     Example:
     
-    ... ado.net/XML headers & schema ...
+    ... ado.net/XML headers &amp; schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
     <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
@@ -147,7 +147,7 @@
     <value>提示：双击以浏览</value>
   </data>
   <data name="ConfigExternalTools_BtnExternalBrowserIncognitoTest" xml:space="preserve">
-    <value>测试(&T)</value>
+    <value>测试(&amp;T)</value>
   </data>
   <data name="ConfigGeneral_LblInfo4" xml:space="preserve">
     <value>HASS.Agent 在通知您与 MQTT 或 HA 的 API 断开连接之前会等待一个宽限期。
@@ -157,7 +157,7 @@
     <value>秒</value>
   </data>
   <data name="ConfigGeneral_LblDisconGracePeriod" xml:space="preserve">
-    <value>断开连接宽限期(&P)</value>
+    <value>断开连接宽限期(&amp;P)</value>
   </data>
   <data name="ConfigGeneral_LblInfo3" xml:space="preserve">
     <value>重要提示：如果您更改此值，HASS.Agent 将取消发布所有传感器和命令，并强制重启自身，以便它们可以在新设备名称下重新发布。
@@ -171,19 +171,19 @@
     <value>此页面包含常规配置设置，如需更多设置，您可以浏览左侧的选项卡。</value>
   </data>
   <data name="ConfigGeneral_LblDeviceName" xml:space="preserve">
-    <value>设备名称(&N)</value>
+    <value>设备名称(&amp;N)</value>
   </data>
   <data name="ConfigHomeAssistantApi_LblTip1" xml:space="preserve">
     <value>提示：双击此字段以浏览</value>
   </data>
   <data name="ConfigHomeAssistantApi_LblClientCertificate" xml:space="preserve">
-    <value>客户端证书(&C)</value>
+    <value>客户端证书(&amp;C)</value>
   </data>
   <data name="ConfigHomeAssistantApi_CbHassAutoClientCertificate" xml:space="preserve">
-    <value>使用自动客户端证书选择(&A)</value>
+    <value>使用自动客户端证书选择(&amp;A)</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi" xml:space="preserve">
-    <value>测试连接(&T)</value>
+    <value>测试连接(&amp;T)</value>
   </data>
   <data name="ConfigHomeAssistantApi_LblInfo1" xml:space="preserve">
     <value>为了解您配置了哪些实体以及发送快捷操作，HASS.Agent 使用
@@ -196,13 +196,13 @@ Home Assistant 的 API。
 请注意，要使用可操作通知功能，您需要提供管理员账户令牌。</value>
   </data>
   <data name="ConfigHomeAssistantApi_LblApiToken" xml:space="preserve">
-    <value>API 令牌(&A)</value>
+    <value>API 令牌(&amp;A)</value>
   </data>
   <data name="ConfigHomeAssistantApi_LblServerUri" xml:space="preserve">
-    <value>服务器 URI(&U)</value>
+    <value>服务器 URI(&amp;U)</value>
   </data>
   <data name="ConfigHotKey_BtnClearHotKey" xml:space="preserve">
-    <value>清除(&C)</value>
+    <value>清除(&amp;C)</value>
   </data>
   <data name="ConfigHotKey_LblInfo1" xml:space="preserve">
     <value>调出快捷操作的一种简单方式是使用全局热键。
@@ -210,10 +210,10 @@ Home Assistant 的 API。
 这样，无论您在机器上做什么，都可以随时与 Home Assistant 交互。</value>
   </data>
   <data name="ConfigHotKey_CbEnableQuickActionsHotkey" xml:space="preserve">
-    <value>启用快捷操作热键(&E)</value>
+    <value>启用快捷操作热键(&amp;E)</value>
   </data>
   <data name="ConfigHotKey_LblHotkeyCombo" xml:space="preserve">
-    <value>热键组合(&H)</value>
+    <value>热键组合(&amp;H)</value>
   </data>
   <data name="ConfigLocalStorage_BtnClearImageCache" xml:space="preserve">
     <value>清除图像缓存</value>
@@ -239,10 +239,10 @@ Home Assistant 的 API。
 HASS.Agent 本身有问题或开发者要求时使用。</value>
   </data>
   <data name="ConfigLogging_CbExtendedLogging" xml:space="preserve">
-    <value>启用扩展日志记录(&E)</value>
+    <value>启用扩展日志记录(&amp;E)</value>
   </data>
   <data name="ConfigLogging_BtnShowLogs" xml:space="preserve">
-    <value>打开日志文件夹(&O)</value>
+    <value>打开日志文件夹(&amp;O)</value>
   </data>
   <data name="ConfigMqtt_LblTip3" xml:space="preserve">
     <value>提示：双击这些字段以浏览</value>
@@ -254,13 +254,13 @@ HASS.Agent 本身有问题或开发者要求时使用。</value>
     <value>根证书</value>
   </data>
   <data name="ConfigMqtt_CbUseRetainFlag" xml:space="preserve">
-    <value>使用保留标志(&R)</value>
+    <value>使用保留标志(&amp;R)</value>
   </data>
   <data name="ConfigMqtt_CbAllowUntrustedCertificates" xml:space="preserve">
-    <value>允许不受信任的证书(&A)</value>
+    <value>允许不受信任的证书(&amp;A)</value>
   </data>
   <data name="ConfigMqtt_BtnMqttClearConfig" xml:space="preserve">
-    <value>清除配置(&C)</value>
+    <value>清除配置(&amp;C)</value>
   </data>
   <data name="ConfigMqtt_LblTip1" xml:space="preserve">
     <value>（如果不确定，保持默认）</value>
@@ -306,13 +306,13 @@ HASS.Agent 本身有问题或开发者要求时使用。</value>
     <value>HASS.Agent 可以接收来自 Home Assistant 的通知，使用文本、图像和操作。如果您已启用 MQTT，您的设备将自动被添加。否则，请手动配置集成以使用本地 API。</value>
   </data>
   <data name="ConfigNotifications_BtnNotificationsReadme" xml:space="preserve">
-    <value>通知文档(&D)</value>
+    <value>通知文档(&amp;D)</value>
   </data>
   <data name="ConfigNotifications_LblPort" xml:space="preserve">
     <value>端口</value>
   </data>
   <data name="ConfigNotifications_CbAcceptNotifications" xml:space="preserve">
-    <value>接受通知(&A)</value>
+    <value>接受通知(&amp;A)</value>
   </data>
   <data name="ConfigNotifications_BtnSendTestNotification" xml:space="preserve">
     <value>显示测试通知</value>
@@ -321,7 +321,7 @@ HASS.Agent 本身有问题或开发者要求时使用。</value>
     <value>执行端口预留</value>
   </data>
   <data name="ConfigNotifications_CbNotificationsIgnoreImageCertErrors" xml:space="preserve">
-    <value>忽略图像的证书错误(&I)</value>
+    <value>忽略图像的证书错误(&amp;I)</value>
   </data>
   <data name="ConfigService_LblInfo1" xml:space="preserve">
     <value>卫星服务允许您在没有用户登录时运行传感器和命令。 
@@ -331,19 +331,19 @@ HASS.Agent 本身有问题或开发者要求时使用。</value>
     <value>服务状态：</value>
   </data>
   <data name="ConfigService_BtnStartService" xml:space="preserve">
-    <value>启动服务(&T)</value>
+    <value>启动服务(&amp;T)</value>
   </data>
   <data name="ConfigService_BtnDisableService" xml:space="preserve">
-    <value>禁用服务(&D)</value>
+    <value>禁用服务(&amp;D)</value>
   </data>
   <data name="ConfigService_BtnStopService" xml:space="preserve">
-    <value>停止服务(&S)</value>
+    <value>停止服务(&amp;S)</value>
   </data>
   <data name="ConfigService_BtnEnableService" xml:space="preserve">
-    <value>启用服务(&E)</value>
+    <value>启用服务(&amp;E)</value>
   </data>
   <data name="ConfigService_BtnReinstallService" xml:space="preserve">
-    <value>重新安装服务(&R)</value>
+    <value>重新安装服务(&amp;R)</value>
   </data>
   <data name="ConfigService_LblInfo2" xml:space="preserve">
     <value>如果您不配置服务，它将不会执行任何操作。不过，您也可以选择禁用它。
@@ -354,7 +354,7 @@ HASS.Agent 本身有问题或开发者要求时使用。</value>
 您的配置和实体不会被删除。</value>
   </data>
   <data name="ConfigService_BtnShowLogs" xml:space="preserve">
-    <value>打开服务日志文件夹(&L)</value>
+    <value>打开服务日志文件夹(&amp;L)</value>
   </data>
   <data name="ConfigService_LblInfo4" xml:space="preserve">
     <value>如果重新安装后服务仍然失败，请提交工单并发送最新日志的内容。</value>
@@ -366,13 +366,13 @@ HASS.Agent 本身有问题或开发者要求时使用。</value>
 HASS.Agent 即可。</value>
   </data>
   <data name="ConfigStartup_BtnSetStartOnLogin" xml:space="preserve">
-    <value>启用登录时启动(&E)</value>
+    <value>启用登录时启动(&amp;E)</value>
   </data>
   <data name="ConfigStartup_LblStartOnLoginStatusInfo" xml:space="preserve">
     <value>登录时启动状态：</value>
   </data>
   <data name="ConfigUpdates_CbBetaUpdates" xml:space="preserve">
-    <value>通知我测试版发布(&B)</value>
+    <value>通知我测试版发布(&amp;B)</value>
   </data>
   <data name="ConfigUpdates_LblInfo2" xml:space="preserve">
     <value>当有新更新可用时，HASS.Agent 可以下载安装程序并为您启动它。
@@ -380,7 +380,7 @@ HASS.Agent 即可。</value>
 在运行之前将检查下载文件的证书，您仍然可以查看发布说明并手动批准更新。</value>
   </data>
   <data name="ConfigUpdates_CbExecuteUpdater" xml:space="preserve">
-    <value>自动下载未来更新(&D)</value>
+    <value>自动下载未来更新(&amp;D)</value>
   </data>
   <data name="ConfigUpdates_LblInfo1" xml:space="preserve">
     <value>如果启用，HASS.Agent 将在后台检查更新。
@@ -389,7 +389,7 @@ HASS.Agent 即可。</value>
 新版本已准备好安装。</value>
   </data>
   <data name="ConfigUpdates_CbUpdates" xml:space="preserve">
-    <value>当有新版本可用时通知我(&R)</value>
+    <value>当有新版本可用时通知我(&amp;R)</value>
   </data>
   <data name="OnboardingWelcome_LblInfo1" xml:space="preserve">
     <value>欢迎使用 HASS.Agent！看起来这是您第一次启动代理。
@@ -401,10 +401,10 @@ HASS.Agent 即可。</value>
     <value>设备名称用于在 Home Assistant 中标识您的机器，它也用作您的命令和传感器的建议前缀。</value>
   </data>
   <data name="OnboardingWelcome_LblDeviceName" xml:space="preserve">
-    <value>设备名称(&N)</value>
+    <value>设备名称(&amp;N)</value>
   </data>
   <data name="OnboardingStartup_BtnSetLaunchOnLogin" xml:space="preserve">
-    <value>是的，在系统登录时启动 HASS.Agent(&S)</value>
+    <value>是的，在系统登录时启动 HASS.Agent(&amp;S)</value>
   </data>
   <data name="OnboardingStartup_LblInfo1" xml:space="preserve">
     <value>HASS.Agent 可以随您的系统启动，这使得您的设备和 Home Assistant 之间的任何传感器和数据传输在您登录时立即开始。
@@ -443,10 +443,10 @@ HASS.Agent 即可。</value>
 信息。</value>
   </data>
   <data name="OnboardingApi_LblApiToken" xml:space="preserve">
-    <value>API 令牌(&T)</value>
+    <value>API 令牌(&amp;T)</value>
   </data>
   <data name="OnboardingApi_LblServerUri" xml:space="preserve">
-    <value>服务器 URI(&U)（这样就很好）</value>
+    <value>服务器 URI(&amp;U)（这样就很好）</value>
   </data>
   <data name="OnboardingApi_LblInfo1" xml:space="preserve">
     <value>为了解您配置了哪些实体以及发送快捷操作，HASS.Agent 使用
@@ -457,7 +457,7 @@ Home Assistant 的 API。
 并导航到页面底部，直到您看到"创建令牌"按钮。</value>
   </data>
   <data name="OnboardingApi_BtnTest" xml:space="preserve">
-    <value>测试连接(&C)</value>
+    <value>测试连接(&amp;C)</value>
   </data>
   <data name="OnboardingApi_LblTip1" xml:space="preserve">
     <value>提示：可以在配置窗口中找到专用设置。</value>
@@ -490,7 +490,7 @@ Home Assistant 的 API。
     <value>提示：可以在配置窗口中找到专用设置。</value>
   </data>
   <data name="OnboardingHotKey_LblHotkeyCombo" xml:space="preserve">
-    <value>热键组合(&H)</value>
+    <value>热键组合(&amp;H)</value>
   </data>
   <data name="OnboardingHotKey_LblInfo1" xml:space="preserve">
     <value>调出快捷操作的一种简单方式是使用全局热键。
@@ -499,7 +499,7 @@ Home Assistant 的 API。
 </value>
   </data>
   <data name="OnboardingHotKey_BtnClear" xml:space="preserve">
-    <value>清除(&C)</value>
+    <value>清除(&amp;C)</value>
   </data>
   <data name="OnboardingUpdates_LblInfo1" xml:space="preserve">
     <value>如果启用，HASS.Agent 将在后台检查更新。
@@ -513,7 +513,7 @@ Home Assistant 的 API。
     <value>Yes, notify me on new &amp;updates</value>
   </data>
   <data name="OnboardingUpdates_CbExecuteUpdater" xml:space="preserve">
-    <value>是的，为我下载并启动安装程序(&D)</value>
+    <value>是的，为我下载并启动安装程序(&amp;D)</value>
   </data>
   <data name="OnboardingUpdates_LblInfo2" xml:space="preserve">
     <value>当有新更新可用时，HASS.Agent 可以下载安装程序并为您启动它。
@@ -546,25 +546,25 @@ Home Assistant 的 API。
     <value>类型</value>
   </data>
   <data name="ServiceCommands_BtnRemove" xml:space="preserve">
-    <value>移除(&R)</value>
+    <value>移除(&amp;R)</value>
   </data>
   <data name="ServiceCommands_BtnModify" xml:space="preserve">
-    <value>修改(&M)</value>
+    <value>修改(&amp;M)</value>
   </data>
   <data name="ServiceCommands_BtnAdd" xml:space="preserve">
-    <value>添加新项(&A)</value>
+    <value>添加新项(&amp;A)</value>
   </data>
   <data name="ServiceCommands_BtnStore" xml:space="preserve">
-    <value>发送并激活命令(&S)</value>
+    <value>发送并激活命令(&amp;S)</value>
   </data>
   <data name="ServiceCommands_LblStored" xml:space="preserve">
     <value>命令已存储！</value>
   </data>
   <data name="ServiceConnect_BtnRetryAuthId" xml:space="preserve">
-    <value>应用(&A)</value>
+    <value>应用(&amp;A)</value>
   </data>
   <data name="ServiceConnect_LblRetryAuthId" xml:space="preserve">
-    <value>身份验证 ID(&I)</value>
+    <value>身份验证 ID(&amp;I)</value>
   </data>
   <data name="ServiceConnect_LblAuthenticate" xml:space="preserve">
     <value>身份验证</value>
@@ -582,25 +582,25 @@ Home Assistant 的 API。
     <value>此页面包含常规配置设置，如需 MQTT 设置、命令和传感器，请浏览上方不同的选项卡。</value>
   </data>
   <data name="ServiceGeneral_LblAuthId" xml:space="preserve">
-    <value>身份验证 ID(&I)</value>
+    <value>身份验证 ID(&amp;I)</value>
   </data>
   <data name="ServiceGeneral_LblDeviceName" xml:space="preserve">
-    <value>设备名称(&N)</value>
+    <value>设备名称(&amp;N)</value>
   </data>
   <data name="ServiceGeneral_LblTip1" xml:space="preserve">
     <value>提示：双击这些字段以浏览</value>
   </data>
   <data name="ServiceGeneral_LblCustomExecBinary" xml:space="preserve">
-    <value>自定义执行器可执行文件(&B)</value>
+    <value>自定义执行器可执行文件(&amp;B)</value>
   </data>
   <data name="ServiceGeneral_LblCustomExecName" xml:space="preserve">
-    <value>自定义执行器名称(&E)</value>
+    <value>自定义执行器名称(&amp;E)</value>
   </data>
   <data name="ServiceGeneral_LblSeconds" xml:space="preserve">
     <value>秒</value>
   </data>
   <data name="ServiceGeneral_LblDisconGrace" xml:space="preserve">
-    <value>断开连接宽限期(&P)</value>
+    <value>断开连接宽限期(&amp;P)</value>
   </data>
   <data name="ServiceGeneral_Apply" xml:space="preserve">
     <value>应用</value>
@@ -630,13 +630,13 @@ Home Assistant 的 API。
     <value>根证书</value>
   </data>
   <data name="ServiceMqtt_CbUseRetainFlag" xml:space="preserve">
-    <value>使用保留标志(&R)</value>
+    <value>使用保留标志(&amp;R)</value>
   </data>
   <data name="ServiceMqtt_CbAllowUntrustedCertificates" xml:space="preserve">
-    <value>允许不受信任的证书(&A)</value>
+    <value>允许不受信任的证书(&amp;A)</value>
   </data>
   <data name="ServiceMqtt_BtnMqttClearConfig" xml:space="preserve">
-    <value>清除配置(&C)</value>
+    <value>清除配置(&amp;C)</value>
   </data>
   <data name="ServiceMqtt_LblTip1" xml:space="preserve">
     <value>（如果不确定，保持默认）</value>
@@ -661,10 +661,10 @@ Home Assistant 的 API。
     <value>代理 IP 地址或主机名</value>
   </data>
   <data name="ServiceMqtt_BtnStore" xml:space="preserve">
-    <value>发送并激活配置(&S)</value>
+    <value>发送并激活配置(&amp;S)</value>
   </data>
   <data name="ServiceMqtt_BtnCopy" xml:space="preserve">
-    <value>从 HASS.Agent 复制(&H)</value>
+    <value>从 HASS.Agent 复制(&amp;H)</value>
   </data>
   <data name="ServiceMqtt_LblStored" xml:space="preserve">
     <value>配置已存储！</value>
@@ -685,16 +685,16 @@ Home Assistant 的 API。
     <value>刷新</value>
   </data>
   <data name="ServiceSensors_BtnRemove" xml:space="preserve">
-    <value>移除(&R)</value>
+    <value>移除(&amp;R)</value>
   </data>
   <data name="ServiceSensors_BtnAdd" xml:space="preserve">
-    <value>添加新项(&A)</value>
+    <value>添加新项(&amp;A)</value>
   </data>
   <data name="ServiceSensors_BtnModify" xml:space="preserve">
-    <value>修改(&M)</value>
+    <value>修改(&amp;M)</value>
   </data>
   <data name="ServiceSensors_BtnStore" xml:space="preserve">
-    <value>发送并激活传感器(&S)</value>
+    <value>发送并激活传感器(&amp;S)</value>
   </data>
   <data name="ServiceSensors_LblStored" xml:space="preserve">
     <value>传感器已存储！</value>
@@ -757,13 +757,13 @@ Home Assistant 的 API。
     <value>HASS.Agent 配置卫星服务</value>
   </data>
   <data name="CommandMqttTopic_BtnClose" xml:space="preserve">
-    <value>关闭(&C)</value>
+    <value>关闭(&amp;C)</value>
   </data>
   <data name="CommandMqttTopic_LblInfo1" xml:space="preserve">
     <value>这是您可以发布操作命令的 MQTT 主题：</value>
   </data>
   <data name="CommandMqttTopic_BtnCopyClipboard" xml:space="preserve">
-    <value>复制到剪贴板(&T)</value>
+    <value>复制到剪贴板(&amp;T)</value>
   </data>
   <data name="CommandMqttTopic_LblHelp" xml:space="preserve">
     <value>帮助和示例</value>
@@ -772,16 +772,16 @@ Home Assistant 的 API。
     <value>MQTT 操作主题</value>
   </data>
   <data name="CommandsConfig_BtnRemove" xml:space="preserve">
-    <value>移除(&R)</value>
+    <value>移除(&amp;R)</value>
   </data>
   <data name="CommandsConfig_BtnModify" xml:space="preserve">
-    <value>修改(&M)</value>
+    <value>修改(&amp;M)</value>
   </data>
   <data name="CommandsConfig_BtnAdd" xml:space="preserve">
-    <value>添加新项(&A)</value>
+    <value>添加新项(&amp;A)</value>
   </data>
   <data name="CommandsConfig_BtnStore" xml:space="preserve">
-    <value>存储并激活命令(&S)</value>
+    <value>存储并激活命令(&amp;S)</value>
   </data>
   <data name="CommandsConfig_ClmName" xml:space="preserve">
     <value>名称</value>
@@ -799,19 +799,19 @@ Home Assistant 的 API。
     <value>命令配置</value>
   </data>
   <data name="CommandsMod_BtnStore" xml:space="preserve">
-    <value>存储命令(&S)</value>
+    <value>存储命令(&amp;S)</value>
   </data>
   <data name="CommandsMod_LblSetting" xml:space="preserve">
-    <value>配置(&C)</value>
+    <value>配置(&amp;C)</value>
   </data>
   <data name="CommandsMod_LblName" xml:space="preserve">
-    <value>名称(&N)</value>
+    <value>名称(&amp;N)</value>
   </data>
   <data name="CommandsMod_LblDescription" xml:space="preserve">
     <value>描述</value>
   </data>
   <data name="CommandsMod_CbRunAsLowIntegrity" xml:space="preserve">
-    <value>以"低完整性"运行(&R)</value>
+    <value>以"低完整性"运行(&amp;R)</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo" xml:space="preserve">
     <value>这是什么？</value>
@@ -832,7 +832,7 @@ Home Assistant 的 API。
     <value>仅 HASS.Agent！</value>
   </data>
   <data name="CommandsMod_LblEntityType" xml:space="preserve">
-    <value>实体类型(&E)</value>
+    <value>实体类型(&amp;E)</value>
   </data>
   <data name="CommandsMod_LblMqttTopic" xml:space="preserve">
     <value>显示 MQTT 操作主题</value>
@@ -850,19 +850,19 @@ Home Assistant 的 API。
     <value>快捷操作</value>
   </data>
   <data name="QuickActionsConfig_BtnStore" xml:space="preserve">
-    <value>存储快捷操作(&S)</value>
+    <value>存储快捷操作(&amp;S)</value>
   </data>
   <data name="QuickActionsConfig_BtnAdd" xml:space="preserve">
-    <value>添加新项(&A)</value>
+    <value>添加新项(&amp;A)</value>
   </data>
   <data name="QuickActionsConfig_BtnModify" xml:space="preserve">
-    <value>修改(&M)</value>
+    <value>修改(&amp;M)</value>
   </data>
   <data name="QuickActionsConfig_BtnRemove" xml:space="preserve">
-    <value>移除(&R)</value>
+    <value>移除(&amp;R)</value>
   </data>
   <data name="QuickActionsConfig_BtnPreview" xml:space="preserve">
-    <value>预览(&P)</value>
+    <value>预览(&amp;P)</value>
   </data>
   <data name="QuickActionsConfig_ClmDomain" xml:space="preserve">
     <value>域</value>
@@ -886,19 +886,19 @@ Home Assistant 的 API。
     <value>快捷操作配置</value>
   </data>
   <data name="QuickActionsMod_BtnStore" xml:space="preserve">
-    <value>存储快捷操作(&S)</value>
+    <value>存储快捷操作(&amp;S)</value>
   </data>
   <data name="QuickActionsMod_LblDomain" xml:space="preserve">
     <value>域</value>
   </data>
   <data name="QuickActionsMod_LblEntityInfo" xml:space="preserve">
-    <value>实体(&E)</value>
+    <value>实体(&amp;E)</value>
   </data>
   <data name="QuickActionsMod_LblAction" xml:space="preserve">
-    <value>所需操作(&A)</value>
+    <value>所需操作(&amp;A)</value>
   </data>
   <data name="QuickActionsMod_LblDescription" xml:space="preserve">
-    <value>描述(&D)</value>
+    <value>描述(&amp;D)</value>
   </data>
   <data name="QuickActionsMod_LblLoading" xml:space="preserve">
     <value>正在检索实体，请稍候..</value>
@@ -907,7 +907,7 @@ Home Assistant 的 API。
     <value>启用热键</value>
   </data>
   <data name="QuickActionsMod_LblHotkey" xml:space="preserve">
-    <value>热键组合(&H)</value>
+    <value>热键组合(&amp;H)</value>
   </data>
   <data name="QuickActionsMod_LblTip1" xml:space="preserve">
     <value>（可选，将替代实体名称使用）</value>
@@ -916,7 +916,7 @@ Home Assistant 的 API。
     <value>快捷操作</value>
   </data>
   <data name="SensorsConfig_BtnRemove" xml:space="preserve">
-    <value>移除(&R)</value>
+    <value>移除(&amp;R)</value>
   </data>
   <data name="SensorsConfig_BtnModify" xml:space="preserve">
     <value>修改(&amp;M)</value>
@@ -2669,13 +2669,13 @@ NotPresent、Busy、RunningDirect3dFullScreen、PresentationMode、AcceptsNotifi
     <value>无法加载存储的命令设置，将重置为默认值。</value>
   </data>
   <data name="CommandsMod_BtnConfigureCommand" xml:space="preserve">
-    <value>配置命令参数(&P)</value>
+    <value>配置命令参数(&amp;P)</value>
   </data>
   <data name="ConfigLocalApi_BtnExecutePortReservation" xml:space="preserve">
-    <value>执行端口保留(&R)</value>
+    <value>执行端口保留(&amp;R)</value>
   </data>
   <data name="ConfigLocalApi_CbLocalApiActive" xml:space="preserve">
-    <value>启用本地 API(&E)</value>
+    <value>启用本地 API(&amp;E)</value>
   </data>
   <data name="ConfigLocalApi_LblInfo1" xml:space="preserve">
     <value>HASS.Agent 有自己的本地 API，因此 Home Assistant 可以发送请求（例如发送通知）。你可以在此处全局配置它，然后配置相关部分（目前是通知和媒体播放器）。
@@ -2686,7 +2686,7 @@ NotPresent、Busy、RunningDirect3dFullScreen、PresentationMode、AcceptsNotifi
     <value>为了能够监听请求，HASS.Agent 需要在你的防火墙中保留并打开其端口。你可以使用此按钮自动完成此操作。</value>
   </data>
   <data name="ConfigLocalApi_LblPort" xml:space="preserve">
-    <value>端口(&P)</value>
+    <value>端口(&amp;P)</value>
   </data>
   <data name="ConfigLocalStorage_LblAudioCacheLocation" xml:space="preserve">
     <value>音频缓存位置</value>
@@ -2710,10 +2710,10 @@ NotPresent、Busy、RunningDirect3dFullScreen、PresentationMode、AcceptsNotifi
     <value>WebView 缓存位置</value>
   </data>
   <data name="ConfigMediaPlayer_BtnMediaPlayerReadme" xml:space="preserve">
-    <value>媒体播放器文档(&D)</value>
+    <value>媒体播放器文档(&amp;D)</value>
   </data>
   <data name="ConfigMediaPlayer_CbEnableMediaPlayer" xml:space="preserve">
-    <value>启用媒体播放器功能(&E)</value>
+    <value>启用媒体播放器功能(&amp;E)</value>
   </data>
   <data name="ConfigMediaPlayer_LblInfo1" xml:space="preserve">
     <value>HASS.Agent 可以作为 Home Assistant 的媒体播放器，因此你将能够查看和控制任何正在播放的媒体，并发送文本转语音。如果你启用了 MQTT，你的设备将被自动添加。否则，请手动配置集成以使用本地 API。</value>
@@ -2731,22 +2731,22 @@ NotPresent、Busy、RunningDirect3dFullScreen、PresentationMode、AcceptsNotifi
     <value>本地 API 已禁用，但媒体播放器需要它才能运行。</value>
   </data>
   <data name="ConfigMqtt_CbMqttTls" xml:space="preserve">
-    <value>TLS(&T)</value>
+    <value>TLS(&amp;T)</value>
   </data>
   <data name="ConfigNotifications_LblLocalApiDisabled" xml:space="preserve">
     <value>本地 API 已禁用，但媒体播放器需要它才能运行。</value>
   </data>
   <data name="ConfigTrayIcon_BtnShowWebViewPreview" xml:space="preserve">
-    <value>显示预览(&P)</value>
+    <value>显示预览(&amp;P)</value>
   </data>
   <data name="ConfigTrayIcon_CbDefaultMenu" xml:space="preserve">
-    <value>显示默认菜单(&D)</value>
+    <value>显示默认菜单(&amp;D)</value>
   </data>
   <data name="ConfigTrayIcon_CbShowWebView" xml:space="preserve">
-    <value>显示 WebView(&W)</value>
+    <value>显示 WebView(&amp;W)</value>
   </data>
   <data name="ConfigTrayIcon_CbWebViewKeepLoaded" xml:space="preserve">
-    <value>在后台保持页面加载(&K)</value>
+    <value>在后台保持页面加载(&amp;K)</value>
   </data>
   <data name="ConfigTrayIcon_LblInfo1" xml:space="preserve">
     <value>控制右键单击托盘图标时的行为。</value>
@@ -2758,7 +2758,7 @@ NotPresent、Busy、RunningDirect3dFullScreen、PresentationMode、AcceptsNotifi
     <value>大小 (px)</value>
   </data>
   <data name="ConfigTrayIcon_LblWebViewUrl" xml:space="preserve">
-    <value>WebView URL(&W)（例如，你的 Home Assistant 仪表板 URL）</value>
+    <value>WebView URL(&amp;W)（例如，你的 Home Assistant 仪表板 URL）</value>
   </data>
   <data name="Configuration_TablLocalApi" xml:space="preserve">
     <value>本地 API</value>
@@ -2794,7 +2794,7 @@ NotPresent、Busy、RunningDirect3dFullScreen、PresentationMode、AcceptsNotifi
     <value>文档和使用示例</value>
   </data>
   <data name="Main_BtnCheckForUpdate" xml:space="preserve">
-    <value>检查更新(&U)</value>
+    <value>检查更新(&amp;U)</value>
   </data>
   <data name="Main_LblLocalApi" xml:space="preserve">
     <value>本地 API：</value>
@@ -2825,13 +2825,13 @@ NotPresent、Busy、RunningDirect3dFullScreen、PresentationMode、AcceptsNotifi
     <value>HASS.Agent-Integration GitHub 页面</value>
   </data>
   <data name="OnboardingLocalApi_CbEnableLocalApi" xml:space="preserve">
-    <value>是，启用本地 API 端口(&E)</value>
+    <value>是，启用本地 API 端口(&amp;E)</value>
   </data>
   <data name="OnboardingLocalApi_CbEnableMediaPlayer" xml:space="preserve">
-    <value>启用媒体播放器和文本转语音(TTS)(&M)</value>
+    <value>启用媒体播放器和文本转语音(TTS)(&amp;M)</value>
   </data>
   <data name="OnboardingLocalApi_CbEnableNotifications" xml:space="preserve">
-    <value>启用通知(&N)</value>
+    <value>启用通知(&amp;N)</value>
   </data>
   <data name="OnboardingLocalApi_LblInfo1" xml:space="preserve">
     <value>HASS.Agent 有自己的内部 API，因此 Home Assistant 可以发送请求（如通知或文本转语音）。
@@ -2845,7 +2845,7 @@ NotPresent、Busy、RunningDirect3dFullScreen、PresentationMode、AcceptsNotifi
     <value>注意：5115 是默认端口，只有在 Home Assistant 中更改过才需要修改。</value>
   </data>
   <data name="OnboardingMqtt_CbMqttTls" xml:space="preserve">
-    <value>TLS(&T)</value>
+    <value>TLS(&amp;T)</value>
   </data>
   <data name="OnboardingWelcome_Store_MessageBox1" xml:space="preserve">
     <value>你的设备名称包含一些 HA 不允许的字符（只允许字母、数字和空格）。
@@ -2861,19 +2861,19 @@ NotPresent、Busy、RunningDirect3dFullScreen、PresentationMode、AcceptsNotifi
     <value>已存储！</value>
   </data>
   <data name="ServiceMqtt_CbMqttTls" xml:space="preserve">
-    <value>TLS(&T)</value>
+    <value>TLS(&amp;T)</value>
   </data>
   <data name="WebViewCommandConfig_BtnSave" xml:space="preserve">
-    <value>保存(&S)</value>
+    <value>保存(&amp;S)</value>
   </data>
   <data name="WebViewCommandConfig_CbCenterScreen" xml:space="preserve">
-    <value>始终在屏幕居中显示(&A)</value>
+    <value>始终在屏幕居中显示(&amp;A)</value>
   </data>
   <data name="WebViewCommandConfig_CbShowTitleBar" xml:space="preserve">
-    <value>显示窗口标题栏(&T)</value>
+    <value>显示窗口标题栏(&amp;T)</value>
   </data>
   <data name="WebViewCommandConfig_CbTopMost" xml:space="preserve">
-    <value>将窗口设置为'始终置顶'(&T)</value>
+    <value>将窗口设置为'始终置顶'(&amp;T)</value>
   </data>
   <data name="WebViewCommandConfig_LblInfo1" xml:space="preserve">
     <value>拖动并调整此窗口的大小，以设置你的 WebView 命令的大小和位置。</value>
@@ -2888,7 +2888,7 @@ NotPresent、Busy、RunningDirect3dFullScreen、PresentationMode、AcceptsNotifi
     <value>提示：按 ESCAPE 键关闭 WebView。</value>
   </data>
   <data name="WebViewCommandConfig_LblUrl" xml:space="preserve">
-    <value>URL(&U)</value>
+    <value>URL(&amp;U)</value>
   </data>
   <data name="WebViewCommandConfig_Title" xml:space="preserve">
     <value>WebView 配置</value>
@@ -2902,7 +2902,7 @@ NotPresent、Busy、RunningDirect3dFullScreen、PresentationMode、AcceptsNotifi
 请确保键码字段处于焦点状态，然后按下你想要模拟的键，系统将为你生成键码。</value>
   </data>
   <data name="ConfigGeneral_CbEnableDeviceNameSanitation" xml:space="preserve">
-    <value>启用设备名称清理(&S)</value>
+    <value>启用设备名称清理(&amp;S)</value>
   </data>
   <data name="ConfigGeneral_CbEnableStateNotifications" xml:space="preserve">
     <value>启用状态通知</value>
@@ -3031,7 +3031,7 @@ NotPresent、Busy、RunningDirect3dFullScreen、PresentationMode、AcceptsNotifi
     <value>本地 API 和 MQTT 均已禁用，但集成需要至少启用一个才能工作</value>
   </data>
   <data name="ConfigService_BtnManageService" xml:space="preserve">
-    <value>管理服务(&M)</value>
+    <value>管理服务(&amp;M)</value>
   </data>
   <data name="ConfigService_BtnManageService_MessageBox1" xml:space="preserve">
     <value>服务当前已停止，无法配置。
@@ -3061,7 +3061,7 @@ NotPresent、Busy、RunningDirect3dFullScreen、PresentationMode、AcceptsNotifi
 你确定要这样使用它吗？</value>
   </data>
   <data name="Donate_BtnClose" xml:space="preserve">
-    <value>关闭(&C)</value>
+    <value>关闭(&amp;C)</value>
   </data>
   <data name="Donate_CbHideDonateButton" xml:space="preserve">
     <value>我已经捐赠，在主窗口上隐藏按钮。</value>
@@ -3102,10 +3102,10 @@ NotPresent、Busy、RunningDirect3dFullScreen、PresentationMode、AcceptsNotifi
     <value>提示：其他捐赠方式可在"关于"窗口中找到。</value>
   </data>
   <data name="OnboardingIntegrations_CbEnableMediaPlayer" xml:space="preserve">
-    <value>启用媒体播放器(&M)（包括文本转语音）</value>
+    <value>启用媒体播放器(&amp;M)（包括文本转语音）</value>
   </data>
   <data name="OnboardingIntegrations_CbEnableNotifications" xml:space="preserve">
-    <value>启用通知(&N)</value>
+    <value>启用通知(&amp;N)</value>
   </data>
   <data name="OnboardingMqtt_CbEnableMqtt" xml:space="preserve">
     <value>启用 MQTT</value>
@@ -3254,13 +3254,13 @@ NotPresent、Busy、RunningDirect3dFullScreen、PresentationMode、AcceptsNotifi
     <value>无</value>
   </data>
   <data name="SensorsMod_CbIgnoreAvailability" xml:space="preserve">
-    <value>忽略可用性(&I)</value>
+    <value>忽略可用性(&amp;I)</value>
   </data>
   <data name="SensorsMod_IgnoreAvailability_Info" xml:space="preserve">
     <value>请注意，忽略可用性将导致 Home Assistant 始终显示给定传感器的最后一个值，即使 HASS.Agent 处于离线状态。</value>
   </data>
   <data name="ConfigNotifications_CbNotificationsOpenActionUri" xml:space="preserve">
-    <value>像 Android Companion App 一样处理 URI Action 元素（打开）(&T)</value>
+    <value>像 Android Companion App 一样处理 URI Action 元素（打开）(&amp;T)</value>
   </data>
   <data name="ConfigNotifications_TestNotification_No" xml:space="preserve">
     <value>否</value>
@@ -3404,7 +3404,7 @@ HASS.Agent 配置</value>
     <value>NFC</value>
   </data>
   <data name="SensorsMod_BtnAdvancedSettings" xml:space="preserve">
-    <value>高级设置(&V)</value>
+    <value>高级设置(&amp;V)</value>
   </data>
   <data name="AdvancedSensorConfig_Warning" xml:space="preserve">
     <value>警告，添加以下设置（覆盖）可能会破坏传感器，请谨慎使用！</value>
@@ -3451,10 +3451,10 @@ HASS.Agent 配置</value>
 主强调色是传感器值，其他强调色作为属性提供。</value>
   </data>
   <data name="ConfigMqtt_CbUseWebSocket" xml:space="preserve">
-    <value>使用 WebSocket(&W)</value>
+    <value>使用 WebSocket(&amp;W)</value>
   </data>
   <data name="ServiceMqtt_CbUseWebSocket" xml:space="preserve">
-    <value>使用 WebSocket(&W)</value>
+    <value>使用 WebSocket(&amp;W)</value>
   </data>
   <data name="HassDomain_InputButton" xml:space="preserve">
     <value>输入按钮</value>


### PR DESCRIPTION
## Description

This PR adds complete Simplified Chinese (zh-CN) translation for HASS.Agent.

## Changes

- Added `Languages.zh-CN.resx` for the main HASS.Agent project (960 strings translated)
- Added `Languages.zh-CN.resx` for the HASS.Agent.Shared library (912 strings translated)
- Total: 1872 UI strings translated to Simplified Chinese

## Translation Notes

- Proper nouns kept in English (HASS.Agent, Home Assistant, MQTT, API, etc.)
- Button shortcuts converted: `&Test` → `测试(&T)`
- Technical terms translated consistently (Broker→代理, Sensor→传感器, Command→命令, etc.)
- HTML entities and placeholders ({0}, {1}) preserved