### PR TITLE
Feature: PublishSensorCommand

### DIFF
--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/Models/HomeAssistant/Commands/InternalCommands/PublishSensorCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/Models/HomeAssistant/Commands/InternalCommands/PublishSensorCommand.cs
@@ -1,0 +1,33 @@
+﻿using HASS.Agent.Satellite.Service.Sensors;
+using HASS.Agent.Shared.Enums;
+using HASS.Agent.Shared.HomeAssistant.Commands;
+using Serilog;
+
+namespace HASS.Agent.Satellite.Service.Models.HomeAssistant.Commands.InternalCommands;
+
+public class PublishSensorCommand : InternalCommand
+{
+    private const string DefaultName = "publishallsensor";
+
+    internal PublishSensorCommand(string entityName = DefaultName, string name = DefaultName, string sensorName = "", CommandEntityType entityType = CommandEntityType.Switch,
+        string id = default) : base(entityName ?? DefaultName, name ?? null, sensorName, entityType, id)
+    {
+        State = "OFF";
+    }
+
+    public override void TurnOn()
+    {
+        State = "ON";
+
+        if (!string.IsNullOrWhiteSpace(CommandConfig))
+        {
+            SensorsManager.ResetSensorCheck(CommandConfig);
+        }
+        else
+        {
+            Log.Warning("[PUBLISHSENSOR] [{name}] Unable to launch command, it's configured as action-only", EntityName);
+        }
+
+        State = "OFF";
+    }
+}

--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/Models/HomeAssistant/Commands/InternalCommands/PublishSensorCommand.cs
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/Models/HomeAssistant/Commands/InternalCommands/PublishSensorCommand.cs
@@ -30,4 +30,20 @@ public class PublishSensorCommand : InternalCommand
 
         State = "OFF";
     }
+    
+    public override void TurnOnWithAction(string action)
+    {
+        State = "ON";
+
+        if (!string.IsNullOrWhiteSpace(action))
+        {
+            SensorsManager.ResetSensorCheck(action);
+        }
+        else
+        {
+            Log.Warning("[PUBLISHSENSOR] [{name}] Unable to launch command, it's configured as action-only", EntityName);
+        }
+
+        State = "OFF";
+    }
 }

--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/Sensors/SensorsManager.cs
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/Sensors/SensorsManager.cs
@@ -244,6 +244,41 @@ namespace HASS.Agent.Satellite.Service.Sensors
         }
 
         /// <summary>
+        /// Resets sensor check for provided sensor (last sent and previous value), so it is published again
+        /// </summary>
+        internal static void ResetSensorCheck(string sensorName)
+        {
+            try
+            {
+                Pause();
+
+                var singleMatch = Variables.SingleValueSensors.FirstOrDefault(sensor => sensor.Name == sensorName);
+                if (singleMatch != null)
+                {
+                    singleMatch.ResetChecks();
+                    return;
+                }
+                
+                var multiMatch = Variables.MultiValueSensors.FirstOrDefault(sensor => sensor.Name == sensorName);
+                if (multiMatch != null)
+                {
+                    multiMatch.ResetChecks();
+                    return;
+                }
+                
+                Log.Warning("[SENSORS] Can't reset check for sensor '{err}' - not found.", sensorName);
+            }
+            catch (Exception ex)
+            {
+                Log.Fatal(ex, "[SENSORS] Error while resetting sensor check: {err}", ex.Message);
+            }
+            finally
+            {
+                Resume();
+            }
+        }
+        
+        /// <summary>
         /// Stores the provided sensors, and (re)publishes them
         /// </summary>
         /// <param name="sensors"></param>

