### PR TITLE
Feature: access type attribute for network sensors

### DIFF
--- a/src/HASS.Agent/HASS.Agent.Shared/HASS.Agent.Shared.csproj
+++ b/src/HASS.Agent/HASS.Agent.Shared/HASS.Agent.Shared.csproj
@@ -46,6 +46,7 @@
     <PackageReference Include="System.Reactive" Version="6.0.1" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="9.0.6" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="9.0.6" />
+    <PackageReference Include="Vanara.PInvoke.NetListMgr" Version="5.0.7" />
     <PackageReference Include="Vanara.PInvoke.PowrProf" Version="5.0.7" />
   </ItemGroup>
 

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/NetworkSensors.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/NetworkSensors.cs
@@ -24,10 +24,10 @@ public class NetworkSensors : AbstractMultiValueSensor
     public string NetworkCard { get; protected set; }
     private readonly bool _useSpecificCard = false;
 
-    public override sealed Dictionary<string, AbstractSingleValueSensor> Sensors { get; protected set; } = new Dictionary<string, AbstractSingleValueSensor>();
+    public sealed override Dictionary<string, AbstractSingleValueSensor> Sensors { get; protected set; } = new Dictionary<string, AbstractSingleValueSensor>();
 
-    public NetworkSensors(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string networkCard = "*", string id = default) : base(
-        entityName ?? DefaultName, name ?? null, updateInterval ?? 30, id)
+    public NetworkSensors(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string networkCard = "*", string id = default) : base(entityName ?? DefaultName,
+        name ?? null, updateInterval ?? 30, id)
     {
         _updateInterval = updateInterval ?? 30;
 
@@ -124,8 +124,7 @@ public class NetworkSensors : AbstractMultiValueSensor
                 var info = JsonConvert.SerializeObject(networkInfo, Formatting.Indented);
                 var networkInfoEntityName = $"{parentSensorSafeName}_{id}";
                 var networkInfoId = $"{Id}_{id}";
-                var networkInfoSensor = new DataTypeStringSensor(_updateInterval, networkInfoEntityName, nic.Name, networkInfoId, string.Empty, "mdi:lan", string.Empty, EntityName,
-                    true);
+                var networkInfoSensor = new DataTypeStringSensor(_updateInterval, networkInfoEntityName, nic.Name, networkInfoId, string.Empty, "mdi:lan", string.Empty, EntityName, true);
 
                 networkInfoSensor.SetState(nic.OperationalStatus.ToString());
                 networkInfoSensor.SetAttributes(info);
@@ -141,8 +140,7 @@ public class NetworkSensors : AbstractMultiValueSensor
 
         var nicCountEntityName = $"{parentSensorSafeName}_total_network_card_count";
         var nicCountId = $"{Id}_total_network_card_count";
-        var nicCountSensor = new DataTypeIntSensor(_updateInterval, nicCountEntityName, "Network Card Count", nicCountId, string.Empty, "measurement", "mdi:lan", string.Empty,
-            EntityName);
+        var nicCountSensor = new DataTypeIntSensor(_updateInterval, nicCountEntityName, "Network Card Count", nicCountId, string.Empty, "measurement", "mdi:lan", string.Empty, EntityName);
         nicCountSensor.SetState(nicCount);
         AddUpdateSensor(nicCountId, nicCountSensor);
     }

--- a/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/NetworkSensors.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/NetworkSensors.cs
@@ -4,10 +4,12 @@ using System.Net.NetworkInformation;
 using ByteSizeLib;
 using HASS.Agent.Shared.Functions;
 using HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue.DataTypes;
+using HASS.Agent.Shared.Managers;
 using HASS.Agent.Shared.Models.HomeAssistant;
 using HASS.Agent.Shared.Models.Internal;
 using Newtonsoft.Json;
 using Serilog;
+using Vanara.PInvoke.NetListMgr;
 
 namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue;
 
@@ -24,7 +26,8 @@ public class NetworkSensors : AbstractMultiValueSensor
 
     public override sealed Dictionary<string, AbstractSingleValueSensor> Sensors { get; protected set; } = new Dictionary<string, AbstractSingleValueSensor>();
 