--- a/src/HASS.Agent/HASS.Agent.Satellite.Service/Settings/StoredCommands.cs
+++ b/src/HASS.Agent/HASS.Agent.Satellite.Service/Settings/StoredCommands.cs
@@ -132,6 +132,9 @@ namespace HASS.Agent.Satellite.Service.Settings
                 case CommandType.PublishAllSensorsCommand:
                     abstractCommand = new PublishAllSensorsCommand(command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
+                case CommandType.PublishSensorCommand:
+                    abstractCommand = new PublishSensorCommand(command.EntityName, command.Name, command.Command, command.EntityType, command.Id.ToString());
+                    break;
                 case CommandType.CustomExecutorCommand:
                     abstractCommand = new CustomExecutorCommand(command.EntityName, command.Name, command.Command, command.EntityType, command.Id.ToString());
                     break;

--- a/src/HASS.Agent/HASS.Agent.Shared/Enums/CommandType.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Enums/CommandType.cs
@@ -135,6 +135,10 @@ namespace HASS.Agent.Shared.Enums
 
         [LocalizedDescription("CommandType_WinformsSleepCommand", typeof(Languages))]
         [EnumMember(Value = "WinformsSleepCommand")]
-        WinformsSleepCommand
+        WinformsSleepCommand,
+        
+        [LocalizedDescription("CommandType_PublishSensorCommand", typeof(Languages))]
+        [EnumMember(Value = "PublishSensorCommand")]
+        PublishSensorCommand,
     }
 }

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.Designer.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.Designer.cs
@@ -558,7 +558,8 @@ namespace HASS.Agent.Shared.Resources.Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Some desc.
+        ///   Looks up a localized string similar to Forces specific sensor to be published right away, ignoring the interval.
+        ///Use name configured in HASS.Agent..
         /// </summary>
         internal static string CommandsManager_PublishSensorCommandDescription {
             get {

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.Designer.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.Designer.cs
@@ -558,6 +558,15 @@ namespace HASS.Agent.Shared.Resources.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Some desc.
+        /// </summary>
+        internal static string CommandsManager_PublishSensorCommandDescription {
+            get {
+                return ResourceManager.GetString("CommandsManager_PublishSensorCommandDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Restarts the machine after one minute.
         ///
         ///Tip: Accidentally triggered? Run &apos;shutdown /a&apos; to abort shutdown..
@@ -1000,6 +1009,15 @@ namespace HASS.Agent.Shared.Resources.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Sensor Name.
+        /// </summary>
+        internal static string CommandsMod_LblSetting_SensorId {
+            get {
+                return ResourceManager.GetString("CommandsMod_LblSetting_SensorId", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to URL.
         /// </summary>
         internal static string CommandsMod_LblSetting_Url {
@@ -1274,6 +1292,15 @@ namespace HASS.Agent.Shared.Resources.Localization {
         internal static string CommandType_PublishAllSensorsCommand {
             get {
                 return ResourceManager.GetString("CommandType_PublishAllSensorsCommand", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to PublishSensorCommand.
+        /// </summary>
+        internal static string CommandType_PublishSensorCommand {
+            get {
+                return ResourceManager.GetString("CommandType_PublishSensorCommand", resourceCulture);
             }
         }
         

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.de.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.de.resx
@@ -3410,4 +3410,14 @@ Sollte bei neuen Systemen mit „modernem S0ix-Schlafmodus“ eine bessere Benut
   <data name="ConfigMqtt_CbDisableDefaultEntityId" xml:space="preserve">
     <value>Lassen Sie Home Assistant Entitäts-IDs generieren</value>
   </data>
+  <data name="CommandsMod_LblSetting_SensorId" xml:space="preserve">
+    <value>Sensorname</value>
+  </data>
+  <data name="CommandType_PublishSensorCommand" xml:space="preserve">
+    <value>PublishSensorCommand</value>
+  </data>
+  <data name="CommandsManager_PublishSensorCommandDescription" xml:space="preserve">
+    <value>Erzwingt die sofortige Veröffentlichung eines bestimmten Sensors, unabhängig vom Intervall.
+Verwendet den in HASS.Agent konfigurierten Namen.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.en.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.en.resx
@@ -3290,7 +3290,8 @@ Should provide better experience with new systems with "modern S0ix sleep" and n
     <value>Let Home Assistant generate entity IDs</value>
   </data>
   <data name="CommandsManager_PublishSensorCommandDescription" xml:space="preserve">
-    <value>Some desc</value>
+    <value>Forces specific sensor to be published right away, ignoring the interval.
+Use name configured in HASS.Agent.</value>
   </data>
   <data name="CommandType_PublishSensorCommand" xml:space="preserve">
     <value>PublishSensorCommand</value>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.en.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.en.resx
@@ -3289,4 +3289,13 @@ Should provide better experience with new systems with "modern S0ix sleep" and n
   <data name="ConfigMqtt_CbDisableDefaultEntityId" xml:space="preserve">
     <value>Let Home Assistant generate entity IDs</value>
   </data>
+  <data name="CommandsManager_PublishSensorCommandDescription" xml:space="preserve">
+    <value>Some desc</value>
+  </data>
+  <data name="CommandType_PublishSensorCommand" xml:space="preserve">
+    <value>PublishSensorCommand</value>
+  </data>
+  <data name="CommandsMod_LblSetting_SensorId" xml:space="preserve">
+    <value>Sensor Name</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.es.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.es.resx
@@ -3286,4 +3286,15 @@ Esto debería proporcionar una mejor experiencia con los nuevos sistemas con "su
   <data name="ConfigMqtt_CbDisableDefaultEntityId" xml:space="preserve">
     <value>Deja que Home Assistant genere identificadores de entidades.</value>
   </data>
+  <data name="CommandsMod_LblSetting_SensorId" xml:space="preserve">
+    <value>Nombre del sensor</value>
+  </data>
+  <data name="CommandType_PublishSensorCommand" xml:space="preserve">
+    <value>PublishSensorCommand</value>
+  </data>
+  <data name="CommandsManager_PublishSensorCommandDescription" xml:space="preserve">
+    <value>Fuerza la publicación inmediata de un sensor específico, ignorando el intervalo.
+
+Utiliza el nombre configurado en HASS.Agent.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.fr.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.fr.resx
@@ -3319,4 +3319,15 @@ Cela devrait offrir une meilleure expérience avec les nouveaux systèmes dotés
   <data name="ConfigMqtt_CbDisableDefaultEntityId" xml:space="preserve">
     <value>Laissez Home Assistant générer les identifiants d'entité.</value>
   </data>
+  <data name="CommandsMod_LblSetting_SensorId" xml:space="preserve">
+    <value>Nom du capteur</value>
+  </data>
+  <data name="CommandType_PublishSensorCommand" xml:space="preserve">
+    <value>Publier la commande du capteur</value>
+  </data>
+  <data name="CommandsManager_PublishSensorCommandDescription" xml:space="preserve">
+    <value>Force la publication immédiate du capteur spécifique, sans tenir compte de l'intervalle.
+
+Utilisez le nom configuré dans HASS.Agent.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.nl.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.nl.resx
@@ -3308,4 +3308,15 @@ Zou een betere ervaring moeten bieden met nieuwe systemen met een "moderne S0ix-
   <data name="ConfigMqtt_CbDisableDefaultEntityId" xml:space="preserve">
     <value>Laat Home Assistant entiteits-ID's genereren.</value>
   </data>
+  <data name="CommandsMod_LblSetting_SensorId" xml:space="preserve">
+    <value>Sensornaam</value>
+  </data>
+  <data name="CommandType_PublishSensorCommand" xml:space="preserve">
+    <value>PublishSensorCommand</value>
+  </data>
+  <data name="CommandsManager_PublishSensorCommandDescription" xml:space="preserve">
+    <value>Dwingt de specifieke sensor om direct te publiceren, ongeacht het interval.
+
+Gebruik de naam die is geconfigureerd in HASS.Agent.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.pl.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.pl.resx
@@ -3396,4 +3396,14 @@ Powinno to zapewnić lepsze działanie w przypadku nowych systemów z „nowocze
   <data name="ConfigMqtt_CbDisableDefaultEntityId" xml:space="preserve">
     <value>Pozwól Home Assistant generować identyfikatory jednostek</value>
   </data>
+  <data name="CommandsMod_LblSetting_SensorId" xml:space="preserve">
+    <value>Nazwa czujnika</value>
+  </data>
+  <data name="CommandType_PublishSensorCommand" xml:space="preserve">
+    <value>PublishSensorCommand</value>
+  </data>
+  <data name="CommandsManager_PublishSensorCommandDescription" xml:space="preserve">
+    <value>Wymusza natychmiastową publikację określonego czujnika, ignorując interwał.
+Użyj nazwy skonfigurowanej w HASS.Agent.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.pt-br.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.pt-br.resx
@@ -3333,4 +3333,14 @@ Deve proporcionar uma melhor experiência com novos sistemas com "suspensão S0i
   <data name="ConfigMqtt_CbDisableDefaultEntityId" xml:space="preserve">
     <value>Permita que o Home Assistant gere IDs de entidade.</value>
   </data>
+  <data name="CommandsMod_LblSetting_SensorId" xml:space="preserve">
+    <value>Nome do sensor</value>
+  </data>
+  <data name="CommandType_PublishSensorCommand" xml:space="preserve">
+    <value>PublicarComandoSensor</value>
+  </data>
+  <data name="CommandsManager_PublishSensorCommandDescription" xml:space="preserve">
+    <value>Força a publicação imediata de um sensor específico, ignorando o intervalo.
+Use o nome configurado em HASS.Agent.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.resx
@@ -3272,4 +3272,13 @@ Should provide better experience with new systems with "modern S0ix sleep" and n
   <data name="ConfigMqtt_CbDisableDefaultEntityId" xml:space="preserve">
 	  <value>Let Home Assistant generate entity IDs</value>
   </data>
+  <data name="CommandType_PublishSensorCommand" xml:space="preserve">
+	  <value>PublishSensorCommand</value>
+  </data>
+  <data name="CommandsManager_PublishSensorCommandDescription" xml:space="preserve">
+	  <value>Some desc</value>
+  </data>
+  <data name="CommandsMod_LblSetting_SensorId" xml:space="preserve">
+	  <value>Sensor Name</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.resx
@@ -3276,7 +3276,8 @@ Should provide better experience with new systems with "modern S0ix sleep" and n
 	  <value>PublishSensorCommand</value>
   </data>
   <data name="CommandsManager_PublishSensorCommandDescription" xml:space="preserve">
-	  <value>Some desc</value>
+	  <value>Forces specific sensor to be published right away, ignoring the interval.
+Use name configured in HASS.Agent.</value>
   </data>
   <data name="CommandsMod_LblSetting_SensorId" xml:space="preserve">
 	  <value>Sensor Name</value>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.ru.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.ru.resx
@@ -3354,4 +3354,14 @@ Home Assistant.
   <data name="ConfigMqtt_CbDisableDefaultEntityId" xml:space="preserve">
     <value>Пусть Home Assistant генерирует идентификаторы сущностей</value>
   </data>
+  <data name="CommandsMod_LblSetting_SensorId" xml:space="preserve">
+    <value>Название датчика</value>
+  </data>
+  <data name="CommandType_PublishSensorCommand" xml:space="preserve">
+    <value>PublishSensorCommand</value>
+  </data>
+  <data name="CommandsManager_PublishSensorCommandDescription" xml:space="preserve">
+    <value>Принудительно публикует данные с конкретного датчика немедленно, игнорируя интервал.
+Используйте имя, заданное в HASS.Agent.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.sl.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.sl.resx
@@ -3435,4 +3435,14 @@ Omogoča boljšo izkušnjo z novimi sistemi s »sodobnim načinom mirovanja S0ix
   <data name="ConfigMqtt_CbDisableDefaultEntityId" xml:space="preserve">
     <value>Naj Home Assistant ustvari ID-je entitet</value>
   </data>
+  <data name="CommandsMod_LblSetting_SensorId" xml:space="preserve">
+    <value>Ime senzorja</value>
+  </data>
+  <data name="CommandType_PublishSensorCommand" xml:space="preserve">
+    <value>PublishSensorCommand</value>
+  </data>
+  <data name="CommandsManager_PublishSensorCommandDescription" xml:space="preserve">
+    <value>Vsili takojšnjo objavo določenega senzorja, pri čemer se interval prezre.
+Uporabi ime, konfigurirano v HASS.Agent.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.tr.resx
+++ b/src/HASS.Agent/HASS.Agent.Shared/Resources/Localization/Languages.tr.resx
@@ -2893,4 +2893,14 @@ Not: "Modern Uyku" nedeniyle uyku komutları, cihazın OEM ve işletim sistemi y
   <data name="ConfigMqtt_CbDisableDefaultEntityId" xml:space="preserve">
     <value>Home Assistant'ın varlık kimliklerini oluşturmasına izin verin.</value>
   </data>
+  <data name="CommandsMod_LblSetting_SensorId" xml:space="preserve">
+    <value>Sensör Adı</value>
+  </data>
+  <data name="CommandType_PublishSensorCommand" xml:space="preserve">
+    <value>PublishSensorCommand</value>
+  </data>
+  <data name="CommandsManager_PublishSensorCommandDescription" xml:space="preserve">
+    <value>Belirtilen sensörün aralığı dikkate almadan hemen yayınlanmasını sağlar.
+HASS.Agent'ta yapılandırılmış adı kullanın.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Commands/CommandsManager.cs
+++ b/src/HASS.Agent/HASS.Agent/Commands/CommandsManager.cs
@@ -475,7 +475,7 @@ namespace HASS.Agent.Commands
 
             commandInfoCard = new CommandInfoCard(CommandType.PublishSensorCommand,
                 Languages.CommandsManager_PublishSensorCommandDescription,
-                true, true, false);
+                true, true, true);
 
             CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
 

--- a/src/HASS.Agent/HASS.Agent/Commands/CommandsManager.cs
+++ b/src/HASS.Agent/HASS.Agent/Commands/CommandsManager.cs
@@ -470,6 +470,14 @@ namespace HASS.Agent.Commands
                 true, true, false);
 
             CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
+            
+            // =================================
+
+            commandInfoCard = new CommandInfoCard(CommandType.PublishSensorCommand,
+                Languages.CommandsManager_PublishSensorCommandDescription,
+                true, true, false);
+
+            CommandInfoCards.Add(commandInfoCard.CommandType, commandInfoCard);
 
             // =================================
 

--- a/src/HASS.Agent/HASS.Agent/Forms/Commands/CommandsMod.cs
+++ b/src/HASS.Agent/HASS.Agent/Forms/Commands/CommandsMod.cs
@@ -211,6 +211,10 @@ namespace HASS.Agent.Forms.Commands
                 case CommandType.SetAudioInputCommand:
                     TbSetting.Text = Command.Command;
                     break;
+                
+                case CommandType.PublishSensorCommand:
+                    TbSetting.Text = Command.Command;
+                    break;
             }
 
 			CbRunAsLowIntegrity.CheckState = Command.RunAsLowIntegrity ? CheckState.Checked : CheckState.Unchecked;
@@ -529,6 +533,21 @@ namespace HASS.Agent.Forms.Commands
                         return;
                     }
                     break;
+                
+                case CommandType.PublishSensorCommand:
+                    var sensorName = TbSetting.Text.Trim();
+                    if (string.IsNullOrEmpty(sensorName))
+                    {
+                        var q = MessageBoxAdv.Show(this, Languages.CommandsMod_MessageBox_Action, Variables.MessageBoxTitle, MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+                        if (q != DialogResult.Yes)
+                        {
+                            ActiveControl = TbSetting;
+
+                            return;
+                        }
+                    }
+                    Command.Command = sensorName;
+                    break;
 			}
 
 			Command.RunAsLowIntegrity = CbRunAsLowIntegrity.CheckState == CheckState.Checked;
@@ -654,7 +673,11 @@ namespace HASS.Agent.Forms.Commands
 					CbConfigDropdown.DataSource = new BindingSource(_radioDevices, null);
 					SetRadioUi();
 					break;
-
+                
+                case CommandType.PublishSensorCommand:
+                    SetPublishSensorGui();
+                    break;
+                
 				default:
 					SetEmptyGui();
 					break;
@@ -699,6 +722,23 @@ namespace HASS.Agent.Forms.Commands
 				TbSetting.Visible = true;
 			}));
 		}
+        
+        /// <summary>
+        /// Change the UI to a 'powershell' type
+        /// </summary>
+        private void SetPublishSensorGui()
+        {
+            Invoke(new MethodInvoker(delegate
+            {
+                SetEmptyGui();
+
+                LblSetting.Text = Languages.CommandsMod_LblSetting_SensorId;
+                LblSetting.Visible = true;
+
+                TbSetting.Text = string.Empty;
+                TbSetting.Visible = true;
+            }));
+        }
 
 		/// <summary>
 		/// Change the UI to a 'key' type

--- a/src/HASS.Agent/HASS.Agent/HomeAssistant/Commands/InternalCommands/PublishSensorCommand.cs
+++ b/src/HASS.Agent/HASS.Agent/HomeAssistant/Commands/InternalCommands/PublishSensorCommand.cs
@@ -1,0 +1,33 @@
+﻿using HASS.Agent.Sensors;
+using HASS.Agent.Shared.Enums;
+using HASS.Agent.Shared.HomeAssistant.Commands;
+using Serilog;
+
+namespace HASS.Agent.HomeAssistant.Commands.InternalCommands;
+
+public class PublishSensorCommand : InternalCommand
+{
+    private const string DefaultName = "publishallsensor";
+
+    internal PublishSensorCommand(string entityName = DefaultName, string name = DefaultName, string sensorName = "", CommandEntityType entityType = CommandEntityType.Switch,
+        string id = default) : base(entityName ?? DefaultName, name ?? null, sensorName, entityType, id)
+    {
+        State = "OFF";
+    }
+
+    public override void TurnOn()
+    {
+        State = "ON";
+
+        if (!string.IsNullOrWhiteSpace(CommandConfig))
+        {
+            SensorsManager.ResetSensorCheck(CommandConfig);
+        }
+        else
+        {
+            Log.Warning("[PUBLISHSENSOR] [{name}] Unable to launch command, it's configured as action-only", EntityName);
+        }
+
+        State = "OFF";
+    }
+}

--- a/src/HASS.Agent/HASS.Agent/HomeAssistant/Commands/InternalCommands/PublishSensorCommand.cs
+++ b/src/HASS.Agent/HASS.Agent/HomeAssistant/Commands/InternalCommands/PublishSensorCommand.cs
@@ -30,4 +30,20 @@ public class PublishSensorCommand : InternalCommand
 
         State = "OFF";
     }
+    
+    public override void TurnOnWithAction(string action)
+    {
+        State = "ON";
+
+        if (!string.IsNullOrWhiteSpace(action))
+        {
+            SensorsManager.ResetSensorCheck(action);
+        }
+        else
+        {
+            Log.Warning("[PUBLISHSENSOR] [{name}] Unable to launch command, it's configured as action-only", EntityName);
+        }
+
+        State = "OFF";
+    }
 }

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.Designer.cs
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.Designer.cs
@@ -624,6 +624,15 @@ namespace HASS.Agent.Resources.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Some desc.
+        /// </summary>
+        internal static string CommandsManager_PublishSensorCommandDescription {
+            get {
+                return ResourceManager.GetString("CommandsManager_PublishSensorCommandDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Switches selected radio device on/off. Availability of radio devices depends on the device HASS.Agent is installed on..
         /// </summary>
         internal static string CommandsManager_RadioCommandDescription {
@@ -1198,6 +1207,15 @@ namespace HASS.Agent.Resources.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Sensor Name.
+        /// </summary>
+        internal static string CommandsMod_LblSetting_SensorId {
+            get {
+                return ResourceManager.GetString("CommandsMod_LblSetting_SensorId", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to URL.
         /// </summary>
         internal static string CommandsMod_LblSetting_Url {
@@ -1481,6 +1499,15 @@ namespace HASS.Agent.Resources.Localization {
         internal static string CommandType_PublishAllSensorsCommand {
             get {
                 return ResourceManager.GetString("CommandType_PublishAllSensorsCommand", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to PublishSensorCommand.
+        /// </summary>
+        internal static string CommandType_PublishSensorCommand {
+            get {
+                return ResourceManager.GetString("CommandType_PublishSensorCommand", resourceCulture);
             }
         }
         

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.Designer.cs
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.Designer.cs
@@ -624,7 +624,8 @@ namespace HASS.Agent.Resources.Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Some desc.
+        ///   Looks up a localized string similar to Forces specific sensor to be published right away, ignoring the interval.
+        ///Use name configured in HASS.Agent..
         /// </summary>
         internal static string CommandsManager_PublishSensorCommandDescription {
             get {

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.de.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.de.resx
@@ -3585,4 +3585,14 @@ Sollte bei neuen Systemen mit „modernem S0ix-Schlafmodus“ eine bessere Benut
   <data name="ConfigMqtt_CbDisableDefaultEntityId" xml:space="preserve">
     <value>Lassen Sie Home Assistant Entitäts-IDs generieren</value>
   </data>
+  <data name="CommandsMod_LblSetting_SensorId" xml:space="preserve">
+    <value>Sensorname</value>
+  </data>
+  <data name="CommandType_PublishSensorCommand" xml:space="preserve">
+    <value>PublishSensorCommand</value>
+  </data>
+  <data name="CommandsManager_PublishSensorCommandDescription" xml:space="preserve">
+    <value>Erzwingt die sofortige Veröffentlichung eines bestimmten Sensors, unabhängig vom Intervall.
+Verwendet den in HASS.Agent konfigurierten Namen.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.en.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.en.resx
@@ -3494,7 +3494,8 @@ Should provide better experience with new systems with "modern S0ix sleep" and n
     <value>PublishSensorCommand</value>
   </data>
   <data name="CommandsManager_PublishSensorCommandDescription" xml:space="preserve">
-    <value>Some desc</value>
+    <value>Forces specific sensor to be published right away, ignoring the interval.
+Use name configured in HASS.Agent.</value>
   </data>
   <data name="CommandsMod_LblSetting_SensorId" xml:space="preserve">
     <value>Sensor Name</value>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.en.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.en.resx
@@ -3490,4 +3490,13 @@ Should provide better experience with new systems with "modern S0ix sleep" and n
   <data name="ConfigMqtt_CbDisableDefaultEntityId" xml:space="preserve">
     <value>Let Home Assistant generate entity IDs</value>
   </data>
+  <data name="CommandType_PublishSensorCommand" xml:space="preserve">
+    <value>PublishSensorCommand</value>
+  </data>
+  <data name="CommandsManager_PublishSensorCommandDescription" xml:space="preserve">
+    <value>Some desc</value>
+  </data>
+  <data name="CommandsMod_LblSetting_SensorId" xml:space="preserve">
+    <value>Sensor Name</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.es.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.es.resx
@@ -3461,4 +3461,15 @@ Esto debería proporcionar una mejor experiencia con los nuevos sistemas con "su
   <data name="ConfigMqtt_CbDisableDefaultEntityId" xml:space="preserve">
     <value>Deja que Home Assistant genere identificadores de entidades.</value>
   </data>
+  <data name="CommandsMod_LblSetting_SensorId" xml:space="preserve">
+    <value>Nombre del sensor</value>
+  </data>
+  <data name="CommandType_PublishSensorCommand" xml:space="preserve">
+    <value>PublishSensorCommand</value>
+  </data>
+  <data name="CommandsManager_PublishSensorCommandDescription" xml:space="preserve">
+    <value>Fuerza la publicación inmediata de un sensor específico, ignorando el intervalo.
+
+Utiliza el nombre configurado en HASS.Agent.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.fr.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.fr.resx
@@ -3493,4 +3493,15 @@ Cela devrait offrir une meilleure expérience avec les nouveaux systèmes dotés
   <data name="ConfigMqtt_CbDisableDefaultEntityId" xml:space="preserve">
     <value>Laissez Home Assistant générer les identifiants d'entité.</value>
   </data>
+  <data name="CommandsMod_LblSetting_SensorId" xml:space="preserve">
+    <value>Nom du capteur</value>
+  </data>
+  <data name="CommandType_PublishSensorCommand" xml:space="preserve">
+    <value>Publier la commande du capteur</value>
+  </data>
+  <data name="CommandsManager_PublishSensorCommandDescription" xml:space="preserve">
+    <value>Force la publication immédiate du capteur spécifique, sans tenir compte de l'intervalle.
+
+Utilisez le nom configuré dans HASS.Agent.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.nl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.nl.resx
@@ -3482,4 +3482,15 @@ Zou een betere ervaring moeten bieden met nieuwe systemen met een "moderne S0ix-
   <data name="ConfigMqtt_CbDisableDefaultEntityId" xml:space="preserve">
     <value>Laat Home Assistant entiteits-ID's genereren.</value>
   </data>
+  <data name="CommandsMod_LblSetting_SensorId" xml:space="preserve">
+    <value>Sensornaam</value>
+  </data>
+  <data name="CommandType_PublishSensorCommand" xml:space="preserve">
+    <value>PublishSensorCommand</value>
+  </data>
+  <data name="CommandsManager_PublishSensorCommandDescription" xml:space="preserve">
+    <value>Dwingt de specifieke sensor om direct te publiceren, ongeacht het interval.
+
+Gebruik de naam die is geconfigureerd in HASS.Agent.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pl.resx
@@ -3571,4 +3571,14 @@ Powinno to zapewnić lepsze działanie w przypadku nowych systemów z „nowocze
   <data name="ConfigMqtt_CbDisableDefaultEntityId" xml:space="preserve">
     <value>Pozwól Home Assistant generować identyfikatory jednostek</value>
   </data>
+  <data name="CommandsMod_LblSetting_SensorId" xml:space="preserve">
+    <value>Nazwa czujnika</value>
+  </data>
+  <data name="CommandType_PublishSensorCommand" xml:space="preserve">
+    <value>PublishSensorCommand</value>
+  </data>
+  <data name="CommandsManager_PublishSensorCommandDescription" xml:space="preserve">
+    <value>Wymusza natychmiastową publikację określonego czujnika, ignorując interwał.
+Użyj nazwy skonfigurowanej w HASS.Agent.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pt-br.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.pt-br.resx
@@ -3507,4 +3507,14 @@ Deve proporcionar uma melhor experiência com novos sistemas com "suspensão S0i
   <data name="ConfigMqtt_CbDisableDefaultEntityId" xml:space="preserve">
     <value>Permita que o Home Assistant gere IDs de entidade.</value>
   </data>
+  <data name="CommandsMod_LblSetting_SensorId" xml:space="preserve">
+    <value>Nome do sensor</value>
+  </data>
+  <data name="CommandType_PublishSensorCommand" xml:space="preserve">
+    <value>PublicarComandoSensor</value>
+  </data>
+  <data name="CommandsManager_PublishSensorCommandDescription" xml:space="preserve">
+    <value>Força a publicação imediata de um sensor específico, ignorando o intervalo.
+Use o nome configurado em HASS.Agent.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.resx
@@ -3490,7 +3490,8 @@ Note: due to "Modern Sleep" the sleep commands might behave differently dependin
     <value>PublishSensorCommand</value>
   </data>
   <data name="CommandsManager_PublishSensorCommandDescription" xml:space="preserve">
-    <value>Some desc</value>
+    <value>Forces specific sensor to be published right away, ignoring the interval.
+Use name configured in HASS.Agent.</value>
   </data>
   <data name="CommandsMod_LblSetting_SensorId" xml:space="preserve">
     <value>Sensor Name</value>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.resx
@@ -3486,4 +3486,13 @@ Note: due to "Modern Sleep" the sleep commands might behave differently dependin
   <data name="ConfigMqtt_CbDisableDefaultEntityId" xml:space="preserve">
     <value>Let Home Assistant generate entity IDs</value>
   </data>
+  <data name="CommandType_PublishSensorCommand" xml:space="preserve">
+    <value>PublishSensorCommand</value>
+  </data>
+  <data name="CommandsManager_PublishSensorCommandDescription" xml:space="preserve">
+    <value>Some desc</value>
+  </data>
+  <data name="CommandsMod_LblSetting_SensorId" xml:space="preserve">
+    <value>Sensor Name</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.ru.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.ru.resx
@@ -3531,4 +3531,14 @@ Home Assistant.
   <data name="ConfigMqtt_CbDisableDefaultEntityId" xml:space="preserve">
     <value>Пусть Home Assistant генерирует идентификаторы сущностей</value>
   </data>
+  <data name="CommandsMod_LblSetting_SensorId" xml:space="preserve">
+    <value>Название датчика</value>
+  </data>
+  <data name="CommandType_PublishSensorCommand" xml:space="preserve">
+    <value>PublishSensorCommand</value>
+  </data>
+  <data name="CommandsManager_PublishSensorCommandDescription" xml:space="preserve">
+    <value>Принудительно публикует данные с конкретного датчика немедленно, игнорируя интервал.
+Используйте имя, заданное в HASS.Agent.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.sl.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.sl.resx
@@ -3610,4 +3610,14 @@ Omogoča boljšo izkušnjo z novimi sistemi s »sodobnim načinom mirovanja S0ix
   <data name="ConfigMqtt_CbDisableDefaultEntityId" xml:space="preserve">
     <value>Naj Home Assistant ustvari ID-je entitet</value>
   </data>
+  <data name="CommandsMod_LblSetting_SensorId" xml:space="preserve">
+    <value>Ime senzorja</value>
+  </data>
+  <data name="CommandType_PublishSensorCommand" xml:space="preserve">
+    <value>PublishSensorCommand</value>
+  </data>
+  <data name="CommandsManager_PublishSensorCommandDescription" xml:space="preserve">
+    <value>Vsili takojšnjo objavo določenega senzorja, pri čemer se interval prezre.
+Uporabi ime, konfigurirano v HASS.Agent.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.tr.resx
+++ b/src/HASS.Agent/HASS.Agent/Resources/Localization/Languages.tr.resx
@@ -3077,4 +3077,14 @@ Not: "Modern Uyku" nedeniyle uyku komutları, cihazın OEM ve işletim sistemi y
   <data name="ConfigMqtt_CbDisableDefaultEntityId" xml:space="preserve">
     <value>Home Assistant'ın varlık kimliklerini oluşturmasına izin verin.</value>
   </data>
+  <data name="CommandsMod_LblSetting_SensorId" xml:space="preserve">
+    <value>Sensör Adı</value>
+  </data>
+  <data name="CommandType_PublishSensorCommand" xml:space="preserve">
+    <value>PublishSensorCommand</value>
+  </data>
+  <data name="CommandsManager_PublishSensorCommandDescription" xml:space="preserve">
+    <value>Belirtilen sensörün aralığı dikkate almadan hemen yayınlanmasını sağlar.
+HASS.Agent'ta yapılandırılmış adı kullanın.</value>
+  </data>
 </root>

--- a/src/HASS.Agent/HASS.Agent/Sensors/SensorsManager.cs
+++ b/src/HASS.Agent/HASS.Agent/Sensors/SensorsManager.cs
@@ -75,6 +75,7 @@ namespace HASS.Agent.Sensors
                     await sensor.UnPublishAutoDiscoveryConfigAsync(migration);
                 }
             }
+
             if (MultiValueSensorsPresent())
             {
                 foreach (var sensor in Variables.MultiValueSensors)
@@ -99,6 +100,7 @@ namespace HASS.Agent.Sensors
                     await sensor.PublishAutoDiscoveryConfigAsync();
                 }
             }
+
             if (MultiValueSensorsPresent())
             {
                 foreach (var sensor in Variables.MultiValueSensors)
@@ -253,6 +255,41 @@ namespace HASS.Agent.Sensors
         }
 
         /// <summary>
+        /// Resets sensor check for provided sensor (last sent and previous value), so it is published again
+        /// </summary>
+        internal static void ResetSensorCheck(string sensorName)
+        {
+            try
+            {
+                Pause();
+
+                var singleMatch = Variables.SingleValueSensors.FirstOrDefault(sensor => sensor.Name == sensorName);
+                if (singleMatch != null)
+                {
+                    singleMatch.ResetChecks();
+                    return;
+                }
+                
+                var multiMatch = Variables.MultiValueSensors.FirstOrDefault(sensor => sensor.Name == sensorName);
+                if (multiMatch != null)
+                {
+                    multiMatch.ResetChecks();
+                    return;
+                }
+                
+                Log.Warning("[SENSORSMANAGER] Can't reset check for sensor '{err}' - not found.", sensorName);
+            }
+            catch (Exception ex)
+            {
+                Log.Fatal(ex, "[SENSORSMANAGER] Error while resetting sensor check: {err}", ex.Message);
+            }
+            finally
+            {
+                Unpause();
+            }
+        }
+
+        /// <summary>
         /// Stores the provided sensors, and (re)publishes them
         /// </summary>
         /// <param name="sensors"></param>
@@ -329,7 +366,8 @@ namespace HASS.Agent.Sensors
                         if (Variables.SingleValueSensors[currentSensorIndex].EntityName != abstractSensor.EntityName)
                         {
                             // name changed, unregister
-                            Log.Information("[SENSORS] Single-value sensor changed name, re-registering as new entity: {old} to {new}", Variables.SingleValueSensors[currentSensorIndex].EntityName, abstractSensor.EntityName);
+                            Log.Information("[SENSORS] Single-value sensor changed name, re-registering as new entity: {old} to {new}",
+                                Variables.SingleValueSensors[currentSensorIndex].EntityName, abstractSensor.EntityName);
 
                             await Variables.SingleValueSensors[currentSensorIndex].UnPublishAutoDiscoveryConfigAsync();
                         }
@@ -359,7 +397,8 @@ namespace HASS.Agent.Sensors
                         if (Variables.MultiValueSensors[currentSensorIndex].EntityName != abstractSensor.EntityName)
                         {
                             // name changed, unregister
-                            Log.Information("[SENSORS] Multi-value sensor changed name, re-registering as new entity: {old} to {new}", Variables.MultiValueSensors[currentSensorIndex].EntityName, abstractSensor.EntityName);
+                            Log.Information("[SENSORS] Multi-value sensor changed name, re-registering as new entity: {old} to {new}",
+                                Variables.MultiValueSensors[currentSensorIndex].EntityName, abstractSensor.EntityName);
 
                             await Variables.MultiValueSensors[currentSensorIndex].UnPublishAutoDiscoveryConfigAsync();
                         }
@@ -530,8 +569,8 @@ namespace HASS.Agent.Sensors
             // =================================
 
             sensorInfoCard = new SensorInfoCard(SensorType.InternalDeviceSensor,
-            Languages.SensorsManager_InternalDeviceSensorDescription,
-            10, false, true, false);
+                Languages.SensorsManager_InternalDeviceSensorDescription,
+                10, false, true, false);
 
             SensorInfoCards.Add(sensorInfoCard.SensorType, sensorInfoCard);
 
@@ -666,8 +705,8 @@ namespace HASS.Agent.Sensors
             // =================================
 
             sensorInfoCard = new SensorInfoCard(SensorType.ScreenshotSensor,
-            Languages.SensorsManager_ScreenshotSensorDescription,
-            10, false, true, false);
+                Languages.SensorsManager_ScreenshotSensorDescription,
+                10, false, true, false);
 
             SensorInfoCards.Add(sensorInfoCard.SensorType, sensorInfoCard);
 

--- a/src/HASS.Agent/HASS.Agent/Settings/StoredCommands.cs
+++ b/src/HASS.Agent/HASS.Agent/Settings/StoredCommands.cs
@@ -145,6 +145,9 @@ namespace HASS.Agent.Settings
                 case CommandType.PublishAllSensorsCommand:
                     abstractCommand = new PublishAllSensorsCommand(command.EntityName, command.Name, command.EntityType, command.Id.ToString());
                     break;
+                case CommandType.PublishSensorCommand:
+                    abstractCommand = new PublishSensorCommand(command.EntityName, command.Name, command.Command, command.EntityType, command.Id.ToString());
+                    break;
                 case CommandType.LaunchUrlCommand:
                     abstractCommand = new LaunchUrlCommand(command.EntityName, command.Name, command.Command, command.EntityType, command.Id.ToString());
                     break;


### PR DESCRIPTION
This PR adds feature requested via https://github.com/hass-agent/HASS.Agent/issues/477 and partially via https://github.com/hass-agent/HASS.Agent/issues/473.

New "PublishSensorCommand" allows to specify a specific sensor name that will be published "immediately", ignoring the configured interval period.
<img width="1332" height="526" alt="image" src="https://github.com/user-attachments/assets/2d32cf54-78e8-4e4f-b428-761f640e4077" />