-    public NetworkSensors(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string networkCard = "*", string id = default) : base(entityName ?? DefaultName, name ?? null, updateInterval ?? 30, id)
+    public NetworkSensors(int? updateInterval = null, string entityName = DefaultName, string name = DefaultName, string networkCard = "*", string id = default) : base(
+        entityName ?? DefaultName, name ?? null, updateInterval ?? 30, id)
     {
         _updateInterval = updateInterval ?? 30;
 
@@ -36,13 +39,10 @@ public class NetworkSensors : AbstractMultiValueSensor
 
     private void AddUpdateSensor(string sensorId, AbstractSingleValueSensor sensor)
     {
-        if (!Sensors.ContainsKey(sensorId))
-            Sensors.Add(sensorId, sensor);
-        else
-            Sensors[sensorId] = sensor;
+        Sensors[sensorId] = sensor;
     }
 
-    public override sealed void UpdateSensorValues()
+    public sealed override void UpdateSensorValues()
     {
         var parentSensorSafeName = SharedHelperFunctions.GetSafeValue(EntityName);
 
@@ -80,6 +80,7 @@ public class NetworkSensors : AbstractMultiValueSensor
                 networkInfo.IncomingPacketsWithUnknownProtocol = interfaceStats.IncomingUnknownProtocolPackets;
                 networkInfo.OutgoingPacketsDiscarded = interfaceStats.OutgoingPacketsDiscarded;
                 networkInfo.OutgoingPacketsWithErrors = interfaceStats.OutgoingPacketsWithErrors;
+                networkInfo.AccessType = NetworkManager.GetNetworkAccessType(nic);
 
                 var nicProperties = nic.GetIPProperties();
 
@@ -123,7 +124,8 @@ public class NetworkSensors : AbstractMultiValueSensor
                 var info = JsonConvert.SerializeObject(networkInfo, Formatting.Indented);
                 var networkInfoEntityName = $"{parentSensorSafeName}_{id}";
                 var networkInfoId = $"{Id}_{id}";
-                var networkInfoSensor = new DataTypeStringSensor(_updateInterval, networkInfoEntityName, nic.Name, networkInfoId, string.Empty, "mdi:lan", string.Empty, EntityName, true);
+                var networkInfoSensor = new DataTypeStringSensor(_updateInterval, networkInfoEntityName, nic.Name, networkInfoId, string.Empty, "mdi:lan", string.Empty, EntityName,
+                    true);
 
                 networkInfoSensor.SetState(nic.OperationalStatus.ToString());
                 networkInfoSensor.SetAttributes(info);
@@ -139,7 +141,8 @@ public class NetworkSensors : AbstractMultiValueSensor
 
         var nicCountEntityName = $"{parentSensorSafeName}_total_network_card_count";
         var nicCountId = $"{Id}_total_network_card_count";
-        var nicCountSensor = new DataTypeIntSensor(_updateInterval, nicCountEntityName, "Network Card Count", nicCountId, string.Empty, "measurement", "mdi:lan", string.Empty, EntityName);
+        var nicCountSensor = new DataTypeIntSensor(_updateInterval, nicCountEntityName, "Network Card Count", nicCountId, string.Empty, "measurement", "mdi:lan", string.Empty,
+            EntityName);
         nicCountSensor.SetState(nicCount);
         AddUpdateSensor(nicCountId, nicCountSensor);
     }

--- a/src/HASS.Agent/HASS.Agent.Shared/Managers/NetworkManager.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Managers/NetworkManager.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Linq;
+using System.Net.NetworkInformation;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+using HASS.Agent.Shared.Models.Internal;
+using Vanara.PInvoke.NetListMgr;
+
+namespace HASS.Agent.Shared.Managers;
+
+public static class NetworkManager
+{
+    private static INetworkListManager _networkListManager = new INetworkListManager();
+
+    public const NLM_CONNECTIVITY InternetMask = NLM_CONNECTIVITY.NLM_CONNECTIVITY_IPV4_INTERNET |
+                                                 NLM_CONNECTIVITY.NLM_CONNECTIVITY_IPV6_INTERNET;
+
+    public const NLM_CONNECTIVITY LocalMask = NLM_CONNECTIVITY.NLM_CONNECTIVITY_IPV4_SUBNET |
+                                              NLM_CONNECTIVITY.NLM_CONNECTIVITY_IPV4_LOCALNETWORK |
+                                              NLM_CONNECTIVITY.NLM_CONNECTIVITY_IPV6_SUBNET |
+                                              NLM_CONNECTIVITY.NLM_CONNECTIVITY_IPV6_LOCALNETWORK;
+    
+    public static NetworkAccessType GetNetworkAccessType(NetworkInterface networkInterface)
+    {
+        if (!Guid.TryParse(networkInterface.Id, out var adapterGuid))
+        {
+            return NetworkAccessType.NoNetworkAccess;
+        }
+
+        var networkConnection = _networkListManager.GetNetworkConnections().Cast<INetworkConnection>().FirstOrDefault(c => c.GetAdapterId() == adapterGuid);
+
+        return networkConnection == null ? NetworkAccessType.NoNetworkAccess : ConnectivityToAccessType(networkConnection.GetConnectivity());
+    }
+
+    public static NetworkAccessType ConnectivityToAccessType(NLM_CONNECTIVITY connectivity)
+    {
+        if ((connectivity & InternetMask) != 0)
+        {
+            return NetworkAccessType.Internet;
+        }
+
+        if ((connectivity & LocalMask) != 0)
+        {
+            return NetworkAccessType.NoInternetAccess;
+        }
+
+        return NetworkAccessType.NoNetworkAccess;
+    }
+}

--- a/src/HASS.Agent/HASS.Agent.Shared/Models/Internal/NetworkAccessType.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Models/Internal/NetworkAccessType.cs
@@ -1,0 +1,16 @@
+﻿using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace HASS.Agent.Shared.Models.Internal;
+
+[JsonConverter(typeof(StringEnumConverter))]
+public enum NetworkAccessType
+{
+    [EnumMember(Value = "NoNetworkAccess")]
+    NoNetworkAccess,
+    [EnumMember(Value = "NoInternetAccess")]
+    NoInternetAccess,
+    [EnumMember(Value = "Internet")]
+    Internet
+}

--- a/src/HASS.Agent/HASS.Agent.Shared/Models/Internal/NetworkInfo.cs
+++ b/src/HASS.Agent/HASS.Agent.Shared/Models/Internal/NetworkInfo.cs
@@ -33,5 +33,6 @@ namespace HASS.Agent.Shared.Models.Internal
         public bool DnsEnabled { get; set; }
         public string DnsSuffix { get; set; } = string.Empty;
         public List<string> DnsAddresses { get; set; } = new List<string>();
+        public NetworkAccessType AccessType { get; set; }
     }
 }


### PR DESCRIPTION
This PR adds feature requested via https://github.com/hass-agent/HASS.Agent/issues/464.
The feature is a new attribute "AccessType" which is present on network sensors. This attribute corresponds to "Access type" information present in Windows' connections centre:

<img width="529" height="149" alt="image" src="https://github.com/user-attachments/assets/2cc491ed-3d30-4da8-89b7-0eec62733b11" />

<img width="1618" height="825" alt="image" src="https://github.com/user-attachments/assets/3e090f6a-1a65-45ee-aa0c-4356377e1729" />
